### PR TITLE
Added in frameset save/restore and more cleanup.

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -42,15 +42,15 @@
   (lambda ()
     (setq startup-time-message
       (format "Emacs read in %.2f seconds with %d garbage collections."
-	(float-time (time-subtract after-init-time before-init-time))
-	gcs-done))
+      (float-time (time-subtract after-init-time before-init-time))
+      gcs-done))
     (message startup-time-message)))
 
 ;; (use-package gcmh
 ;;   :diminish gcmh-mode
 ;;   :config
 ;;   (setq gcmh-idle-delay 5
-;;     gcmh-high-cons-threshold (* 16 1024 1024))	 ; 16mb
+;;     gcmh-high-cons-threshold (* 16 1024 1024))      ; 16mb
 ;;   (gcmh-mode 1))
 
 (add-hook 'emacs-startup-hook

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -3,13 +3,9 @@
 #+date: 2024-05-11
 #+OPTIONS: toc:nil h:4
 #+STARTUP: showeverything
-#+PROPERTY: header-args:emacs-lisp   :tangle ./init.el :results silent :exports code :mkdirp yes
+#+PROPERTY: header-args:emacs-lisp :tangle ./init.el :results silent :exports code :mkdirp yes
 
 * Welcome!
-:PROPERTIES:
-:CUSTOM_ID: babel-init
-:END:
-<<babel-init>>
 
 This ORG file will configure the * init.el * file based upon all of the * emacs-lisp * source blocks. The emacs-lisp source blocks are defined in an organized order. While these blocks cn generally be moved around, there are some order dependencies. So it's generally best that this order be preserved to prevent any compile-time issues.
 
@@ -170,7 +166,7 @@ This section just sets up the starting part of the ~init.el~ file. These include
 ** Lispy Header
 This is the standard format of a =lisp= header that should appear for all =lisp= scripts. It also indicates that the ~init.el~ file is generated from this ~Configure.org~ file.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; init.el -*- flycheck-disabled-checkers: (emacs-lisp); lexical-binding: nil -*-
   ;;;
   ;;; Commentary:
@@ -198,7 +194,7 @@ Elpaca:
 - Supports thousands of elisp packages out of the box (MELPA, NonGNU/GNU ELPA, Org/org-contrib).
 - Makes it easy for users to create their own ELPAs.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (defvar elpaca-installer-version 0.7)
   (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
@@ -260,7 +256,7 @@ Other variables are also defined here that define other emacs behaviors and defa
 ** Customization groups
 These are the groups used by this Emacs config for customization.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Define my customization groups
 
@@ -288,7 +284,7 @@ These are the groups used by this Emacs config for customization.
 
 ** File Locations and Variables
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
       ;;; --------------------------------------------------------------------------
 
   (defcustom dashboard-landing-screen t
@@ -325,54 +321,60 @@ These are the groups used by this Emacs config for customization.
 
 Thes values toggle the availability of specific packages. These options are not grouped together as can be done with the =mrf-custom-features= group so are all separate values.
 
-#+begin_src emacs-lisp :tangle "init.el"
-  ;;; --------------------------------------------------------------------------
-  ;;; Feature Toggles
+#+begin_src emacs-lisp
+   ;;; --------------------------------------------------------------------------
+   ;;; Feature Toggles
 
-  (defcustom enable-gb-dev nil
-    "If set to t, the z80-mode and other GameBoy related packages
-      will be enabled."
-    :type 'boolean
-    :group 'mrf-custom-toggles)
+   (defcustom enable-gb-dev nil
+     "If set to t, the z80-mode and other GameBoy related packages
+       will be enabled."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
 
-  (defcustom enable-ts nil
-    "Set to t to enable TypeScript handling."
-    :type 'boolean
-    :group 'mrf-custom-toggles)
+   (defcustom enable-ts nil
+     "Set to t to enable TypeScript handling."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
 
-  (defcustom enable-centaur-tabs nil
-    "Set to t to enable `centaur-tabs' which uses tabs to represent open buffer."
-    :type 'boolean
-    :group 'mrf-custom-toggles)
+   (defcustom enable-centaur-tabs nil
+     "Set to t to enable `centaur-tabs' which uses tabs to represent open buffer."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
 
-  (defcustom enable-neotree nil
-    "Set to t to enable the `neotree' package."
-    :type 'boolean
-    :group 'mrf-custom-toggles)
+   (defcustom enable-neotree nil
+     "Set to t to enable the `neotree' package."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
 
-  (defcustom enable-golden-ratio nil
-    "Set to t to enable `golden-ratio-mode' which resizes the active buffer
-      window to the dimensions of a golden-rectangle "
-    :type 'boolean
-    :group 'mrf-custom-toggles)
+   (defcustom enable-golden-ratio nil
+     "Set to t to enable `golden-ratio-mode' which resizes the active buffer
+      window to the dimensions of a golden-rectangle"
+     :type 'boolean
+     :group 'mrf-custom-toggles)
 
-  (defcustom enable-org-fill-column-centering nil
-    "Set to t to center the visual-fill column of the Org display."
-    :type 'boolean
-    :group 'mrf-custom-toggles)
+   (defcustom enable-org-fill-column-centering nil
+     "Set to t to center the visual-fill column of the Org display."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
 
-  (defcustom enable-embark nil
-    "Set to t to enable the Embark package."
-    :type 'boolean
-    :group 'mrf-custom-toggles)
-  
+   (defcustom enable-embark nil
+     "Set to t to enable the Embark package."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
+
+   (defcustom enable-frameset-restore nil
+     "Set to t to enable restoring the last Emacs window size and position
+      upon startup."
+     :type 'boolean
+     :group 'mrf-custom-toggles)
+   
 #+end_src
 
 ** Feature selections
 
 These are features that basically have multiple-choice options instead of being a typical binary t or nil.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defcustom undo-handler 'undo-handler-vundo
@@ -460,7 +462,7 @@ These are features that basically have multiple-choice options instead of being 
 ** Theme Specific Values
 This is a curated selection of themes that I personally like. Most of them are dark mode but there are a few light versions. New themes can be added here or done via the =customize= interface. If a new theme is added to this list, it's important to ensure that the theme is actually included (see [[Color Theming][Color Theming]] section)
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Theming related
 
@@ -474,7 +476,8 @@ This is a curated selection of themes that I personally like. Most of them are d
                          "ef-melissa-dark"
                          "darktooth-dark"
                          "material"
-                         "deeper-blue")
+                         "tron-legacy")
+
     "My personal list of themes to cycle through indexed by `theme-selector'.
   If additional themes are added, they must be previously installed."
     :group 'mrf-custom-theming
@@ -491,12 +494,12 @@ This is a curated selection of themes that I personally like. Most of them are d
     :type 'natnum)
 
   ;;; Font related
-  (defcustom default-font-family "Hack"
+  (defcustom default-font-family "Fira Code Retina"
     "The font family used as the default font."
     :type 'string
     :group 'mrf-custom-fonts)
 
-  (defcustom mono-spaced-font-family "Hack"
+  (defcustom mono-spaced-font-family "Fira Code Retina"
     "The font family used as the mono-spaced font."
     :type 'string
     :group 'mrf-custom-fonts)
@@ -553,6 +556,9 @@ This is a curated selection of themes that I personally like. Most of them are d
     :type 'natnum
     :group 'mrf-custom-fonts)
 
+  (defvar custom-default-mono-font-size 170
+    "Storage for the current mono-spaced font height.")
+
 #+end_src
 
 
@@ -563,7 +569,7 @@ Setup initial paths, global values and settings, and Emacs working directories.
 ** Use Shell Path
 Because in macOS, Emacs could be started outside of a shell (like an application on the Dock), this code is used to migrate the <current user's shell path to Emacs ~exec-path~.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Use shell path
@@ -593,7 +599,7 @@ Because in macOS, Emacs could be started outside of a shell (like an application
 
 By default, the =user-emacs-directory= points to the .emacs.d* directory from which the =init.el= is used when Emacs starts. What this means is that any package that writes to this directory will be writing files to this initialization directory. Since we want to keep this directory clean, we set this directory to something external. A new variable, =emacs-config-directory= is set to now point to the starting Emacs condfiguration directory.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Set a variable that represents the actual emacs configuration directory.
   ;;; This is being done so that the user-emacs-directory which normally points
@@ -625,7 +631,7 @@ By default, the =user-emacs-directory= points to the .emacs.d* directory from wh
 This directory is expected to be in the ~emacs-config-direcory~ dir. This can be used to store custom lisp (or non-elpa/melpa) files that can'tbe found by =require.el= or =straight-use-package=.
 
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (add-to-list 'load-path (expand-file-name "lisp" emacs-config-directory))
@@ -635,7 +641,7 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
 ** Global default variables
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   ;;; --------------------------------------------------------------------------
 
@@ -665,10 +671,9 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 #+end_src
 
 ** Globally enabled/disabled modes
-
 *** Save History
-#+begin_src emacs-lisp :tangle "init.el"
-
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
   (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
   (savehist-mode t)
   (setq history-length t)
@@ -682,8 +687,8 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 #+end_src
 
 
-#+begin_src emacs-lisp :tangle "init.el"
-
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
   ;; (global-display-line-numbers-mode 1) ;; Line numbers appear everywhere
   (save-place-mode 1)                  ;; Remember where we were last editing a file.
   (show-paren-mode 1)
@@ -695,9 +700,43 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
 #+end_src
 
+*** Save / Restore Frameset
+
+These functions will save and restore Emacs framework. These are normally called when starting and exiting Emacs.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (defun mrf/save-desktop-frameset ()
+    (unless (daemonp)
+      (desktop-save-mode 0)
+      (desktop-save-frameset)
+      (with-temp-file (expand-file-name "saved-frameset.el" user-emacs-directory)
+        (insert
+        (format "(setq desktop-saved-frameset %S)" desktop-saved-frameset)))))
+
+  (add-hook 'kill-emacs-hook 'mrf/save-desktop-frameset)
+
+  ;;; --------------------------------------------------------------------------
+   
+  (defun mrf/restore-desktop-frameset ()
+    (unless (daemonp)
+      (let
+        ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
+        (desktop-save-mode 0)
+        (when (f-exists? file) (load file)
+        (desktop-restore-frameset)
+        (when (featurep 'spacious-padding)
+          (when spacious-padding-mode
+            (spacious-padding-mode 0)
+            (spacious-padding-mode 1)))))
+        ))
+
+#+end_src
+
 ** Emacs in server mode
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   ;; Allow access from emacsclient
   (add-hook 'elpaca-after-init-hook
@@ -717,13 +756,31 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 These are the common packages that I pretty much use universally in my normal Emacs workflow.
 It excludes packages that can be customized through my =mrf-custom= variables as they are generally in their own section
 
+** F.el
+
+Much inspired by @magnarss excellent s.el and dash.el, f.el is a modern API for working with files and directories in Emacs.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package f
+    :ensure ( :package "f" :source "MELPA" :protocol https :inherit t
+            :depth 1 :fetcher github :repo "rejeep/f.el"
+            :files ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
+                     "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
+                     "lisp/*.el" (:exclude ".dir-locals.el" "test.el"
+                                   "tests.el" "*-test.el" "*-tests.el"
+                                   "LICENSE" "README*" "*-pkg.el"))))
+
+#+end_src
+
 ** Hydra
 
 This is a package for GNU Emacs that can be used to tie related commands into a family of short bindings with a common prefix - a Hydra. Once you summon the Hydra through the prefixed binding (the body + any one head), all heads can be called in succession with only a short extension.
 
 The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, arrives. Note that Hercules, besides vanquishing the Hydra, will still serve his original purpose, calling his proper command. This makes the Hydra very seamless, it's like a minor mode that disables itself auto-magically.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package hydra
@@ -734,7 +791,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 #+end_src
 
 ** Diminish
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/set-diminish ()
@@ -763,7 +820,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 ** Which Key
 [[https://github.com/justbur/emacs-which-key][which-key]] is a useful UI panel that appears when you start pressing any key binding in Emacs to offer you all possible completions for the prefix.  For example, if you press =C-c= (hold control and press the letter =c=), a panel will appear at the bottom of the frame displaying all of the bindings under that prefix and which command they run.  This is very useful for learning the possible key bindings in the mode of your current buffer.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package which-key
@@ -778,7 +835,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 ** Multiple-cursors
 Multiple cursors for Emacs. This is some pretty crazy functionality, so yes, there are kinks. Don't be afraid though.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package multiple-cursors
@@ -793,7 +850,7 @@ Multiple cursors for Emacs. This is some pretty crazy functionality, so yes, the
 
 anzu.el is an Emacs port of anzu.vim. anzu.el provides a minor mode which displays current match and total matches information in the mode-line in various search modes.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package anzu
@@ -818,7 +875,7 @@ anzu.el is an Emacs port of anzu.vim. anzu.el provides a minor mode which displa
 
 We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]] to center =org-mode= buffers for a more pleasing writing experience as it centers the contents of the buffer horizontally to seem more like you are editing a document.  This is really a matter of personal preference so you can remove the block below if you don't like the behavior.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package visual-fill-column
@@ -828,7 +885,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 
 ** Default Text Scale
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   
   (use-package default-text-scale
@@ -838,7 +895,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 
 ** Mac Specific
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Macintosh specific configurations.
@@ -883,7 +940,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 #+end_src
 
 ** Global key-binding
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (bind-key "C-c ]" 'indent-region prog-mode-map)
@@ -918,7 +975,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 
 This package displays ElDoc documentations in a childframe. The childframe is selectable and scrollable with mouse, even though the cursor is hidden.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
     ;;; --------------------------------------------------------------------------
 
   ;; prevent (emacs) eldoc loaded before Elpaca activation warning.
@@ -952,7 +1009,7 @@ The auto-package-update package helps us keep our Emacs packages up to date!  It
 
 You can also use =M-x auto-package-update-now= to update right now!
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Automatic Package Updates
 
@@ -973,7 +1030,7 @@ You can also use =M-x auto-package-update-now= to update right now!
 
 These are useful snippets of code that are commonly used in various languages. You can even create your own.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; YASnippets
 
@@ -999,7 +1056,7 @@ These are useful snippets of code that are commonly used in various languages. Y
 
 Collections of more yasnippet snippets for various languages.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package yasnippet-snippets
@@ -1014,7 +1071,7 @@ Emacs.  Icon Fonts allow you to propertize and format icons the same way you
 would normal text.  This enables things such as better scaling of and anti
 aliasing of the icons.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package all-the-icons
@@ -1063,7 +1120,7 @@ Features:
 ** Ace Window
 [[https://github.com/abo-abo/ace-window][ace-window]] is a package for selecting a window to switch to. Like =other-window= but better!
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package ace-window
@@ -1074,7 +1131,7 @@ Features:
 
 ** Winum
 Window numbers for Emacs: Navigate your windows and frames using numbers. This is not only handy but used by Treemacs.
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Window Number
 
@@ -1088,9 +1145,7 @@ Window numbers for Emacs: Navigate your windows and frames using numbers. This i
 
 These are packages located in the ~"lisp"~ directory within the emacs-config-directory.
 
-#+begin_src emacs-lisp :tangle "init.el"
-
-
+#+begin_src emacs-lisp
 
 #+end_src
 
@@ -1103,7 +1158,7 @@ These are packages located in the ~"lisp"~ directory within the emacs-config-dir
 
 Vundo displays the undo history as a tree and lets you move in the tree to go back to previous buffer states. To use vundo, type M-x vundo RET in the buffer you want to undo. An undo tree buffer should pop up.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package vundo
@@ -1122,7 +1177,7 @@ Vundo displays the undo history as a tree and lets you move in the tree to go ba
 
 Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode treats undo history as a branching tree of changes, similar to the way Vim handles it. This makes it substantially easier to undo and redo any change, while preserving the entire history of past states. The undo-tree visualizer is particularly helpful in complex cases. An added side bonus is that undo history can in some cases be stored more efficiently, allowing more changes to accumulate before Emacs starts discarding history. Undo history can be saved persistently across sessions with Emacs 24.3 and later. It also sports various other nifty features: storing and restoring past buffer states in registers, a diff view of the changes that will be made by undoing, and probably more besides.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/undo-tree-hook ()
@@ -1136,7 +1191,7 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
   
 #+end_src
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;;
@@ -1174,7 +1229,7 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
 
 This bit of code contains a list of themes that I like personally and then allows them to be switched between themselves. The index of ~theme-selector~ is what is set in order to access a theme via the ~mrf/load-theme-from-selector()~ function.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;;
@@ -1194,6 +1249,7 @@ This bit of code contains a list of themes that I like personally and then allow
   (add-to-list 'savehist-additional-variables 'loaded-theme)
   (add-to-list 'savehist-additional-variables 'custom-default-font-size)
   (add-to-list 'savehist-additional-variables 'theme-selector)
+  (add-to-list 'savehist-additional-variables 'custom-default-mono-font-size)
 
 #+end_src
 
@@ -1201,7 +1257,7 @@ This bit of code contains a list of themes that I like personally and then allow
 
 This is the main function that allows cycling (up or down) through the list of themes defined in the ~theme-list~.  This function is normally called by the ~disable-theme-functions~ hook. Before calling this function, set the variable ~theme-cycle-step~ to either a 1 or -1 depending upon which direction in the ~theme-list~ array to select the next element from. The resulting index will cycle to the end or the beginning of the list if the computed index goes beyond element 0 or the length of ~theme-list~. The parameter theme is passed to this function when a theme becomes disabled (via the ~disable-theme~ function) and represents the theme that has become disabled.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/cycle-theme-selector (&rest theme)
@@ -1228,7 +1284,7 @@ This is the main function that allows cycling (up or down) through the list of t
 
 This function simply loads the theme from the theme-list indexed by the ~theme-selector~ variable. Note the advice for ~load-theme~ that deactivates the current theme before activating the new theme. This is done to reset all the colors, a clean slate, before the new theme is activated.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defvar theme-did-load nil
@@ -1254,7 +1310,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
 ** Theme selection helper functions.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (defun mrf/print-custom-theme-name ()
     "Print the current loaded theme from the `theme-list' on the modeline."
@@ -1287,7 +1343,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
 ** Theme Override Values
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-theme-override-values ()
@@ -1296,7 +1352,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
       "Face used for the line delimiting the begin of source blocks.")
 
     (defface org-block
-      '((t (:background "#242635" :extend t :font "JetBrains Mono")))
+      '((t (:background "#242635" :extend t :font "Fira Code Retina")))
       "Face used for the source block background.")
 
     (defface org-block-end-line
@@ -1339,12 +1395,13 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 <<<Color Theming>>> as a curated list of theming packages.
 *Note:* If new themes are added in the ~theme-list~ custom variable then they must be included here along with any customizations.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
 
   (mrf/org-theme-override-values)
+  (use-package tron-legacy-theme :defer t)
   (use-package ef-themes :init (mrf/customize-ef-theme) :defer t)
   (use-package modus-themes :init (mrf/customize-modus-theme) :defer t)
   (use-package material-theme :defer t)
@@ -1359,7 +1416,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 ** Selected theme
 This includes the theme to use in both graphical and non-graphical.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; (add-hook 'emacs-startup-hook #'(mrf/load-theme-from-selector))
   ;; (mrf/load-theme-from-selector)
@@ -1393,22 +1450,26 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
 
 ** Define the various font size constants
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Frame (view) setup including fonts.
   ;; You will most likely need to adjust this font size for your system!
 
   (setq-default mrf/small-font-size 150)
+  (setq-default mrf/small-mono-font-size 150)
   (setq-default mrf/small-variable-font-size 170)
 
   (setq-default mrf/medium-font-size 170)
+  (setq-default mrf/medium-mono-font-size 170)
   (setq-default mrf/medium-variable-font-size 190)
 
   (setq-default mrf/large-font-size 190)
+  (setq-default mrf/large-mono-font-size 190)
   (setq-default mrf/large-variable-font-size 210)
 
   (setq-default mrf/x-large-font-size 220)
+  (setq-default mrf/x-large-mono-font-size 220)
   (setq-default mrf/x-large-variable-font-size 240)
 
   ;; (setq-default custom-default-font-size mrf/medium-font-size)
@@ -1423,7 +1484,7 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
 #+end_src
 
 ** Functions to set the frame size
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Functions to set the frame size
@@ -1477,14 +1538,14 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
     (setq sheight (nth 4 (assq 'geometry (car (display-monitor-attributes-list)))))
 
     (add-to-list 'default-frame-alist '(fullscreen . maximized))
-    (mrf/frame-recenter)
+    (unless enable-frameset-restore (mrf/frame-recenter))
     )
 
 #+end_src
 
 ** Default fonts and sizes
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Default fonts
@@ -1500,7 +1561,7 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
     ;; Set the fixed pitch face
     (set-face-attribute 'fixed-pitch nil
       :family mono-spaced-font-family
-      :height custom-default-font-size
+      :height custom-default-mono-font-size
       :weight 'medium)
 
     ;; Set the variable pitch face
@@ -1516,7 +1577,8 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
       (when (display-graphic-p)
         (mrf/update-face-attribute)
         (unless (daemonp)
-        (mrf/frame-recenter)))))
+        (when enable-frameset-restore
+          (mrf/restore-desktop-frameset))))))
 
 #+end_src
 
@@ -1524,24 +1586,23 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
 
 The functions in the list =after-setting-font-hook= are called whenever the frame's font changes. In order to save this value, we capture it and store it in the =custom-default-font-size= custom variable. This variable is saved whenver Emacs exists. Then, when Emacs is started again, the default and fixed-pitch font height values are set to =custom-default-font-size=. The variable pitch font is computed as ~(+ custom-default-font-size 20)~
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/default-font-height-change ()
     (setq-default custom-default-font-size (face-attribute 'default :height))
     (mrf/update-face-attribute)
-    (mrf/frame-recenter))
+    (unless enable-frameset-restore (mrf/frame-recenter)))
 
   (add-hook 'after-setting-font-hook 'mrf/default-font-height-change)
 
 #+end_src
 
 ** Helper to up the font size for a higher-res monitor.
-
 *** Frame font selection
 This little function toggles between a larger font size and the default font size.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Frame font selection
 
@@ -1551,23 +1612,27 @@ This little function toggles between a larger font size and the default font siz
     (cond
       ((equal mrf/font-size-slot 3)
         (setq custom-default-font-size mrf/x-large-font-size
-        mrf/default-variable-font-size (+ custom-default-font-size 20)
-        mrf/font-size-slot 2)
+              custom-default-mono-font-size mrf/x-large-mono-font-size
+              mrf/default-variable-font-size (+ custom-default-font-size 20)
+              mrf/font-size-slot 2)
         (mrf/update-face-attribute))
       ((equal mrf/font-size-slot 2)
         (setq custom-default-font-size mrf/large-font-size
-        mrf/default-variable-font-size (+ custom-default-font-size 20)
-        mrf/font-size-slot 1)
+              custom-default-mono-font-size mrf/large-mono-font-size
+              mrf/default-variable-font-size (+ custom-default-font-size 20)
+              mrf/font-size-slot 1)
         (mrf/update-face-attribute))
       ((equal mrf/font-size-slot 1)
         (setq custom-default-font-size mrf/medium-font-size
-        mrf/default-variable-font-size (+ custom-default-font-size 20)
-        mrf/font-size-slot 0)
+              custom-default-mono-font-size mrf/medium-mono-font-size
+              mrf/default-variable-font-size (+ custom-default-font-size 20)
+              mrf/font-size-slot 0)
         (mrf/update-face-attribute))
       ((equal mrf/font-size-slot 0)
         (setq custom-default-font-size mrf/small-font-size
-        mrf/default-variable-font-size (+ custom-default-font-size 20)
-        mrf/font-size-slot 3)
+              custom-default-mono-font-size mrf/small-mono-font-size
+              mrf/default-variable-font-size (+ custom-default-font-size 20)
+              mrf/font-size-slot 3)
         (mrf/update-face-attribute))))
 
 #+end_src
@@ -1575,7 +1640,7 @@ This little function toggles between a larger font size and the default font siz
 **** Resolution Key Bindings
 Some key kindings to switch to different screen resolutions.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Some alternate keys below....
 
@@ -1584,44 +1649,61 @@ Some key kindings to switch to different screen resolutions.
     ("C-c 3". use-large-display-font)
     ("C-c 4". use-x-large-display-font))
 
+  (let ((map global-map))
+    (define-key map (kbd "C-S-c 1")
+      (lambda () (interactive) (use-small-display-font t)))
+    (define-key map (kbd "C-S-c 2")
+      (lambda () (interactive) (use-medium-display-font t)))
+    (define-key map (kbd "C-S-c 3")
+      (lambda () (interactive) (use-large-display-font t)))
+    (define-key map (kbd "C-S-c 4")
+      (lambda () (interactive) (use-x-large-display-font t))))
+
 #+end_src
 
 **** Frame support functions
 These functions are used to configure the main frame font size. Based upon a monitor's size, it may be necessary to make the font larger or smaller.
 
-#+begin_src emacs-lisp :tangle "init.el"
-  ;;; --------------------------------------------------------------------------
+#+begin_src emacs-lisp
+    ;;; --------------------------------------------------------------------------
   ;; Frame support functions
 
   (defun mrf/set-frame-font (slot)
     (setq mrf/font-size-slot slot)
     (mrf/update-font-size)
-    (mrf/frame-recenter)
-    )
+    (unless enable-frameset-restore (mrf/frame-recenter)))
 
-  (defun use-small-display-font ()
+  (defun mrf/should-recenter (&optional force-recenter)
+    (if force-recenter
+      (mrf/frame-recenter)
+      ;;else
+      (unless enable-frameset-restore (mrf/frame-recenter))))
+
+  ;;; --------------------------------------------------------------------------
+
+  (defun use-small-display-font (&optional force-recenter)
     (interactive)
     (mrf/set-frame-font 0)
-    (mrf/frame-recenter)
-    )
+    (mrf/should-recenter force-recenter))
 
-  (defun use-medium-display-font ()
+
+  (defun use-medium-display-font (&optional force-recenter)
     (interactive)
     (mrf/set-frame-font 1)
-    (mrf/frame-recenter)
-    )
+    (mrf/should-recenter force-recenter))
 
-  (defun use-large-display-font ()
+
+  (defun use-large-display-font (&optional force-recenter)
     (interactive)
     (mrf/set-frame-font 2)
-    (mrf/frame-recenter)
-    )
+    (mrf/should-recenter force-recenter))
 
-  (defun use-x-large-display-font ()
+
+  (defun use-x-large-display-font (&optional force-recenter)
     (interactive)
     (mrf/set-frame-font 3)
-    (mrf/frame-recenter)
-    )
+    (mrf/should-recenter force-recenter))
+
 
   ;; This is done so that the Emacs window is sized early in the init phase along with the default font size.
   ;; Startup works without this but it's nice to see the window expand early...
@@ -1631,8 +1713,8 @@ These functions are used to configure the main frame font size. Based upon a mon
         (progn
         (mrf/update-face-attribute)
         (unless (daemonp)
-          (mrf/frame-recenter))))
-      ))
+          (unless enable-frameset-restore (mrf/frame-recenter))))
+        )))
 
 #+end_src
 
@@ -1640,7 +1722,7 @@ These functions are used to configure the main frame font size. Based upon a mon
 
 This package provides a global minor mode to increase the spacing/padding of Emacs windows and frames. The idea is to make editing and reading feel more comfortable.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package spacious-padding
@@ -1676,7 +1758,7 @@ The =mrf/org-font-setup= function configures various text faces to tweak the siz
 
 This function sets up the fonts faces that are used within org-mode.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package faces :ensure nil)
@@ -1688,17 +1770,56 @@ This function sets up the fonts faces that are used within org-mode.
       '(("^ *\\([-]\\) "
           (0 (prog1 () (compose-region (match-beginning 1) (match-end 1) "•"))))))
     
-    (set-face-attribute 'org-block nil     :foreground 'unspecified
-      :inherit 'fixed-pitch :font "JetBrains Mono" :height custom-default-font-size)
-    (set-face-attribute 'org-formula nil  :inherit 'fixed-pitch)
-    (set-face-attribute 'org-code nil      :inherit '(shadow fixed-pitch))
-    (set-face-attribute 'org-table nil     :inherit '(shadow fixed-pitch))
-    (set-face-attribute 'org-verbatim nil :inherit '(shadow fixed-pitch))
-    (set-face-attribute 'org-special-keyword nil :inherit '(font-lock-comment-face fixed-pitch))
-    (set-face-attribute 'org-meta-line nil :inherit '(font-lock-comment-face fixed-pitch))
-    (set-face-attribute 'org-checkbox nil  :inherit 'fixed-pitch)
-    (set-face-attribute 'line-number nil :inherit 'fixed-pitch)
-    (set-face-attribute 'line-number-current-line nil :inherit 'fixed-pitch)
+    (set-face-attribute 'org-block nil
+      :foreground 'unspecified
+      :inherit 'fixed-pitch
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size)
+    
+    (set-face-attribute 'org-formula nil
+      :inherit 'fixed-pitch)
+    
+    (set-face-attribute 'org-code nil
+      :foreground 'unspecified
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size
+      :inherit '(shadow fixed-pitch))
+
+    (set-face-attribute 'org-table nil
+      :foreground 'unspecified
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size
+      :inherit '(shadow fixed-pitch))
+    
+    (set-face-attribute 'org-verbatim nil
+      :foreground 'unspecified
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size
+      :inherit '(shadow fixed-pitch))
+    
+    (set-face-attribute 'org-special-keyword nil
+      :inherit '(font-lock-comment-face fixed-pitch))
+    
+    (set-face-attribute 'org-meta-line nil
+      :inherit '(font-lock-comment-face fixed-pitch))
+    
+    (set-face-attribute 'org-checkbox nil
+      :foreground 'unspecified
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size
+      :inherit 'fixed-pitch)
+    
+    (set-face-attribute 'line-number nil
+      :foreground 'unspecified
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size
+      :inherit 'fixed-pitch)
+    
+    (set-face-attribute 'line-number-current-line nil
+      :foreground 'unspecified
+      :font mono-spaced-font-family
+      :height custom-default-mono-font-size
+      :inherit 'fixed-pitch)
 
     (dolist (face '((org-level-1 . 1.50)
                      (org-level-2 . 1.25)
@@ -1716,7 +1837,7 @@ This function sets up the fonts faces that are used within org-mode.
 
 This section contains the basic configuration for =org-mode= plus the configuration for Org agendas and capture templates.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;; -----------------------------------------------------------------
 
   (defun mrf/org-mode-visual-fill ()
@@ -1751,7 +1872,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 **** Function to setup the agenda
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-setup-agenda ()
@@ -1807,7 +1928,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 **** The capture-templates function
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-setup-capture-templates ()
@@ -1843,7 +1964,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+end_src
 
 ** The main 'Org' package
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package org
@@ -1893,7 +2014,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 ** Org Modern
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package org-modern
@@ -1940,7 +2061,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 ** Better Bullets
 [[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package org-superstar
@@ -1954,7 +2075,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 ** Export Code
 To execute or export code in =org-mode= code blocks, you'll need to set up =org-babel-load-languages= for each language you'd like to use.  [[https://orgmode.org/worg/org-contrib/babel/languages.html][Babel]] documents all of the languages that you can use with =org-babel=.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (with-eval-after-load 'org
@@ -1973,7 +2094,7 @@ Org Mode's structure templates feature enables you to quickly insert code blocks
 
 This snippet adds a hook to =org-mode= buffers so that =mrf/org-babel-tangle-config= gets executed each time such a buffer gets saved.  This function checks to see if the file being saved is the Emacs.org file you're looking at right now, and if so, automatically exports the configuration here to the associated output files.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (with-eval-after-load 'org
@@ -1986,8 +2107,8 @@ This snippet adds a hook to =org-mode= buffers so that =mrf/org-babel-tangle-con
 
 ** Markdown support
 While there is standard markdown support built into =org-mode=, this additional markdown package can also be used.
-
-#+begin_src emacs-lisp :tangle "init.el"
+*Disabled for now. Plus there is a large starup time.*
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
 
   (use-package ox-gfm
@@ -2007,10 +2128,10 @@ Org Roam solves these problems by making it easy to create topic-focused Org Fil
 
 *** Some required pacakages 
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
-  (use-package emacsql :demand t :ensure t)
-  (use-package emacsql-sqlite :demand t :ensure t)
+  (use-package emacsql :demand t :ensure t :after org)
+  (use-package emacsql-sqlite :demand t :ensure t :after org)
    
 #+end_src
 
@@ -2021,7 +2142,7 @@ Typically you won’t want to pull in all of your Org Roam notes, so we’ll onl
 
 Here is a snippet that will find all the notes with a specific tag and then set your org-agenda-list with the corresponding note files.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; The buffer you put this code in must have lexical-binding set to t!
   ;; See the final configuration at the end for more details.
@@ -2052,7 +2173,7 @@ One added benefit is that we can override the set of capture templates that get 
 
 This means that we can automatically create a new note with our project capture template if the note doesn’t already exist!
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-roam-project-finalize-hook ()
@@ -2089,7 +2210,7 @@ This means that we can automatically create a new note with our project capture 
 If you want to quickly capture new notes and tasks with a single keybinding into a place that you can review later, we can use org-roam-capture- to capture to a single-specific file like Inbox.org!
 
 Even though this file won’t have the timestamped filename, it will still be treated as a node in your Org Roam notes.
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-roam-capture-inbox ()
@@ -2097,11 +2218,12 @@ Even though this file won’t have the timestamped filename, it will still be tr
     (org-roam-capture- :node (org-roam-node-create)
       :templates '(("i" "inbox" plain "* %?"
                    :if-new (file+head "Inbox.org" "#+title: Inbox\n")))))
+  
 #+end_src
 
 *** Insert a node immediately
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (defun mrf/org-roam-node-insert-immediate (arg &rest args)
     (interactive "P")
@@ -2117,7 +2239,7 @@ If you’ve set up project note files like we mentioned earlier, you can set up 
 
 Much like the example before, we can either select a project that exists or automatically create a project note when it doesn’t exist yet.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-roam-capture-task ()
@@ -2138,7 +2260,7 @@ Much like the example before, we can either select a project that exists or auto
 *** Todo
 The following snippet sets up a hook for all Org task state changes and then copies the completed (DONE) entry to today’s note file
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/org-roam-copy-todo-to-today ()
@@ -2162,7 +2284,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 #+end_src
 
 *** Table-of-contents
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package toc-org
     :after org markdown-mode
@@ -2176,7 +2298,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 *** Main Org-roam Configuration
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package org-roam
     ;; :demand t  ;; Ensure org-roam is loaded by default
@@ -2242,7 +2364,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 ** Denote Keymap
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/define-denote-keymap ()
@@ -2291,7 +2413,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 ** Denote Configuration
 
-#+begin_src  emacs-lisp :tangle "init.el"
+#+begin_src  emacs-lisp
   ;;; --------------------------------------------------------------------------
   
   (use-package denote
@@ -2339,7 +2461,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 * Treemacs
 <<<Treemacs>>> is a file and project explorer similar to NeoTree or vim’s NerdTree, but largely inspired by the Project Explorer in Eclipse. It shows the file system outlines of your projects in a simple tree layout allowing quick navigation and exploration, while also possessing basic file management utilities.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Treemacs
 
@@ -2433,7 +2555,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 ** Treemacs Projectile
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package treemacs-projectile
@@ -2443,7 +2565,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 #+end_src
 
 ** Treemacs dired
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package treemacs-icons-dired
@@ -2453,7 +2575,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 #+end_src
 
 ** Treemacs Persp
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; (use-package treemacs-perspective
@@ -2470,7 +2592,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 ** Treemacs tab-bar
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
@@ -2481,7 +2603,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 ** Treemacs all-the-icons
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package treemacs-all-the-icons
@@ -2502,7 +2624,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 ***** a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
 
 ** Dashboard Setup
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
     ;;; --------------------------------------------------------------------------
 
   (use-package dashboard
@@ -2541,7 +2663,7 @@ The following are configured for Python development and provide an IDE type expe
 
 <<<Eglot>>> is the Emacs client for the Language Server Protocol (LSP). Eglot provides infrastructure and a set of commands for enriching the source code editing capabilities of Emacs via LSP. Eglot itself is completely language-agnostic, but it can support any programming language for which there is a language server and an Emacs major mode.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
     ;;; --------------------------------------------------------------------------
     ;;; Emacs Polyglot is the Emacs LSP client that stays out of your way:
 
@@ -2566,7 +2688,7 @@ The following are configured for Python development and provide an IDE type expe
 
 The JSON-RPC protocol is used to communicate with many different types of server. This is required for the DAPE and DAP Debug Adapters as well as Eglot.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; ------------------------------------------------------------------------
   (use-package jsonrpc
     :config
@@ -2581,7 +2703,7 @@ The JSON-RPC protocol is used to communicate with many different types of server
 
 *** Eglot Setup
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package eglot
     :when (equal custom-ide 'custom-ide-eglot)
@@ -2631,19 +2753,12 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
 🌟 Flexible - choose between full-blown IDE with flashy UI or minimal distraction free.
 ⚙ Easy to configure - works out of the box and automatically upgrades if additional packages are present.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Language Server Protocol
 
-  (when (equal custom-ide 'custom-ide-lsp)
-    (eval-when-compile (defvar lsp-enable-which-key-integration)))
-
-  (defun mrf/lsp-mode-setup ()
-    "Custom LSP setup function."
-    (when (equal custom-ide 'custom-ide-lsp)
-      (setq lsp-headerline-breadcrumb-segments '(path-up-to-project file symbols))
-      (setq lsp-clangd-binary-path "/usr/bin/clangd")'
-      (lsp-headerline-breadcrumb-mode)))
+  ;; (when (equal custom-ide 'custom-ide-lsp)
+  ;;   (eval-when-compile (defvar lsp-enable-which-key-integration)))
 
   (use-package lsp-mode
     :when (equal custom-ide 'custom-ide-lsp)
@@ -2657,6 +2772,15 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
         ("<tab>" . company-indent-or-complete-common)))
     (mrf/define-rust-lsp-values)
     (lsp-enable-which-key-integration t))
+  
+#+end_src
+
+*** LSP UI
+
+This package contains all the higher level UI modules of lsp-mode, like flycheck support and code lenses. By default, lsp-mode automatically activates lsp-ui unless lsp-auto-configure is set to nil. You only have to put (use-package lsp-ui) in your config and the package will work out of the box.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package lsp-ui
     :when (equal custom-ide 'custom-ide-lsp)
@@ -2679,6 +2803,17 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
     :bind (:map lsp-ui-mode-map
             ("C-c l d" . lsp-ui-doc-focus-frame))
     :hook (lsp-mode . lsp-ui-mode))
+  
+#+end_src
+
+*** LSP Treemacs integration
+
+Integration between lsp-mode and treemacs and implementation of treeview controls using treemacs as a tree renderer.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;;; To enable bidirectional synchronization of lsp workspace folders and
+  ;;; treemacs projects set lsp-treemacs-sync-mode to 1.
 
   (use-package lsp-treemacs
     :when (equal custom-ide 'custom-ide-lsp)
@@ -2692,10 +2827,28 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
     :when (and (equal custom-ide 'custom-ide-lsp)
             (equal completion-handler 'comphand-ivy-counsel))
     :after lsp ivy)
+#+end_src
+
+*** LSP mode hook function
+
+This function is called from the lsp-mode-hook when enering or leaving LSP mode.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;;; LSP mode setup hook
+
+  (defun mrf/lsp-mode-setup ()
+    "Custom LSP setup function."
+    (add-hook 'lsp-after-open-hook 'lsp-enable-imenu)
+    (when (equal custom-ide 'custom-ide-lsp)
+      (setq lsp-headerline-breadcrumb-segments '(path-up-to-project file symbols))
+      (setq lsp-clangd-binary-path "/usr/bin/clangd")'
+      (lsp-headerline-breadcrumb-mode)))
 
 #+end_src
 
-*** Rust LSP configuration
+*** LSP configuration for Rust
+
 #+begin_src emacs-lisp
 
   (defun mrf/define-rust-lsp-values ()
@@ -2733,16 +2886,14 @@ Advantages of lsp-bridge:
 
 + Flexible Customization: Customizing LSP server options is as simple as using a JSON file, allowing different projects to have different JSON configurations with just a few lines of rules
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
-
-  (use-package markdown-mode
-    :when (equal custom-ide 'custom-ide-lsp-bridge))
-  ;;:ensure (:fetcher github :repo "jrblevin/markdown-mode"))
 
   (use-package lsp-bridge
     :when (equal custom-ide 'custom-ide-lsp-bridge)
-    :ensure (:host github :repo "manateelazycat/lsp-bridge" :files (:defaults "*.el" "*.py" "acm" "core" "langserver" "multiserver" "resources") :build (:not compile))
+    :ensure ( :host github :repo "manateelazycat/lsp-bridge"
+            :files (:defaults "*.el" "*.py" "acm" "core" "langserver"
+                     "multiserver" "resources") :build (:not compile))
     :custom
     (lsp-bridge-python-lsp-server "pylsp")
     :config
@@ -2750,11 +2901,21 @@ Advantages of lsp-bridge:
 
 #+end_src
 
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  
+  (use-package markdown-mode
+    :when (equal custom-ide 'custom-ide-lsp-bridge))
+
+#+end_src
+
+
 ** Anaconda-mode
 
 Anaconda-mode provides Code navigation, documentation lookup and completion for Python.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package anaconda-mode
@@ -2778,7 +2939,7 @@ Anaconda-mode provides Code navigation, documentation lookup and completion for 
 ** ELPY
 Elpy is an Emacs package to bring powerful Python editing to Emacs.  It combines and configures a number of other packages, both written in Emacs Lisp as well as Python.  Elpy is fully documented at [[https://elpy.readthedocs.io/en/latest/index.html][read the docs]].
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package elpy
@@ -2827,7 +2988,7 @@ As compared to other packages which accomplish similar tasks, including IDO, Ivy
 
 TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package prescient)
   
@@ -2837,7 +2998,7 @@ TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
 
 This package provides an orderless completion style that divides the pattern into space-separated components, and matches candidates that match all of the components in any order. Each component can match in any one of several ways: literally, as a regexp, as an initialism, in the flex style, or as multiple word prefixes. By default, regexp and literal matches are enabled.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package orderless
@@ -2853,7 +3014,7 @@ This package provides an orderless completion style that divides the pattern int
 
 <<<Ivy>>> is an excellent completion framework for Emacs.  It provides a minimal yet powerful selection menu that appears when you open files, switch buffers, and for many other tasks in Emacs.  Counsel is a customized set of commands to replace `find-file` with `counsel-find-file`, etc which provide useful commands for each of the default completion commands.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Swiper and IVY mode
 
@@ -2888,7 +3049,7 @@ This package provides an orderless completion style that divides the pattern int
 Ivy-rich provides rich transformers for commands from ivy and counsel.
 Ivy-yasnippet lets you preview yasnippet snippets with ivy.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package ivy-rich
@@ -2909,7 +3070,7 @@ Ivy-yasnippet lets you preview yasnippet snippets with ivy.
 *** Swiper
 Swiper is an alternative to isearch that uses Ivy to show an overview of all matches.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package swiper
@@ -2923,7 +3084,7 @@ Swiper is an alternative to isearch that uses Ivy to show an overview of all mat
 ~ivy-mode~ ensures that any Emacs command using completing-read-function uses ivy for completion.
 Counsel takes this further, providing versions of common Emacs commands that are customised to make the best use of Ivy. For example, ~counsel-find-file~ has some additional keybindings. Pressing =DEL= will move you to the parent directory.
 
-#+begin_src emacs-lisp :tangle "init.el" :results output silent
+#+begin_src emacs-lisp :results output silent
   ;;; --------------------------------------------------------------------------
 
   (use-package counsel
@@ -2945,7 +3106,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 *** Ivy Prescient
 ~prescient.el~ is a library which sorts and filters lists of candidates, such as appear when you use a package like =Ivy= or =Company=.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package ivy-prescient
@@ -2962,7 +3123,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 
 <<<Corfu>>> enhances in-buffer completion with a small completion popup. The current candidates are shown in a popup below or above the point. The candidates can be selected by moving up and down. Corfu is the minimalistic in-buffer completion counterpart of the Vertico minibuffer UI.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;;;; Code Completion
@@ -3002,7 +3163,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 
 *** Corfu-prescient
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package corfu-prescient
     :when (equal completion-handler 'comphand-corfu)
@@ -3014,7 +3175,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 
 <<<Vertico>>> provides a performant and minimalistic vertical completion UI based on the default completion system. The focus of Vertico is to provide a UI which behaves correctly under all circumstances. By reusing the built-in facilities system, Vertico achieves full compatibility with built-in Emacs completion commands and completion tables.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package vertico
@@ -3041,7 +3202,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 
 Marginalia are marks or annotations placed at the margin of the page of a book or in this case helpful colorful annotations placed at the margin of the  minibuffer for your completion candidates. Marginalia can only add annotations  to the completion candidates. It cannot modify the appearance of the candidates  themselves, which are shown unaltered as supplied by the original command.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package marginalia
@@ -3058,7 +3219,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
 
 *** Icons for Marginalia
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package all-the-icons-completion
     :after (marginalia all-the-icons)
@@ -3070,7 +3231,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
 
 Consult provides search and navigation commands based on the Emacs completion function completing-read. Completion allows you to quickly select an item from a list of candidates. Consult offers asynchronous and interactive consult-grep and  consult-ripgrep commands, and the line-based search command consult-line. Furthermore Consult provides an advanced buffer switching command consult-buffer to switch between buffers, recently opened files, bookmarks and buffer-like candidates from other sources. Some of the Consult commands are enhanced versions of built-in Emacs commands.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package consult
     :when (equal completion-handler 'comphand-vertico)
@@ -3124,7 +3285,7 @@ Consult provides search and navigation commands based on the Emacs completion fu
 
 *** Vertico support packages
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package vertico-prescient
@@ -3135,7 +3296,7 @@ Consult provides search and navigation commands based on the Emacs completion fu
 
 vertico-posframe is an vertico extension, which lets vertico use posframe to show its candidate menu.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package vertico-posframe
@@ -3163,7 +3324,7 @@ vertico-posframe is an vertico extension, which lets vertico use posframe to sho
 ** Built-In (Ido)
 Enable the IDO handler everywhere.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; This has to be evaluated at the end of the init since it's possible that the
@@ -3180,7 +3341,7 @@ Enable the IDO handler everywhere.
 
 Embark makes it easy to choose a command to run based on what is near point, both during a minibuffer completion session (in a way familiar to Helm or Counsel users) and in normal buffers. Bind the command  embark-act to a key and it acts like prefix-key for a keymap of actions (commands) relevant to the target around point. With point on an URL in a buffer you can open the URL in a browser or eww or download the file it points to. If while switching buffers you spot an old one, you can kill it right there and continue to select another. Embark comes preconfigured with over a hundred actions for common types of targets such as files, buffers, identifiers, s-expressions, sentences; and it is easy to add more actions and more target types. Embark can also collect all the candidates in a minibuffer to an occur-like buffer or export them to a buffer in a major-mode specific to the type of candidates, such as dired for a set of files, ibuffer for a set of buffers, or customize for a set of variables.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package embark
@@ -3230,7 +3391,7 @@ Embark makes it easy to choose a command to run based on what is near point, bot
 
 This is more support for a language rather than a langage itself
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
     ;;; --------------------------------------------------------------------------
 
   (use-package flycheck
@@ -3256,7 +3417,7 @@ Tree-sitter is a parser generator tool and an incremental parsing library. It ca
 - Robust enough to provide useful results even in the presence of syntax errors
 - Dependency-free so that the runtime library (which is written in pure C) can be embedded in any application
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/tree-sitter-setup ()
@@ -3293,7 +3454,7 @@ Tree-sitter is a parser generator tool and an incremental parsing library. It ca
 *** Magit
 [[https://magit.vc/][Magit]] is the one of the best Git interface implementations .  Common Git operations are easy to execute quickly using Magit's command panel system.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   (use-package transient :defer t)
   (use-package git-commit :after transient :defer t)
@@ -3308,7 +3469,7 @@ Tree-sitter is a parser generator tool and an incremental parsing library. It ca
 
 #+end_src
 
-** Python
+** Python :Python:
 
 <<<Python>>> is an interpreted, interactive, object-oriented programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes. It supports multiple programming paradigms beyond object-oriented programming, such as procedural and functional programming. Python combines remarkable power with very clear syntax. It has interfaces to many system calls and libraries, as well as to various window systems, and is extensible in C or C++. It is also usable as an extension language for applications that need a programmable interface. Finally, Python is portable: it runs on many Unix variants including Linux and macOS, and on Windows.
 
@@ -3334,10 +3495,10 @@ In addition to that, it is important that =autopep8=, which is a script, can rea
 : file-missing "Doing vfork" "No such file or directory" :
 message
 
-*** Specialized python-mode Keymaps
+*** Specialized python-mode Keymaps :Python:
 The following are keymaps that are used by by the custom-ide and for python-mode
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/set-custom-ide-python-keymaps ()
@@ -3378,11 +3539,13 @@ The following are keymaps that are used by by the custom-ide and for python-mode
 
 These functions are used during python intialization or file loading. This is where Python IDE functionality, linting and debugging setup begins.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/load-python-file-hook ()
     (python-mode)
+    (when (equal custom-ide 'custom-ide-anaconda)
+      (anaconda-mode 1))
     (message ">>> mrf/load-python-file-hook")
     (setq highlight-indentation-mode -1)
     (setq display-fill-column-indicator-mode t))
@@ -3430,7 +3593,7 @@ These functions are used during python intialization or file loading. This is wh
 
 This is the primary Python setup that is triggered by the first load of the Python mode and then any time a file is loaded.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (add-to-list 'auto-mode-alist '("\\.py\\'" . mrf/load-python-file-hook))
@@ -3449,7 +3612,7 @@ This is the primary Python setup that is triggered by the first load of the Pyth
 *** Auto-pep 8
 autopep8 automatically formats Python code to conform to the `PEP 8` style guide.  It uses the pycodestyle_ utility to determine what parts of the code needs to be formatted.  autopep8 is capable of fixing most of the formatting issues_ that can be reported by pycodestyle. Refer to the [[IMPORTANT][IMPORTANT]] section above for possible issues when autopep8 is installed.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package py-autopep8
@@ -3460,7 +3623,7 @@ autopep8 automatically formats Python code to conform to the `PEP 8` style guide
 
 *** Python Keybinding
 **** Helpful Macros
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; This is a helpful macro that is used to put double quotes around a word.
@@ -3481,7 +3644,7 @@ autopep8 automatically formats Python code to conform to the `PEP 8` style guide
 *** Python Virtual Environment Support
 We use Pyvenv-auto is a package that automatically changes to the Python virtual environment based upon the project's directory.  pyvenv-auto looks at the root director of the project for a =.venv= or =venv= (and a few others)
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package pyvenv-auto
@@ -3492,7 +3655,7 @@ We use Pyvenv-auto is a package that automatically changes to the Python virtual
 
 *** Pydoc
 #Pydoc, the Python documentation navigation package
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package pydoc
@@ -3508,7 +3671,7 @@ We use Pyvenv-auto is a package that automatically changes to the Python virtual
 *** Typescript
 This is a basic configuration for the TypeScript language so that =.ts= files activate =typescript-ts-mode= when opened.  We're also adding a hook to =typescript-mode-hook= to call =lsp-deferred= so that we activate =lsp-mode= to get LSP features every time we edit TypeScript code.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package typescript-mode
@@ -3532,7 +3695,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 
 *** NodeJS
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/load-js-file-hook ()
@@ -3559,7 +3722,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 #+end_src
 
 *** JS2-Mode
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package js2-mode
@@ -3577,7 +3740,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 #+end_src
 
 ** C/C++
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/load-c-file-hook ()
@@ -3606,7 +3769,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 *** GameBoy Development
 RGBDS is a compiler that has been around quite a long time (since 1997). It supports Z80 and the LR35902 assembler syntaxes that are used in the development of Game Boy and Game Boy color games.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package z80-mode
@@ -3666,7 +3829,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 
 *** Rust-mode configuration
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; (use-package graphql-mode)
@@ -3676,15 +3839,18 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
     :hook
     (rust-mode . lsp-deferred)
     (rust-mode . (lambda () (setq indent-tabs-mode nil)
-                 (prettify-symbols-mode)))
+                   (prettify-symbols-mode)))
     :config
     (setq rust-format-on-save t))
-                                        ; ;(use-package rust-analyzer)
+
+  (use-package rust-playground :ensure t :after rust-mode)
+  (use-package toml-mode :ensure t :after rust-mode)
+
 #+end_src
 
 *** Cargo-mode configuration
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package cargo-mode
     :defer t
@@ -3701,18 +3867,19 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 
 ** Go!
 **** Important!
-Make sure that =gopls= is installed:
+Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  language server - like LSP. =dlv= is the =golang= debugger.
 
 #+begin_src shell
 
   brew install gopls
   go get golang.org/x/tools/cmd/guru
-  
+  brew install dlv
+
 #+end_src
 
 *** Main go-mode config
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
     ;;; --------------------------------------------------------------------------
 
   (defun eglot-format-buffer-on-save ()
@@ -3728,6 +3895,7 @@ Make sure that =gopls= is installed:
         (add-hook 'go-mode-hook #'eglot-format-buffer-on-save))
       ((equal custom-ide 'custom-ide-lsp)
         (add-hook 'go-mode-hook 'lsp-deferred))))
+  
 #+end_src
 
 *** go-eldoc config
@@ -3735,7 +3903,7 @@ Make sure that =gopls= is installed:
 =go-eldoc.el= provides eldoc for Go language. `go-eldoc.el' shows type information
 for variable, functions and current argument position of function.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package go-eldoc
     :after go-mode
@@ -3751,7 +3919,7 @@ for variable, functions and current argument position of function.
 
 Integration of the Go 'guru' analysis tool into Emacs.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package go-guru
     :after go-mode
@@ -3766,7 +3934,7 @@ Lesser used or lesser known languages.
 
 Lisp support is handled by SLIME which is the “Superior Lisp Interaction Mode for Emacs”. SLIME extends Emacs with support for interactive programming in Common Lisp. The features are centered around slime-mode, an Emacs minor-mode that complements the standard lisp-mode. While lisp-mode supports editing Lisp source files, slime-mode adds support for interacting with a running Common Lisp process for compilation, debugging, documentation lookup, and so on. Extensive documentation can be found [[https://slime.common-lisp.dev/doc/html/][at this link]].
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package slime
@@ -3862,7 +4030,7 @@ For complete functionality, make sure to enable eldoc-mode in your source buffer
 
 Please note that DAP is triggered after loading of various languages (for Emacs startup time).  New languages that use DAPE should also be listed. Don't put just ~prog-mode~ since we want to delay loading until needed be specific languages only.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; ------------------------------------------------------------------------
 
   (use-package dape
@@ -3886,7 +4054,7 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
 
 **** DAPE for TypeScript
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (setq mrf/vscode-js-debug-dir (file-name-concat user-emacs-directory "dape/vscode-js-debug"))
@@ -3907,7 +4075,7 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
 
 This is meant to be evaluated and run once. Calling this function will clone the vscode-js-debug framework. This is a DAP-based JavaScript debugger. It debugs Node.js, Chrome, Edge, WebView2, VS Code extensions, and more. It has been the default JavaScript debugger in Visual Studio Code since 1.46, and is gradually rolling out in Visual Studio proper.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; (mrf/install-vscode-js-debug)
@@ -3919,7 +4087,7 @@ This is meant to be evaluated and run once. Calling this function will clone the
 
 **** Additional DAPE Configs
 :Golang:
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; ------------------------------------------------------------------------
   (defun mrf/additional-dape-configs ()
     "Additional DAPE configruations for various languages."
@@ -3946,7 +4114,7 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
 
 ***** DAPE Hydra Debug Functions
 
-#+begin_src emacs-lisp :tangle "init.el" :output silent
+#+begin_src emacs-lisp :output silent
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/dape-end-debug-session ()
@@ -3964,7 +4132,7 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
 
 ***** DAPE Hydra Definition
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   ;;; --------------------------------------------------------------------------
 
@@ -4020,7 +4188,7 @@ The idea behind the Debug Adapter Protocol (DAP) is to abstract the way how the 
 
 The Debug Adapter Protocol makes it possible to implement a generic debugger for a development tool that can communicate with different debuggers via Debug Adapters. And Debug Adapters can be re-used across multiple development tools which significantly reduces the effort to support a new debugger in different tools.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; Debug Adapter Protocol
   (use-package dap-mode
@@ -4033,6 +4201,8 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
     :custom
     (dap-auto-configure-features '(sessions locals breakpoints expressions repl controls tooltip))
     :config
+    (require 'dap-lldb)
+    (require 'dap-gdb-lldb)
     (define-dap-hydra)
     (bind-keys :map prog-mode-map
       ("C-c ." . dap-hydra/body))
@@ -4043,7 +4213,7 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
 
 **** DAP Package for Python :Python:
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;;; DAP for Python
 
@@ -4057,27 +4227,44 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
   
 #+end_src
 
-**** DAP Setup for Rust and Go
+**** DAP Setup for Rust and Go :Rust:Go:
 
 Something that is needed for Rust and Go debugging.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package dap-lldb
     :when (equal debug-adapter 'debug-adapter-dap-mode)
     :defer t
     :after dap-mode
-    :ensure (:package "dap-lldb" :type git :host github :repo "emacs-lsp/dap-mode")
+    :ensure (:package "dap-lldb" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode")
     :custom
-    (dap-lldb-debug-program "~/Developer/command-line-unix/llvm/lldb-build/bin/lldb-dap"))
+    (dap-lldb-debug-program "~/Developer/command-line-unix/llvm/lldb-build/bin/lldb-dap")
+    :config
+    (dap-register-debug-template
+      "Rust::LLDB Run Configuration"
+      (list :type "lldb"
+        :request "launch"
+        :name "LLDB::Run"
+        :gdbpath "rust-lldb"
+        :target nil
+        :cwd nil)))
 
   (use-package dap-gdb-lldb
-    :ensure (:package "dap-gdb-lldb" :type git :host github :repo "emacs-lsp/dap-mode")
+    :when (equal debug-adapter 'debug-adapter-dap-mode)
+    :ensure (:package "dap-gdb-lldb" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode")
     :defer t
     :after dap-lldb
     :config
     (dap-gdb-lldb-setup))
 
+  (use-package dap-cpptools
+    :when (equal debug-adapter 'debug-adapter-dap-mode)
+    :defer t
+    :after dap-mode
+    :ensure (:package "dap-cpptools" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode"))
+    ;; :config
+    ;; (dap-cpptools-setup))
 
 #+end_src
 
@@ -4111,7 +4298,7 @@ Something that is needed for Rust and Go debugging.
 
 #+end_src
 
-**** DAP Templates For Various Languages
+**** DAP Templates For Various Languages :Python:Rust:
 
 #+begin_src emacs-lisp
 
@@ -4141,14 +4328,15 @@ Something that is needed for Rust and Go debugging.
         :program nil
         :request "launch"
         :name "Python :: Run file (buffer)")))
+  
 #+end_src
 
 **** DAP Hydra
 
 Below are all the necessary functions and definitions for Hydra use under DAP.
 
-***** DAP Hydra Debug Functions
-#+begin_src emacs-lisp :tangle "init.el"
+***** DAP Hydra Debug Functions :Python:
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/dap-end-debug-session ()
@@ -4174,7 +4362,7 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 #+end_src
 
 ***** DAP Hydra Definition Function
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun define-dap-hydra ()
@@ -4232,6 +4420,8 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 
 #+end_src
 
+z
+
 
 * Company Mode
 
@@ -4239,7 +4429,7 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 
 We also use [[https://github.com/sebastiencs/company-box][company-box]] to further enhance the look of the completions with icons and better overall presentation.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
@@ -4285,8 +4475,8 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 
 #+end_src
 
-** Company Packages
-#+begin_src emacs-lisp :tangle "init.el"
+** Company Packages :Python:
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package company-box
@@ -4319,7 +4509,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 
 [[https://projectile.mx/][Projectile]] is a project management library for Emacs which makes it a lot easier to navigate around code projects for various languages.  Many packages integrate with Projectile so it's a good idea to have it installed even if you don't use its commands directly.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package projectile
@@ -4348,7 +4538,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 * Project.el
 This is the default built-in project system. For those not needing the full-featured ~projectile~, this package is generally enough.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (defun project-find-go-module (dir)
     (when-let ((root (locate-dominating-file dir "go.mod")))
@@ -4384,7 +4574,7 @@ Run a terminal with =M-x term!=
 - =C-c C-j= - Return to line-mode
 - If you have =evil-collection= installed, =term-mode= will enter char mode when you use Evil's Insert mode
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package term+
@@ -4403,7 +4593,7 @@ Run a terminal with =M-x term!=
 
 The =eterm-256color= package enhances the output of =term-mode= to enable handling of a wider range of color codes so that many popular terminal applications look as you would expect them to.  Keep in mind that this package requires =ncurses= to be installed on your machine so that it has access to the =tic= program.  Most Linux distributions come with this program installed already so you may not have to do anything extra to use it.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package eterm-256color
@@ -4417,7 +4607,7 @@ The =eterm-256color= package enhances the output of =term-mode= to enable handli
 
 Make sure that you have the [[https://github.com/akermu/emacs-libvterm/#requirements][necessary dependencies]] installed before trying to use =vterm= because there is a module that will need to be compiled before you can use it successfully.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package vterm
@@ -4461,7 +4651,7 @@ For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
 - https://ambrevar.xyz/emacs-eshell/index.html
 - https://ambrevar.xyz/emacs-eshell-versus-shell/index.html
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (defun mrf/configure-eshell ()
@@ -4554,7 +4744,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 
 *** Configuration
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Prefer g-prefixed coreutils version of standard utilities when available
@@ -4585,7 +4775,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 *** Single Window
 Dired, by default, opens up multiple windows - one for each directory. It would be nice to be able to limit =dired= to use just a single window. [[https://codeberg.org/amano.kenji/dired-single][dired-single]] does just that. We configure =dired-single= to open up a directory while in dired with the =C-<return>=  key combination. This will then open up the directory in the buffer named =*dired*=. Whenever a directory is opened with the =C-<return>= key sequence, that directory will then replace what's currently in the =*dired*= buffer.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Single Window dired - don't continually open new buffers
 
@@ -4624,7 +4814,7 @@ The following packages are some additional quality of life features.
 
 [[https://github.com/Wilfred/helpful][Helpful]] adds a lot of very helpful (get it?) information to Emacs' =describe-= command buffers.  For example, if you use =describe-function=, you will not only get the documentation about the function, you will also see the source code of the function and where it gets used in other places in the Emacs configuration.  It is very useful for figuring out how things work in Emacs.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; helpful package
 
@@ -4646,7 +4836,7 @@ The following packages are some additional quality of life features.
 #+end_src
 
 ** Solair mode
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package solaire-mode
@@ -4661,7 +4851,7 @@ The following packages are some additional quality of life features.
 #+end_src
 
 ** Golden Ratio
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Golen Ratio
 
@@ -4690,11 +4880,25 @@ The following packages are some additional quality of life features.
     (golden-ratio-mode 1))
 
 #+end_src
+** Swap Buffers
+
+This file is for lazy people wanting to swap buffers without typing C-x b on each window.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  
+  (use-package buffer-move
+    :bind (("C-S-<up>"     . buf-move-up)
+          ("C-S-<down>"  . buf-move-down)
+          ("C-S-<left>"  . buf-move-left)
+          ("C-S-<right>" . buf-move-right)))
+
+#+end_src
 
 ** Neotree
 A tree plugin like NerdTree for Vim
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package neotree
@@ -4723,7 +4927,7 @@ Here are some helpful functions.
 #+end_src
 
 ** Centaur Tabs
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Enable tabs for each buffer
 
@@ -4744,7 +4948,7 @@ Here are some helpful functions.
 ** Diff HL
 =diff-hl-mode= highlights uncommitted changes on the left side of the window (area also known as the "gutter"), allows you to jump between and revert them selectively.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package diff-hl
@@ -4754,7 +4958,7 @@ Here are some helpful functions.
 #+end_src
 
 ** Pulsar
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package pulsar
@@ -4772,10 +4976,21 @@ Here are some helpful functions.
 
 This minor mode sets background color to strings that match color names, e.g. #0000FF is displayed in white with a blue background.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
 
   (use-package rainbow-mode
     :hook (prog-mode . (lambda () (rainbow-mode t))))
+
+#+end_src
+
+** Lisp Hightlighter
+
+highlight-defined is an Emacs minor mode that highlights defined Emacs Lisp symbols in source code.
+
+#+begin_src emacs-lisp
+
+  (use-package highlight-defined
+    :hook (emacs-lisp-mode . highlight-defined-mode))
 
 #+end_src
 
@@ -4811,12 +5026,44 @@ Designate any buffer to “popup” status, and it will stay out of your way. Di
 
 #+end_src
 
+** Markdown Mode
+
+markdown-mode is a major mode for editing Markdown-formatted text. The latest stable version is markdown-mode 2.5, released on Feb 12, 2022. See the release notes for details. markdown-mode is free software, licensed under the GNU GPL, version 3 or later.
+
+#+begin_src emacs-lisp :tangle no
+
+  (use-package markdown-mode
+    :ensure t
+    :mode ("README\\.md\\'" . gfm-mode)
+    :init (setq markdown-command "multimarkdown"))
+
+#+end_src
+
+** GRIP Mode
+
+Instant Github-flavored Markdown/Org preview using Grip (GitHub Readme Instant Preview).
+
+#+begin_src emacs-lisp :tangle no
+
+  ;; Use keybindings
+  (use-package grip-mode
+    :ensure t
+    :bind (:map markdown-mode-command-map
+           ("g" . grip-mode)))
+
+  ;; Or using hooks
+  (use-package grip-mode
+    :ensure t
+    :hook ((markdown-mode org-mode) . grip-mode))
+  
+#+end_src
+
 ** Mitch's Minor Mode
 
 Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It works well when =which-key= is active.
 
 *** Mitch's Minor Mode Functions
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   
   (defun mrf/set-fill-column-interactively (num)
     "Asks for the fill column."
@@ -4832,30 +5079,29 @@ Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It work
 
 #+end_src
 
-
 *** Mitch's Minor-Mode Standard Keymaps
 
 This is a set of keymaps that do the same things as the popup menu. Both are here for convenience. *Note* that the ~mmm-menu~ is called with either a ="C-c RET RET"= or simply a ="C-c C-<return>"=.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   (defun mrf/define-mmm-minor-mode-map ()
     (defvar mmm-keys-minor-mode-map
       (let ((map (make-sparse-keymap)))
         (bind-keys :map map
-        ("M-RET p" . pulsar-pulse-line)
-        ("M-RET d" . dashboard-open)
-        ("M-RET S e" . eshell)
-        ("M-RET f" . mrf/set-fill-column-interactively)
+          ("M-RET p" . pulsar-pulse-line)
+          ("M-RET d" . dashboard-open)
+          ("M-RET S e" . eshell)
+          ("M-RET f" . mrf/set-fill-column-interactively)
           ("M-RET r" . repeat-mode)
-        ("M-RET S i" . ielm)
-        ("M-RET S v" . vterm-other-window)
-        ("M-RET t" . treemacs)
-        ("M-RET |" . global-display-fill-column-indicator-mode)
-        ("M-RET T +" . next-theme)
-        ("M-RET T -" . previous-theme)
-        ("M-RET T ?" . which-theme)
-        ("M-RET ?" . eldoc-box-help-at-point))
+          ("M-RET S i" . ielm)
+          ("M-RET S v" . vterm-other-window)
+          ("M-RET t" . treemacs)
+          ("M-RET |" . global-display-fill-column-indicator-mode)
+          ("M-RET T +" . next-theme)
+          ("M-RET T -" . previous-theme)
+          ("M-RET T ?" . which-theme)
+          ("M-RET ?" . eldoc-box-help-at-point))
         map)
       "mmm-keys-minor-mode keymap.")
 
@@ -4874,7 +5120,7 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
 For those menus that would normally show up as either =prefix= or =lambda=, given them a better description via the which-key replacement function. This is run via the ~which-key-inhibit-display-hook~ hook which is run just before the which-key popup is
 shown. Plus, some keys are mode specific and will only appear when that major mode is active.
 
-#+begin_src emacs-lisp :tangle "init.el" :results output silent
+#+begin_src emacs-lisp :results output silent
 
   (defun mrf/mmm-handle-context-keys ()
     "Enable or Disable keys based upon featurep context."
@@ -4908,10 +5154,9 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
 
 #+end_src
 
-
 ** Initial *scratch* buffer message
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (add-hook 'elpaca-after-init-hook
@@ -4928,8 +5173,6 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
   (if dashboard-landing-screen
     ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
     (add-hook 'lisp-interaction-mode-hook 'dashboard-open))
-
-  ;; (add-hook 'lisp-interaction-mode-hook 'use-package-report)
 
 #+end_src
 
@@ -4967,7 +5210,7 @@ The following is a list of major mode-hooks variables that are set so that they 
 ** Lispy Footer
 The standard =lisp= footer that should appear at the end of every =lisp= source file.
 
-#+begin_src emacs-lisp :tangle "init.el"
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;;; init.el ends here.

--- a/init.el
+++ b/init.el
@@ -16,35 +16,35 @@
 (defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
 (defvar elpaca-repos-directory (expand-file-name "repos/" elpaca-directory))
 (defvar elpaca-order '(elpaca :repo "https://github.com/progfolio/elpaca.git"
-			:ref nil :depth 1
-			:files (:defaults "elpaca-test.el" (:exclude "extensions"))
-			:build (:not elpaca--activate-package)))
-(let* ((repo	(expand-file-name "elpaca/" elpaca-repos-directory))
-	(build (expand-file-name "elpaca/" elpaca-builds-directory))
-	(order (cdr elpaca-order))
-	(default-directory repo))
+                        :ref nil :depth 1
+                        :files (:defaults "elpaca-test.el" (:exclude "extensions"))
+                        :build (:not elpaca--activate-package)))
+(let* ((repo  (expand-file-name "elpaca/" elpaca-repos-directory))
+        (build (expand-file-name "elpaca/" elpaca-builds-directory))
+        (order (cdr elpaca-order))
+        (default-directory repo))
   (add-to-list 'load-path (if (file-exists-p build) build repo))
   (unless (file-exists-p repo)
     (make-directory repo t)
     (when (< emacs-major-version 28) (require 'subr-x))
     (condition-case-unless-debug err
       (if-let ((buffer
-		 (pop-to-buffer-same-window "*elpaca-bootstrap*"))
-		((zerop (apply #'call-process
-			  `("git" nil ,buffer t "clone"
-			     ,@(when-let ((depth (plist-get order :depth)))
-				 (list (format "--depth=%d" depth)
-				   "--no-single-branch"))
-			     ,(plist-get order :repo) ,repo))))
-		((zerop (call-process "git" nil buffer t "checkout"
-			  (or (plist-get order :ref) "--"))))
-		(emacs (concat invocation-directory invocation-name))
-		((zerop (call-process emacs nil buffer nil "-Q" "-L" "." "--batch"
-			  "--eval" "(byte-recompile-directory \".\" 0 'force)")))
-		((require 'elpaca))
-		((elpaca-generate-autoloads "elpaca" repo)))
-	(progn (message "%s" (buffer-string)) (kill-buffer buffer))
-	(error "%s" (with-current-buffer buffer (buffer-string))))
+                 (pop-to-buffer-same-window "*elpaca-bootstrap*"))
+                ((zerop (apply #'call-process
+                          `("git" nil ,buffer t "clone"
+                             ,@(when-let ((depth (plist-get order :depth)))
+                                 (list (format "--depth=%d" depth)
+                                   "--no-single-branch"))
+                             ,(plist-get order :repo) ,repo))))
+                ((zerop (call-process "git" nil buffer t "checkout"
+                          (or (plist-get order :ref) "--"))))
+                (emacs (concat invocation-directory invocation-name))
+                ((zerop (call-process emacs nil buffer nil "-Q" "-L" "." "--batch"
+                          "--eval" "(byte-recompile-directory \".\" 0 'force)")))
+                ((require 'elpaca))
+                ((elpaca-generate-autoloads "elpaca" repo)))
+        (progn (message "%s" (buffer-string)) (kill-buffer buffer))
+        (error "%s" (with-current-buffer buffer (buffer-string))))
       ((error) (warn "%s" err) (delete-directory repo 'recursive))))
   (unless (require 'elpaca-autoloads nil t)
     (require 'elpaca)
@@ -136,7 +136,7 @@ The Dashboard will be in the *dashboard* buffer and can also be opened using
 
 (defcustom enable-golden-ratio nil
   "Set to t to enable `golden-ratio-mode' which resizes the active buffer
-    window to the dimensions of a golden-rectangle "
+   window to the dimensions of a golden-rectangle"
   :type 'boolean
   :group 'mrf-custom-toggles)
 
@@ -147,6 +147,12 @@ The Dashboard will be in the *dashboard* buffer and can also be opened using
 
 (defcustom enable-embark nil
   "Set to t to enable the Embark package."
+  :type 'boolean
+  :group 'mrf-custom-toggles)
+
+(defcustom enable-frameset-restore nil
+  "Set to t to enable restoring the last Emacs window size and position
+   upon startup."
   :type 'boolean
   :group 'mrf-custom-toggles)
 
@@ -163,9 +169,9 @@ capability to persist undo history across Emacs sessions.
 
 Finally, the standard undo handler can also be chosen."
   :type '(radio
-	   (const :tag "Vundo (default)" undo-handler-vundo)
-	   (const :tag "Undo-tree" undo-handler-undo-tree)
-	   (const :tag "Built-in" undo-handler-built-in))
+         (const :tag "Vundo (default)" undo-handler-vundo)
+         (const :tag "Undo-tree" undo-handler-undo-tree)
+         (const :tag "Built-in" undo-handler-built-in))
   :group 'mrf-custom-features)
 
 (defcustom completion-handler 'comphand-vertico
@@ -181,10 +187,10 @@ also includes Counsel. Counsel provides completion versions of common Emacs
 commands that are customised to make the best use of Ivy.  Swiper is an
 alternative to isearch that uses Ivy to show an overview of all matches."
   :type '(radio
-	   (const :tag "Vertico completion system." comphand-vertico)
-	   (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
-	   (const :tag "Cofu completion systems" comphand-corfu)
-	   (const :tag "Built-in Ido" comphand-built-in))
+         (const :tag "Vertico completion system." comphand-vertico)
+         (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
+         (const :tag "Cofu completion systems" comphand-corfu)
+         (const :tag "Built-in Ido" comphand-built-in))
   :group 'mrf-custom-features)
 
 (defcustom debug-adapter 'debug-adapter-dape
@@ -198,8 +204,8 @@ implemented entirely in Emacs Lisp. There are no other external dependencies
 with DAPE. DAPE supports most popular languages, however, not as many as
 dap-mode."
   :type '(radio
-	   (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
-	   (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
+         (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
+         (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
   :group 'mrf-custom-features)
 
 (defcustom custom-ide 'custom-ide-eglot
@@ -219,11 +225,11 @@ for which there is a language server and an Emacs major mode.
 Anaconda-mode is another IDE for Python very much like Elpy. It is not as
 configurable but has a host of great feaures that just work."
   :type '(radio
-	   (const :tag "Elpy: Emacs Lisp Python Environment" custom-ide-elpy)
-	   (const :tag "Emacs Polyglot (Eglot)" custom-ide-eglot)
-	   (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
-	   (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
-	   (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
+         (const :tag "Elpy: Emacs Lisp Python Environment" custom-ide-elpy)
+         (const :tag "Emacs Polyglot (Eglot)" custom-ide-eglot)
+         (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
+         (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
+         (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
   :group 'mrf-custom-features)
 
 (defcustom custom-project-handler 'custom-project-project
@@ -245,7 +251,8 @@ configurable but has a host of great feaures that just work."
 			 "ef-melissa-dark"
 			 "darktooth-dark"
 			 "material"
-			 "deeper-blue")
+			 "tron-legacy")
+
   "My personal list of themes to cycle through indexed by `theme-selector'.
 If additional themes are added, they must be previously installed."
   :group 'mrf-custom-theming
@@ -262,12 +269,12 @@ If additional themes are added, they must be previously installed."
   :type 'natnum)
 
 ;;; Font related
-(defcustom default-font-family "Hack"
+(defcustom default-font-family "Fira Code Retina"
   "The font family used as the default font."
   :type 'string
   :group 'mrf-custom-fonts)
 
-(defcustom mono-spaced-font-family "Hack"
+(defcustom mono-spaced-font-family "Fira Code Retina"
   "The font family used as the mono-spaced font."
   :type 'string
   :group 'mrf-custom-fonts)
@@ -324,6 +331,9 @@ font size is computed + 20 of this value."
   :type 'natnum
   :group 'mrf-custom-fonts)
 
+(defvar custom-default-mono-font-size 170
+  "Storage for the current mono-spaced font height.")
+
 ;;; --------------------------------------------------------------------------
 
 ;; Use shell path
@@ -335,7 +345,7 @@ font size is computed + 20 of this value."
    ;;; apps are not started from a shell."
   (interactive)
   (let ((path-from-shell (replace-regexp-in-string "[ \t\n]*$" ""
-			   (shell-command-to-string "$SHELL --login -c 'echo $PATH'"))))
+                           (shell-command-to-string "$SHELL --login -c 'echo $PATH'"))))
     (setenv "PATH" path-from-shell)
     (setq exec-path (split-string path-from-shell path-separator))
     (add-to-list 'exec-path "/opt/homebrew/bin")
@@ -384,23 +394,24 @@ font size is computed + 20 of this value."
   frame-resize-pixelwise t
   dired-dwim-target t       ;; try to guess target directory
   truncate-partial-width-windows 1 ;; truncate lines in partial-width windows
-  backup-inhibited t	       ;; disable backup (No ~ tilde files)
+  backup-inhibited t         ;; disable backup (No ~ tilde files)
   auto-save-default nil     ;; disable auto save
   global-auto-revert-mode 1 ;; Refresh buffer if file has changed
   global-auto-revert-non-file-buffers t
-  history-length 25	       ;; Reasonable buffer length
+  history-length 25          ;; Reasonable buffer length
   inhibit-startup-message t ;; Hide the startup message
   inhibit-startup-screent t
   lisp-indent-offset '2     ;; emacs lisp tab size
-  visible-bell t	       ;; Set up the visible bell
-  truncate-lines 1	       ;; long lines of text do not wrap
-  fill-column 80	       ;; Default line limit for fills
+  visible-bell t             ;; Set up the visible bell
+  truncate-lines 1           ;; long lines of text do not wrap
+  fill-column 80             ;; Default line limit for fills
   ;; Triggers project for directories with any of the following files:
   project-vc-extra-root-markers '(".dir-locals.el"
-				   "requirements.txt"
-				   "Gemfile"
-				   "package.json"))
+                                 "requirements.txt"
+                                 "Gemfile"
+                                 "package.json"))
 
+;;; --------------------------------------------------------------------------
 (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
 (savehist-mode t)
 (setq history-length t)
@@ -411,14 +422,42 @@ font size is computed + 20 of this value."
         search-ring
         regexp-search-ring))
 
+;;; --------------------------------------------------------------------------
 ;; (global-display-line-numbers-mode 1) ;; Line numbers appear everywhere
-(save-place-mode 1)		       ;; Remember where we were last editing a file.
+(save-place-mode 1)                  ;; Remember where we were last editing a file.
 (show-paren-mode 1)
 (column-number-mode 1)
-(tool-bar-mode -1)		       ;; Hide the toolbar
+(tool-bar-mode -1)                   ;; Hide the toolbar
 (global-prettify-symbols-mode 1)     ;; Display pretty symbols (i.e. λ = lambda)
 ;; (repeat-mode 1)
 (add-hook 'prog-mode-hook 'display-line-numbers-mode)
+
+;;; --------------------------------------------------------------------------
+
+(defun mrf/save-desktop-frameset ()
+  (unless (daemonp)
+    (desktop-save-mode 0)
+    (desktop-save-frameset)
+    (with-temp-file (expand-file-name "saved-frameset.el" user-emacs-directory)
+      (insert
+	(format "(setq desktop-saved-frameset %S)" desktop-saved-frameset)))))
+
+(add-hook 'kill-emacs-hook 'mrf/save-desktop-frameset)
+
+;;; --------------------------------------------------------------------------
+ 
+(defun mrf/restore-desktop-frameset ()
+  (unless (daemonp)
+    (let
+      ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
+      (desktop-save-mode 0)
+      (when (f-exists? file) (load file)
+	(desktop-restore-frameset)
+	(when (featurep 'spacious-padding)
+	  (when spacious-padding-mode
+	    (spacious-padding-mode 0)
+	    (spacious-padding-mode 1)))))
+	))
 
 ;; Allow access from emacsclient
 (add-hook 'elpaca-after-init-hook
@@ -432,9 +471,20 @@ font size is computed + 20 of this value."
 
 ;;; --------------------------------------------------------------------------
 
+(use-package f
+  :ensure ( :package "f" :source "MELPA" :protocol https :inherit t
+	    :depth 1 :fetcher github :repo "rejeep/f.el"
+	    :files ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
+		     "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
+		     "lisp/*.el" (:exclude ".dir-locals.el" "test.el"
+				   "tests.el" "*-test.el" "*-tests.el"
+				   "LICENSE" "README*" "*-pkg.el"))))
+
+;;; --------------------------------------------------------------------------
+
 (use-package hydra
   :ensure (:repo "abo-abo/hydra" :fetcher github
-	    :files (:defaults (:exclude "lv.el"))))
+            :files (:defaults (:exclude "lv.el"))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -471,9 +521,9 @@ font size is computed + 20 of this value."
 
 (use-package multiple-cursors
   :bind (("C-S-c C-S-c" . mc/edit-lines)
-	  ("C->" . mc/mark-next-like-this)
-	  ("C-<" . mc/mark-previous-like-this)
-	  ("C-c C-<" . mc/mark-all-like-this)))
+        ("C->" . mc/mark-next-like-this)
+        ("C-<" . mc/mark-previous-like-this)
+        ("C-c C-<" . mc/mark-all-like-this)))
 
 ;;; --------------------------------------------------------------------------
 
@@ -586,7 +636,7 @@ font size is computed + 20 of this value."
 
 (use-package yasnippet
   :bind (:map yas-minor-mode-map
-	  ("<C-'>" . yas-expand))
+        ("<C-'>" . yas-expand))
   :config
   (setq yas-global-mode t)
   (setq yas-minor-mode t)
@@ -645,7 +695,7 @@ font size is computed + 20 of this value."
 (defun undo-tree-split-side-by-side (original-function &rest args)
   "Split undo-tree side-by-side"
   (let ((split-height-threshold nil)
-	 (split-width-threshold 0))
+       (split-width-threshold 0))
     (apply original-function args)))
 
 ;;; --------------------------------------------------------------------------
@@ -681,21 +731,22 @@ font size is computed + 20 of this value."
 
 ;;
 ;; 1. The function `mrf/load-theme-from-selector' is called from the
-;;	"C-= =" Keybinding (just search for it).
+;;    "C-= =" Keybinding (just search for it).
 ;;
 ;; 2. Once the new theme is loaded via the `theme-selector', the previous
-;;	theme is unloaded (or disabled) the function(s) defined in the
-;;	`disable-theme-functions' hook are called (defined in the load-theme.el
-;;	package).
+;;    theme is unloaded (or disabled) the function(s) defined in the
+;;    `disable-theme-functions' hook are called (defined in the load-theme.el
+;;    package).
 ;;
 ;; 3. The function `mrf/cycle-theme-selector' is called by the hook. This
-;;	function increments the theme-selector by 1, cycling the value to 0
-;;	if beyond the `theme-list' bounds.
+;;    function increments the theme-selector by 1, cycling the value to 0
+;;    if beyond the `theme-list' bounds.
 ;;
 (setq-default loaded-theme (nth theme-selector theme-list))
 (add-to-list 'savehist-additional-variables 'loaded-theme)
 (add-to-list 'savehist-additional-variables 'custom-default-font-size)
 (add-to-list 'savehist-additional-variables 'theme-selector)
+(add-to-list 'savehist-additional-variables 'custom-default-mono-font-size)
 
 ;;; --------------------------------------------------------------------------
 
@@ -705,11 +756,11 @@ font size is computed + 20 of this value."
   (when (not (eq theme-cycle-step nil))
     (let ((step theme-cycle-step) (result 0))
       (when step
-	(setq result (+ step theme-selector))
-	(when (< result 0)
-	  (setq result (- (length theme-list) 1)))
-	(when (> result (- (length theme-list) 1))
-	  (setq result 0)))
+      (setq result (+ step theme-selector))
+      (when (< result 0)
+        (setq result (- (length theme-list) 1)))
+      (when (> result (- (length theme-list) 1))
+        (setq result 0)))
       (setq-default theme-selector result))))
 
 ;; This is used to trigger the cycling of the theme-selector
@@ -774,7 +825,7 @@ font size is computed + 20 of this value."
     "Face used for the line delimiting the begin of source blocks.")
 
   (defface org-block
-    '((t (:background "#242635" :extend t :font "JetBrains Mono")))
+    '((t (:background "#242635" :extend t :font "Fira Code Retina")))
     "Face used for the source block background.")
 
   (defface org-block-end-line
@@ -815,6 +866,7 @@ font size is computed + 20 of this value."
 (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
 
 (mrf/org-theme-override-values)
+(use-package tron-legacy-theme :defer t)
 (use-package ef-themes :init (mrf/customize-ef-theme) :defer t)
 (use-package modus-themes :init (mrf/customize-modus-theme) :defer t)
 (use-package material-theme :defer t)
@@ -838,14 +890,14 @@ font size is computed + 20 of this value."
   (progn
     (if (not elpaca-after-init-time)
       (add-hook 'elpaca-after-init-hook
-	(lambda ()
-	  (unless theme-did-load
-	    (mrf/load-theme-from-selector))))
+      (lambda ()
+        (unless theme-did-load
+          (mrf/load-theme-from-selector))))
       ;; else
       (add-hook 'window-setup-hook
-	(lambda ()
-	  (unless theme-did-load
-	    (mrf/load-theme-from-selector))))
+      (lambda ()
+        (unless theme-did-load
+          (mrf/load-theme-from-selector))))
       )))
 
 ;;; --------------------------------------------------------------------------
@@ -854,15 +906,19 @@ font size is computed + 20 of this value."
 ;; You will most likely need to adjust this font size for your system!
 
 (setq-default mrf/small-font-size 150)
+(setq-default mrf/small-mono-font-size 150)
 (setq-default mrf/small-variable-font-size 170)
 
 (setq-default mrf/medium-font-size 170)
+(setq-default mrf/medium-mono-font-size 170)
 (setq-default mrf/medium-variable-font-size 190)
 
 (setq-default mrf/large-font-size 190)
+(setq-default mrf/large-mono-font-size 190)
 (setq-default mrf/large-variable-font-size 210)
 
 (setq-default mrf/x-large-font-size 220)
+(setq-default mrf/x-large-mono-font-size 220)
 (setq-default mrf/x-large-variable-font-size 240)
 
 ;; (setq-default custom-default-font-size mrf/medium-font-size)
@@ -880,35 +936,35 @@ font size is computed + 20 of this value."
 
 (defun mrf/frame-recenter (&optional frame)
   "Center FRAME on the screen.  FRAME can be a frame name, a terminal name,
-  or a frame.	 If FRAME is omitted or nil, use currently selected frame."
+  or a frame.  If FRAME is omitted or nil, use currently selected frame."
   (interactive)
   ;; (set-frame-size (selected-frame) 250 120)
   (unless (eq 'maximised (frame-parameter nil 'fullscreen))
     (progn
       (let ((width (nth 3 (assq 'geometry (car (display-monitor-attributes-list)))))
-	     (height (nth 4 (assq 'geometry (car (display-monitor-attributes-list))))))
-	(cond (( > width 3000) (mrf/update-large-display))
-	  (( > width 2000) (mrf/update-built-in-display))
-	  (t (mrf/set-frame-alpha-maximized)))
-	))
+             (height (nth 4 (assq 'geometry (car (display-monitor-attributes-list))))))
+        (cond (( > width 3000) (mrf/update-large-display))
+          (( > width 2000) (mrf/update-built-in-display))
+          (t (mrf/set-frame-alpha-maximized)))
+        ))
     ))
 
 (defun mrf/update-large-display ()
   (modify-frame-parameters
     frame '((user-position . t)
-	     (top . 0.0)
-	     (left . 0.70)
-	     (width . (text-pixels . 2800))
-	     (height . (text-pixels . 1650))) ;; 1800
+             (top . 0.0)
+             (left . 0.70)
+             (width . (text-pixels . 2800))
+             (height . (text-pixels . 1650))) ;; 1800
     ))
 
 (defun mrf/update-built-in-display ()
   (modify-frame-parameters
     frame '((user-position . t)
-	     (top . 0.0)
-	     (left . 0.90)
-	     (width . (text-pixels . 1800))
-	     (height . (text-pixels . 1170)));; 1329
+             (top . 0.0)
+             (left . 0.90)
+             (width . (text-pixels . 1800))
+             (height . (text-pixels . 1170)));; 1329
     ))
 
 
@@ -927,7 +983,7 @@ font size is computed + 20 of this value."
   (setq sheight (nth 4 (assq 'geometry (car (display-monitor-attributes-list)))))
 
   (add-to-list 'default-frame-alist '(fullscreen . maximized))
-  (mrf/frame-recenter)
+  (unless enable-frameset-restore (mrf/frame-recenter))
   )
 
 ;;; --------------------------------------------------------------------------
@@ -945,7 +1001,7 @@ font size is computed + 20 of this value."
   ;; Set the fixed pitch face
   (set-face-attribute 'fixed-pitch nil
     :family mono-spaced-font-family
-    :height custom-default-font-size
+    :height custom-default-mono-font-size
     :weight 'medium)
 
   ;; Set the variable pitch face
@@ -961,14 +1017,15 @@ font size is computed + 20 of this value."
     (when (display-graphic-p)
       (mrf/update-face-attribute)
       (unless (daemonp)
-	(mrf/frame-recenter)))))
+	(when enable-frameset-restore
+	  (mrf/restore-desktop-frameset))))))
 
 ;;; --------------------------------------------------------------------------
 
 (defun mrf/default-font-height-change ()
   (setq-default custom-default-font-size (face-attribute 'default :height))
   (mrf/update-face-attribute)
-  (mrf/frame-recenter))
+  (unless enable-frameset-restore (mrf/frame-recenter)))
 
 (add-hook 'after-setting-font-hook 'mrf/default-font-height-change)
 
@@ -981,23 +1038,27 @@ font size is computed + 20 of this value."
   (cond
     ((equal mrf/font-size-slot 3)
       (setq custom-default-font-size mrf/x-large-font-size
-	mrf/default-variable-font-size (+ custom-default-font-size 20)
-	mrf/font-size-slot 2)
+            custom-default-mono-font-size mrf/x-large-mono-font-size
+            mrf/default-variable-font-size (+ custom-default-font-size 20)
+            mrf/font-size-slot 2)
       (mrf/update-face-attribute))
     ((equal mrf/font-size-slot 2)
       (setq custom-default-font-size mrf/large-font-size
-	mrf/default-variable-font-size (+ custom-default-font-size 20)
-	mrf/font-size-slot 1)
+            custom-default-mono-font-size mrf/large-mono-font-size
+            mrf/default-variable-font-size (+ custom-default-font-size 20)
+            mrf/font-size-slot 1)
       (mrf/update-face-attribute))
     ((equal mrf/font-size-slot 1)
       (setq custom-default-font-size mrf/medium-font-size
-	mrf/default-variable-font-size (+ custom-default-font-size 20)
-	mrf/font-size-slot 0)
+            custom-default-mono-font-size mrf/medium-mono-font-size
+            mrf/default-variable-font-size (+ custom-default-font-size 20)
+            mrf/font-size-slot 0)
       (mrf/update-face-attribute))
     ((equal mrf/font-size-slot 0)
       (setq custom-default-font-size mrf/small-font-size
-	mrf/default-variable-font-size (+ custom-default-font-size 20)
-	mrf/font-size-slot 3)
+            custom-default-mono-font-size mrf/small-mono-font-size
+            mrf/default-variable-font-size (+ custom-default-font-size 20)
+            mrf/font-size-slot 3)
       (mrf/update-face-attribute))))
 
 ;;; --------------------------------------------------------------------------
@@ -1008,38 +1069,55 @@ font size is computed + 20 of this value."
   ("C-c 3". use-large-display-font)
   ("C-c 4". use-x-large-display-font))
 
+(let ((map global-map))
+  (define-key map (kbd "C-S-c 1")
+    (lambda () (interactive) (use-small-display-font t)))
+  (define-key map (kbd "C-S-c 2")
+    (lambda () (interactive) (use-medium-display-font t)))
+  (define-key map (kbd "C-S-c 3")
+    (lambda () (interactive) (use-large-display-font t)))
+  (define-key map (kbd "C-S-c 4")
+    (lambda () (interactive) (use-x-large-display-font t))))
+
 ;;; --------------------------------------------------------------------------
 ;; Frame support functions
 
 (defun mrf/set-frame-font (slot)
   (setq mrf/font-size-slot slot)
   (mrf/update-font-size)
-  (mrf/frame-recenter)
-  )
+  (unless enable-frameset-restore (mrf/frame-recenter)))
 
-(defun use-small-display-font ()
+(defun mrf/should-recenter (&optional force-recenter)
+  (if force-recenter
+    (mrf/frame-recenter)
+    ;;else
+    (unless enable-frameset-restore (mrf/frame-recenter))))
+
+;;; --------------------------------------------------------------------------
+
+(defun use-small-display-font (&optional force-recenter)
   (interactive)
   (mrf/set-frame-font 0)
-  (mrf/frame-recenter)
-  )
+  (mrf/should-recenter force-recenter))
 
-(defun use-medium-display-font ()
+
+(defun use-medium-display-font (&optional force-recenter)
   (interactive)
   (mrf/set-frame-font 1)
-  (mrf/frame-recenter)
-  )
+  (mrf/should-recenter force-recenter))
 
-(defun use-large-display-font ()
+
+(defun use-large-display-font (&optional force-recenter)
   (interactive)
   (mrf/set-frame-font 2)
-  (mrf/frame-recenter)
-  )
+  (mrf/should-recenter force-recenter))
 
-(defun use-x-large-display-font ()
+
+(defun use-x-large-display-font (&optional force-recenter)
   (interactive)
   (mrf/set-frame-font 3)
-  (mrf/frame-recenter)
-  )
+  (mrf/should-recenter force-recenter))
+
 
 ;; This is done so that the Emacs window is sized early in the init phase along with the default font size.
 ;; Startup works without this but it's nice to see the window expand early...
@@ -1047,10 +1125,10 @@ font size is computed + 20 of this value."
   (add-hook 'elpaca-after-init-hook
     (lambda ()
       (progn
-	(mrf/update-face-attribute)
-	(unless (daemonp)
-	  (mrf/frame-recenter))))
-    ))
+  	(mrf/update-face-attribute)
+  	(unless (daemonp)
+  	  (unless enable-frameset-restore (mrf/frame-recenter))))
+      )))
 
 ;;; --------------------------------------------------------------------------
 
@@ -1070,8 +1148,8 @@ font size is computed + 20 of this value."
 ;; Read the doc string of `spacious-padding-subtle-mode-line' as it
 ;; is very flexible and provides several examples.
 ;; (setq spacious-padding-subtle-mode-line
-;;	   `( :mode-line-active 'default
-;;	      :mode-line-inactive vertical-border))
+;;       `( :mode-line-active 'default
+;;          :mode-line-inactive vertical-border))
 
 ;;; --------------------------------------------------------------------------
 
@@ -1082,28 +1160,67 @@ font size is computed + 20 of this value."
   (font-lock-add-keywords
     'org-mode
     '(("^ *\\([-]\\) "
-	(0 (prog1 () (compose-region (match-beginning 1) (match-end 1) "•"))))))
+        (0 (prog1 () (compose-region (match-beginning 1) (match-end 1) "•"))))))
   
-  (set-face-attribute 'org-block nil	   :foreground 'unspecified
-    :inherit 'fixed-pitch :font "JetBrains Mono" :height custom-default-font-size)
-  (set-face-attribute 'org-formula nil  :inherit 'fixed-pitch)
-  (set-face-attribute 'org-code nil	   :inherit '(shadow fixed-pitch))
-  (set-face-attribute 'org-table nil	   :inherit '(shadow fixed-pitch))
-  (set-face-attribute 'org-verbatim nil :inherit '(shadow fixed-pitch))
-  (set-face-attribute 'org-special-keyword nil :inherit '(font-lock-comment-face fixed-pitch))
-  (set-face-attribute 'org-meta-line nil :inherit '(font-lock-comment-face fixed-pitch))
-  (set-face-attribute 'org-checkbox nil  :inherit 'fixed-pitch)
-  (set-face-attribute 'line-number nil :inherit 'fixed-pitch)
-  (set-face-attribute 'line-number-current-line nil :inherit 'fixed-pitch)
+  (set-face-attribute 'org-block nil
+    :foreground 'unspecified
+    :inherit 'fixed-pitch
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size)
+  
+  (set-face-attribute 'org-formula nil
+    :inherit 'fixed-pitch)
+  
+  (set-face-attribute 'org-code nil
+    :foreground 'unspecified
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size
+    :inherit '(shadow fixed-pitch))
+
+  (set-face-attribute 'org-table nil
+    :foreground 'unspecified
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size
+    :inherit '(shadow fixed-pitch))
+  
+  (set-face-attribute 'org-verbatim nil
+    :foreground 'unspecified
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size
+    :inherit '(shadow fixed-pitch))
+  
+  (set-face-attribute 'org-special-keyword nil
+    :inherit '(font-lock-comment-face fixed-pitch))
+  
+  (set-face-attribute 'org-meta-line nil
+    :inherit '(font-lock-comment-face fixed-pitch))
+  
+  (set-face-attribute 'org-checkbox nil
+    :foreground 'unspecified
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size
+    :inherit 'fixed-pitch)
+  
+  (set-face-attribute 'line-number nil
+    :foreground 'unspecified
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size
+    :inherit 'fixed-pitch)
+  
+  (set-face-attribute 'line-number-current-line nil
+    :foreground 'unspecified
+    :font mono-spaced-font-family
+    :height custom-default-mono-font-size
+    :inherit 'fixed-pitch)
 
   (dolist (face '((org-level-1 . 1.50)
-		   (org-level-2 . 1.25)
-		   (org-level-3 . 1.15)
-		   (org-level-4 . 1.05)
-		   (org-level-5 . 0.95)
-		   (org-level-6 . 0.90)
-		   (org-level-7 . 0.90)
-		   (org-level-8 . 0.90)))
+                   (org-level-2 . 1.25)
+                   (org-level-3 . 1.15)
+                   (org-level-4 . 1.05)
+                   (org-level-5 . 0.95)
+                   (org-level-6 . 0.90)
+                   (org-level-7 . 0.90)
+                   (org-level-8 . 0.90)))
     (set-face-attribute (car face) nil :font "SF Pro" :weight 'regular
       :height (cdr face))))
 
@@ -1121,7 +1238,7 @@ font size is computed + 20 of this value."
   (visual-line-mode 1)
   (mrf/org-mode-visual-fill)
   (font-lock-add-keywords nil
-    '(("^_\\{5,\\}"	 0 '(:foreground "green" :weight bold))))
+    '(("^_\\{5,\\}"    0 '(:foreground "green" :weight bold))))
   (setq org-ellipsis " ▾")
   (setq org-agenda-start-with-log-mode t)
   (setq org-log-done 'time)
@@ -1132,7 +1249,7 @@ font size is computed + 20 of this value."
   (setq org-todo-keywords
     '((sequence "TODO(t)" "NEXT(n)" "|" "DONE(d!)")
        (sequence "BACKLOG(b)" "PLAN(p)" "READY(r)" "ACTIVE(a)"
-	 "REVIEW(v)" "WAIT(w@/!)" "HOLD(h)" "|" "COMPLETED(c)" "CANC(k@)")))
+         "REVIEW(v)" "WAIT(w@/!)" "HOLD(h)" "|" "COMPLETED(c)" "CANC(k@)")))
   (setq org-refile-targets
     '(("Archive.org" :maxlevel . 1)
        ("Tasks.org" :maxlevel . 1))))
@@ -1142,50 +1259,50 @@ font size is computed + 20 of this value."
 (defun mrf/org-setup-agenda ()
   (setq org-agenda-custom-commands
     '(("d" "Dashboard"
-	((agenda "" ((org-deadline-warning-days 7)))
-	  (todo "NEXT"
-	    ((org-agenda-overriding-header "Next Tasks")))
-	  (tags-todo "agenda/ACTIVE" ((org-agenda-overriding-header "Active Projects")))))
+        ((agenda "" ((org-deadline-warning-days 7)))
+          (todo "NEXT"
+            ((org-agenda-overriding-header "Next Tasks")))
+          (tags-todo "agenda/ACTIVE" ((org-agenda-overriding-header "Active Projects")))))
 
        ("n" "Next Tasks"
-	 ((todo "NEXT"
-	    ((org-agenda-overriding-header "Next Tasks")))))
+         ((todo "NEXT"
+            ((org-agenda-overriding-header "Next Tasks")))))
 
        ("W" "Work Tasks" tags-todo "+work-email")
 
        ;; Low-effort next actions
        ("e" tags-todo "+TODO=\"NEXT\"+Effort<15&+Effort>0"
-	 ((org-agenda-overriding-header "Low Effort Tasks")
-	   (org-agenda-max-todos 20)
-	   (org-agenda-files org-agenda-files)))
+         ((org-agenda-overriding-header "Low Effort Tasks")
+           (org-agenda-max-todos 20)
+           (org-agenda-files org-agenda-files)))
 
        ("w" "Workflow Status"
-	 ((todo "WAIT"
-	    ((org-agenda-overriding-header "Waiting on External")
-	      (org-agenda-files org-agenda-files)))
-	   (todo "REVIEW"
-	     ((org-agenda-overriding-header "In Review")
-	       (org-agenda-files org-agenda-files)))
-	   (todo "PLAN"
-	     ((org-agenda-overriding-header "In Planning")
-	       (org-agenda-todo-list-sublevels nil)
-	       (org-agenda-files org-agenda-files)))
-	   (todo "BACKLOG"
-	     ((org-agenda-overriding-header "Project Backlog")
-	       (org-agenda-todo-list-sublevels nil)
-	       (org-agenda-files org-agenda-files)))
-	   (todo "READY"
-	     ((org-agenda-overriding-header "Ready for Work")
-	       (org-agenda-files org-agenda-files)))
-	   (todo "ACTIVE"
-	     ((org-agenda-overriding-header "Active Projects")
-	       (org-agenda-files org-agenda-files)))
-	   (todo "COMPLETED"
-	     ((org-agenda-overriding-header "Completed Projects")
-	       (org-agenda-files org-agenda-files)))
-	   (todo "CANC"
-	     ((org-agenda-overriding-header "Cancelled Projects")
-	       (org-agenda-files org-agenda-files)))))))
+         ((todo "WAIT"
+            ((org-agenda-overriding-header "Waiting on External")
+              (org-agenda-files org-agenda-files)))
+           (todo "REVIEW"
+             ((org-agenda-overriding-header "In Review")
+               (org-agenda-files org-agenda-files)))
+           (todo "PLAN"
+             ((org-agenda-overriding-header "In Planning")
+               (org-agenda-todo-list-sublevels nil)
+               (org-agenda-files org-agenda-files)))
+           (todo "BACKLOG"
+             ((org-agenda-overriding-header "Project Backlog")
+               (org-agenda-todo-list-sublevels nil)
+               (org-agenda-files org-agenda-files)))
+           (todo "READY"
+             ((org-agenda-overriding-header "Ready for Work")
+               (org-agenda-files org-agenda-files)))
+           (todo "ACTIVE"
+             ((org-agenda-overriding-header "Active Projects")
+               (org-agenda-files org-agenda-files)))
+           (todo "COMPLETED"
+             ((org-agenda-overriding-header "Completed Projects")
+               (org-agenda-files org-agenda-files)))
+           (todo "CANC"
+             ((org-agenda-overriding-header "Cancelled Projects")
+               (org-agenda-files org-agenda-files)))))))
   ) ;; mrf/org-setup-agenda
 
 ;;; --------------------------------------------------------------------------
@@ -1194,31 +1311,31 @@ font size is computed + 20 of this value."
   (setq org-capture-templates
     `(("t" "Tasks / Projects")
        ("tt" "Task" entry (file+olp "~/Projects/Code/emacs-from-scratch/OrgFiles/Tasks.org" "Inbox")
-	 "* TODO %?\n  %U\n  %a\n	 %i" :empty-lines 1)
+       "* TODO %?\n  %U\n  %a\n        %i" :empty-lines 1)
 
        ("j" "Journal Entries")
        ("jj" "Journal" entry
-	 (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-	 "\n* %<%I:%M %p> - Journal :journal:\n\n%?\n\n"
-	 ;; ,(dw/read-file-as-string "~/Notes/Templates/Daily.org")
-	 :clock-in :clock-resume
-	 :empty-lines 1)
+       (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+       "\n* %<%I:%M %p> - Journal :journal:\n\n%?\n\n"
+       ;; ,(dw/read-file-as-string "~/Notes/Templates/Daily.org")
+       :clock-in :clock-resume
+       :empty-lines 1)
        ("jm" "Meeting" entry
-	 (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-	 "* %<%I:%M %p> - %a :meetings:\n\n%?\n\n"
-	 :clock-in :clock-resume
-	 :empty-lines 1)
+       (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+       "* %<%I:%M %p> - %a :meetings:\n\n%?\n\n"
+       :clock-in :clock-resume
+       :empty-lines 1)
 
        ("w" "Workflows")
        ("we" "Checking Email" entry (file+olp+datetree
-				      "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-	 "* Checking Email :email:\n\n%?" :clock-in :clock-resume :empty-lines 1)
+                                    "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+       "* Checking Email :email:\n\n%?" :clock-in :clock-resume :empty-lines 1)
 
        ("m" "Metrics Capture")
        ("mw" "Weight" table-line (file+headline
-				   "~/Projects/Code/emacs-from-scratch/OrgFiles/Metrics.org"
-				   "Weight")
-	 "| %U | %^{Weight} | %^{Notes} |" :kill-buffer t))))
+                                 "~/Projects/Code/emacs-from-scratch/OrgFiles/Metrics.org"
+                                 "Weight")
+       "| %U | %^{Weight} | %^{Notes} |" :kill-buffer t))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -1236,7 +1353,7 @@ font size is computed + 20 of this value."
   (org-startup-with-inline-images t)
   (org-image-actual-width '(300))
   :bind (:map org-mode-map
-	  ("C-c e" . org-edit-src-code))
+          ("C-c e" . org-edit-src-code))
   :config
   (setq org-hide-emphasis-markers nil)
   ;; Save Org buffers after refiling!
@@ -1274,8 +1391,8 @@ font size is computed + 20 of this value."
     '((right-divider-width . 40)
        (internal-border-width . 40)))
   (dolist (face '(window-divider
-		   window-divider-first-pixel
-		   window-divider-last-pixel))
+                   window-divider-first-pixel
+                   window-divider-last-pixel))
     (face-spec-reset-face face)
     (set-face-foreground face (face-attribute 'default :background nil)))
   (set-face-background 'fringe (face-attribute 'default :background nil))
@@ -1332,13 +1449,8 @@ font size is computed + 20 of this value."
   (add-to-list 'org-structure-template-alist '("py" . "src python")))
 
 ;;; --------------------------------------------------------------------------
-
-(use-package ox-gfm
-  :after org)
-
-;;; --------------------------------------------------------------------------
-(use-package emacsql :demand t :ensure t)
-(use-package emacsql-sqlite :demand t :ensure t)
+(use-package emacsql :demand t :ensure t :after org)
+(use-package emacsql-sqlite :demand t :ensure t :after org)
 
 ;;; --------------------------------------------------------------------------
 ;; The buffer you put this code in must have lexical-binding set to t!
@@ -1385,8 +1497,8 @@ capture was not aborted."
     (mrf/org-roam-filter-by-tag "Project")
     :templates
     '(("p" "project" plain "* Goals\n\n%?\n\n* Tasks\n\n** TODO Add initial tasks\n\n* Dates\n\n"
-	:if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" "#+title: ${title}\n#+category: ${title}\n#+filetags: Project")
-	:unnarrowed t))))
+      :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" "#+title: ${title}\n#+category: ${title}\n#+filetags: Project")
+      :unnarrowed t))))
 
 ;; (global-set-key (kbd "C-c n p") #'mrf/org-roam-find-project)
 
@@ -1396,14 +1508,14 @@ capture was not aborted."
   (interactive)
   (org-roam-capture- :node (org-roam-node-create)
     :templates '(("i" "inbox" plain "* %?"
-		   :if-new (file+head "Inbox.org" "#+title: Inbox\n")))))
+                 :if-new (file+head "Inbox.org" "#+title: Inbox\n")))))
 
 (defun mrf/org-roam-node-insert-immediate (arg &rest args)
   (interactive "P")
   (let ((args (push arg args))
-	 (org-roam-capture-templates
-	   (list (append (car org-roam-capture-templates)
-		   '(:immediate-finish t)))))
+       (org-roam-capture-templates
+         (list (append (car org-roam-capture-templates)
+                 '(:immediate-finish t)))))
     (apply #'org-roam-node-insert args)))
 
 ;;; --------------------------------------------------------------------------
@@ -1415,23 +1527,23 @@ capture was not aborted."
 
   ;; Capture the new task, creating the project file if necessary
   (org-roam-capture- :node (org-roam-node-read nil
-			     (mrf/org-roam-filter-by-tag "Project"))
+                           (mrf/org-roam-filter-by-tag "Project"))
     :templates '(("p" "project" plain "** TODO %?"
-		   :if-new
-		   (file+head+olp "%<%Y%m%d%H%M%S>-${slug}.org"
-		     "#+title: ${title}\n#+category: ${title}\n#+filetags: Project"
-		     ("Tasks"))))))
+                 :if-new
+                 (file+head+olp "%<%Y%m%d%H%M%S>-${slug}.org"
+                   "#+title: ${title}\n#+category: ${title}\n#+filetags: Project"
+                   ("Tasks"))))))
 
 ;;; --------------------------------------------------------------------------
 
 (defun mrf/org-roam-copy-todo-to-today ()
   (interactive)
   (let ((org-refile-keep t) ;; Set this to nil to delete the original!
-	 (org-roam-dailies-capture-templates
-	   '(("t" "tasks" entry "%?"
-	       :if-new (file+head+olp "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d>\n" ("Tasks")))))
-	 (org-after-refile-insert-hook #'save-buffer)
-	 today-file pos)
+       (org-roam-dailies-capture-templates
+         '(("t" "tasks" entry "%?"
+             :if-new (file+head+olp "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d>\n" ("Tasks")))))
+       (org-after-refile-insert-hook #'save-buffer)
+       today-file pos)
     (save-window-excursion
       (org-roam-dailies--capture (current-time) t)
       (setq today-file (buffer-file-name))
@@ -1439,7 +1551,7 @@ capture was not aborted."
 
     ;; Only refile if the target file is different than the current file
     (unless (equal (file-truename today-file)
-	      (file-truename (buffer-file-name)))
+            (file-truename (buffer-file-name)))
       (org-refile nil nil (list "Tasks" today-file nil pos)))))
 
 (use-package toc-org
@@ -1448,7 +1560,7 @@ capture was not aborted."
   (org-mode . toc-org-mode)
   (markdown-mode-hook . toc-org-mode)
   :bind (:map markdown-mode-map
-	  ("C-c C-o" . toc-org-markdown-follow-thing-at-point)))
+        ("C-c C-o" . toc-org-markdown-follow-thing-at-point)))
 
 (use-package org-roam
   ;; :demand t  ;; Ensure org-roam is loaded by default
@@ -1463,17 +1575,17 @@ capture was not aborted."
   (org-roam-directory (expand-file-name "org-roam-notes" user-emacs-directory))
   (org-roam-completion-everywhere t)
   :bind ( ("C-c n l" . org-roam-buffer-toggle)
-	  ("C-c n f" . org-roam-node-find)
-	  ("C-c n i" . org-roam-node-insert)
-	  ("C-c n I" . mrf/org-roam-node-insert-immediate)
-	  ("C-c n p" . mrf/org-roam-find-project)
-	  ("C-c n t" . mrf/org-roam-capture-task)
-	  ("C-c n b" . mrf/org-roam-capture-inbox)
-	  :map org-mode-map
-	  ("C-M-i" . completion-at-point)
-	  :map org-roam-dailies-map
-	  ("Y" . org-roam-dailies-capture-yesterday)
-	  ("T" . org-roam-dailies-capture-tomorrow))
+        ("C-c n f" . org-roam-node-find)
+        ("C-c n i" . org-roam-node-insert)
+        ("C-c n I" . mrf/org-roam-node-insert-immediate)
+        ("C-c n p" . mrf/org-roam-find-project)
+        ("C-c n t" . mrf/org-roam-capture-task)
+        ("C-c n b" . mrf/org-roam-capture-inbox)
+        :map org-mode-map
+        ("C-M-i" . completion-at-point)
+        :map org-roam-dailies-map
+        ("Y" . org-roam-dailies-capture-yesterday)
+        ("T" . org-roam-dailies-capture-tomorrow))
   :bind-keymap
   ("C-c n d" . org-roam-dailies-map)
   :config
@@ -1482,7 +1594,7 @@ capture was not aborted."
   (add-to-list 'org-after-todo-state-change-hook
     (lambda ()
       (when (equal org-state "DONE")
-	(mrf/org-roam-copy-todo-to-today))))
+      (mrf/org-roam-copy-todo-to-today))))
   (org-roam-db-autosync-mode))
 
 ;;; --------------------------------------------------------------------------
@@ -1576,71 +1688,71 @@ capture was not aborted."
 (use-package treemacs
   :after (:all winum ace-window)
   :bind (:map global-map
-	  ("M-0"	   . treemacs-select-window)
-	  ("C-x t 1"   . treemacs-delete-other-windows)
-	  ("C-x t t"   . treemacs)
-	  ("C-x t d"   . treemacs-select-directory)
-	  ("C-x t B"   . treemacs-bookmark)
-	  ("C-x t C-t" . treemacs-find-file)
-	  ("C-x t M-t" . treemacs-find-tag))
+          ("M-0"         . treemacs-select-window)
+          ("C-x t 1"   . treemacs-delete-other-windows)
+          ("C-x t t"   . treemacs)
+          ("C-x t d"   . treemacs-select-directory)
+          ("C-x t B"   . treemacs-bookmark)
+          ("C-x t C-t" . treemacs-find-file)
+          ("C-x t M-t" . treemacs-find-tag))
   :config
-  (setq treemacs-collapse-dirs		  (if treemacs-python-executable 3 0)
-    treemacs-deferred-git-apply-delay	 0.5
-    treemacs-directory-name-transformer	 #'identity
-    treemacs-display-in-side-window		 t
-    treemacs-eldoc-display			 'simple
-    treemacs-file-event-delay		 2000
-    treemacs-file-extension-regex		 treemacs-last-period-regex-value
-    treemacs-file-follow-delay		 0.2
-    treemacs-file-name-transformer		 #'identity
-    treemacs-follow-after-init		 t
-    treemacs-expand-after-init		 t
-    treemacs-find-workspace-method		 'find-for-file-or-pick-first
-    treemacs-git-command-pipe		 ""
-    treemacs-goto-tag-strategy		 'refetch-index
-    treemacs-header-scroll-indicators	 '(nil . "^^^^^^")
-    treemacs-hide-dot-git-directory		 t
-    treemacs-indentation			 2
-    treemacs-indentation-string		 " "
-    treemacs-is-never-other-window		 nil
-    treemacs-max-git-entries		 5000
-    treemacs-missing-project-action		 'ask
-    treemacs-move-forward-on-expand		 nil
-    treemacs-no-png-images			 nil
-    treemacs-no-delete-other-windows	 t
-    treemacs-project-follow-cleanup		 nil
-    treemacs-persist-file			 (expand-file-name
-						   ".cache/treemacs-persist"
-						   user-emacs-directory)
-    treemacs-position			 'left
-    treemacs-read-string-input		 'from-child-frame
-    treemacs-recenter-distance		 0.1
-    treemacs-recenter-after-file-follow	 nil
-    treemacs-recenter-after-tag-follow	 nil
-    treemacs-recenter-after-project-jump	 'always
-    treemacs-recenter-after-project-expand	 'on-distance
-    treemacs-litter-directories		 '("/node_modules"
-					    "/.venv"
-					    "/.cask"
-					    "/__pycache__")
-    treemacs-project-follow-into-home	 nil
-    treemacs-show-cursor			 nil
-    treemacs-show-hidden-files		 t
-    treemacs-silent-filewatch		 nil
-    treemacs-silent-refresh			 nil
-    treemacs-sorting			 'alphabetic-asc
+  (setq treemacs-collapse-dirs                  (if treemacs-python-executable 3 0)
+    treemacs-deferred-git-apply-delay  0.5
+    treemacs-directory-name-transformer        #'identity
+    treemacs-display-in-side-window            t
+    treemacs-eldoc-display                     'simple
+    treemacs-file-event-delay          2000
+    treemacs-file-extension-regex              treemacs-last-period-regex-value
+    treemacs-file-follow-delay                 0.2
+    treemacs-file-name-transformer             #'identity
+    treemacs-follow-after-init                 t
+    treemacs-expand-after-init                 t
+    treemacs-find-workspace-method             'find-for-file-or-pick-first
+    treemacs-git-command-pipe          ""
+    treemacs-goto-tag-strategy                 'refetch-index
+    treemacs-header-scroll-indicators  '(nil . "^^^^^^")
+    treemacs-hide-dot-git-directory            t
+    treemacs-indentation                       2
+    treemacs-indentation-string                " "
+    treemacs-is-never-other-window             nil
+    treemacs-max-git-entries           5000
+    treemacs-missing-project-action            'ask
+    treemacs-move-forward-on-expand            nil
+    treemacs-no-png-images                     nil
+    treemacs-no-delete-other-windows   t
+    treemacs-project-follow-cleanup            nil
+    treemacs-persist-file                      (expand-file-name
+                                                   ".cache/treemacs-persist"
+                                                   user-emacs-directory)
+    treemacs-position                  'left
+    treemacs-read-string-input                 'from-child-frame
+    treemacs-recenter-distance                 0.1
+    treemacs-recenter-after-file-follow        nil
+    treemacs-recenter-after-tag-follow         nil
+    treemacs-recenter-after-project-jump       'always
+    treemacs-recenter-after-project-expand     'on-distance
+    treemacs-litter-directories                '("/node_modules"
+                                            "/.venv"
+                                            "/.cask"
+                                            "/__pycache__")
+    treemacs-project-follow-into-home  nil
+    treemacs-show-cursor                       nil
+    treemacs-show-hidden-files                 t
+    treemacs-silent-filewatch          nil
+    treemacs-silent-refresh                    nil
+    treemacs-sorting                   'alphabetic-asc
     treemacs-select-when-already-in-treemacs 'move-back
-    treemacs-space-between-root-nodes	 t
-    treemacs-tag-follow-cleanup		 t
-    treemacs-tag-follow-delay		 1.5
-    treemacs-text-scale			 nil
-    treemacs-user-mode-line-format		 nil
-    treemacs-user-header-line-format	 nil
-    treemacs-wide-toggle-width		 70
-    treemacs-width				 38
-    treemacs-width-increment		 1
-    treemacs-width-is-initially-locked	 t
-    treemacs-workspace-switch-cleanup	 nil)
+    treemacs-space-between-root-nodes  t
+    treemacs-tag-follow-cleanup                t
+    treemacs-tag-follow-delay          1.5
+    treemacs-text-scale                        nil
+    treemacs-user-mode-line-format             nil
+    treemacs-user-header-line-format   nil
+    treemacs-wide-toggle-width                 70
+    treemacs-width                             38
+    treemacs-width-increment           1
+    treemacs-width-is-initially-locked         t
+    treemacs-workspace-switch-cleanup  nil)
 
   ;; The default width and height of the icons is 22 pixels. If you are
   ;; using a Hi-DPI display, uncomment this to double the icon size.
@@ -1652,7 +1764,7 @@ capture was not aborted."
   (when treemacs-python-executable
     (treemacs-git-commit-diff-mode t))
   (pcase (cons (not (null (executable-find "git")))
-	   (not (null treemacs-python-executable)))
+           (not (null treemacs-python-executable)))
     (`(t . t)
       (treemacs-git-mode 'deferred))
     (`(t . _)
@@ -1674,9 +1786,9 @@ capture was not aborted."
 ;;; --------------------------------------------------------------------------
 
 ;; (use-package treemacs-perspective
-;;	:disabled
-;;	:after (treemacs persp-mode) ;;or perspective vs. persp-mode
-;;	:config (treemacs-set-scope-type 'Perspectives))
+;;    :disabled
+;;    :after (treemacs persp-mode) ;;or perspective vs. persp-mode
+;;    :config (treemacs-set-scope-type 'Perspectives))
 
 (use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
   ;;:ensure (:files ("src/extra/treemacs-persp.el" "treemacs-persp-pkg.el"):host github :repo "Alexander-Miller/treemacs")
@@ -1700,8 +1812,8 @@ capture was not aborted."
 (use-package dashboard
   :custom
   (dashboard-items '(   (recents . 15)
-		      (bookmarks . 10)
-		      (projects . 10)))
+                      (bookmarks . 10)
+                      (projects . 10)))
   (dashboard-center-content t)
   (dashboard-set-heading-icons t)
   (dashboard-set-file-icons t)
@@ -1782,15 +1894,8 @@ capture was not aborted."
 ;;; --------------------------------------------------------------------------
 ;;; Language Server Protocol
 
-(when (equal custom-ide 'custom-ide-lsp)
-  (eval-when-compile (defvar lsp-enable-which-key-integration)))
-
-(defun mrf/lsp-mode-setup ()
-  "Custom LSP setup function."
-  (when (equal custom-ide 'custom-ide-lsp)
-    (setq lsp-headerline-breadcrumb-segments '(path-up-to-project file symbols))
-    (setq lsp-clangd-binary-path "/usr/bin/clangd")'
-    (lsp-headerline-breadcrumb-mode)))
+;; (when (equal custom-ide 'custom-ide-lsp)
+;;   (eval-when-compile (defvar lsp-enable-which-key-integration)))
 
 (use-package lsp-mode
   :when (equal custom-ide 'custom-ide-lsp)
@@ -1804,6 +1909,8 @@ capture was not aborted."
       ("<tab>" . company-indent-or-complete-common)))
   (mrf/define-rust-lsp-values)
   (lsp-enable-which-key-integration t))
+
+;;; --------------------------------------------------------------------------
 
 (use-package lsp-ui
   :when (equal custom-ide 'custom-ide-lsp)
@@ -1824,21 +1931,36 @@ capture was not aborted."
   (lsp-ui-doc-use-childframe t)
   :commands lsp-ui-mode
   :bind (:map lsp-ui-mode-map
-	  ("C-c l d" . lsp-ui-doc-focus-frame))
+          ("C-c l d" . lsp-ui-doc-focus-frame))
   :hook (lsp-mode . lsp-ui-mode))
+
+;;; --------------------------------------------------------------------------
+;;; To enable bidirectional synchronization of lsp workspace folders and
+;;; treemacs projects set lsp-treemacs-sync-mode to 1.
 
 (use-package lsp-treemacs
   :when (equal custom-ide 'custom-ide-lsp)
   :after lsp treemacs
   :bind (:map prog-mode-map
-	  ("C-c t" . treemacs))
+          ("C-c t" . treemacs))
   :config
   (lsp-treemacs-sync-mode 1))
 
 (use-package lsp-ivy
   :when (and (equal custom-ide 'custom-ide-lsp)
-	  (equal completion-handler 'comphand-ivy-counsel))
+          (equal completion-handler 'comphand-ivy-counsel))
   :after lsp ivy)
+
+;;; --------------------------------------------------------------------------
+;;; LSP mode setup hook
+
+(defun mrf/lsp-mode-setup ()
+  "Custom LSP setup function."
+  (add-hook 'lsp-after-open-hook 'lsp-enable-imenu)
+  (when (equal custom-ide 'custom-ide-lsp)
+    (setq lsp-headerline-breadcrumb-segments '(path-up-to-project file symbols))
+    (setq lsp-clangd-binary-path "/usr/bin/clangd")'
+    (lsp-headerline-breadcrumb-mode)))
 
 (defun mrf/define-rust-lsp-values ()
   (setq-default lsp-rust-analyzer-cargo-watch-command "clippy")
@@ -1858,13 +1980,11 @@ capture was not aborted."
 
 ;;; --------------------------------------------------------------------------
 
-(use-package markdown-mode
-  :when (equal custom-ide 'custom-ide-lsp-bridge))
-;;:ensure (:fetcher github :repo "jrblevin/markdown-mode"))
-
 (use-package lsp-bridge
   :when (equal custom-ide 'custom-ide-lsp-bridge)
-  :ensure (:host github :repo "manateelazycat/lsp-bridge" :files (:defaults "*.el" "*.py" "acm" "core" "langserver" "multiserver" "resources") :build (:not compile))
+  :ensure ( :host github :repo "manateelazycat/lsp-bridge"
+	    :files (:defaults "*.el" "*.py" "acm" "core" "langserver"
+		     "multiserver" "resources") :build (:not compile))
   :custom
   (lsp-bridge-python-lsp-server "pylsp")
   :config
@@ -1872,12 +1992,17 @@ capture was not aborted."
 
 ;;; --------------------------------------------------------------------------
 
+(use-package markdown-mode
+  :when (equal custom-ide 'custom-ide-lsp-bridge))
+
+;;; --------------------------------------------------------------------------
+
 (use-package anaconda-mode
   :when (equal custom-ide 'custom-ide-anaconda)
   :bind (:map python-mode-map
-	  ("C-c g o" . anaconda-mode-find-definitions-other-frame)
-	  ("C-c g g" . anaconda-mode-find-definitions)
-	  ("C-c C-x" . next-error))
+        ("C-c g o" . anaconda-mode-find-definitions-other-frame)
+        ("C-c g g" . anaconda-mode-find-definitions)
+        ("C-c C-x" . next-error))
   :config
   (which-key-add-key-based-replacements "C-c g o" "find-defitions-other-window")
   (which-key-add-key-based-replacements "C-c g g" "find-defitions")
@@ -1898,10 +2023,10 @@ capture was not aborted."
   (display-fill-column-indicator-mode 1)
   (highlight-indentation-mode nil)
   :bind (:map python-mode-map
-	  ("C-c g a" . elpy-goto-assignment)
-	  ("C-c g o" . elpy-goto-definition-other-window)
-	  ("C-c g g" . elpy-goto-definition)
-	  ("C-c g ?" . elpy-doc))
+        ("C-c g a" . elpy-goto-assignment)
+        ("C-c g o" . elpy-goto-definition-other-window)
+        ("C-c g g" . elpy-goto-definition)
+        ("C-c g ?" . elpy-doc))
   :config
   (use-package jedi)
   (use-package flycheck
@@ -1910,13 +2035,13 @@ capture was not aborted."
     :defer t
     :diminish FlM
     ;;:ensure (:host github :repo "flycheck/flycheck")
-    :hook (elpy-mode . flycheck-mode))	(which-key-add-key-based-replacements "C-c g a" "goto-assignment")
+    :hook (elpy-mode . flycheck-mode))        (which-key-add-key-based-replacements "C-c g a" "goto-assignment")
   (which-key-add-key-based-replacements "C-c g o" "find-defitions-other-window")
   (which-key-add-key-based-replacements "C-c g g" "find-defitions")
   (which-key-add-key-based-replacements "C-c g ?" "eldoc-definition")
   (if (featurep 'company)
     (bind-keys :map elpy-mode-map
-	("<tab>" . company-indent-or-complete-common)))
+      ("<tab>" . company-indent-or-complete-common)))
   (elpy-enable))
 
 (use-package prescient)
@@ -1925,7 +2050,7 @@ capture was not aborted."
 
 (use-package orderless
   :when (or (equal completion-handler 'comphand-vertico)
-	  (equal completion-handler 'comphand-ivy-counsel))
+          (equal completion-handler 'comphand-ivy-counsel))
   :custom
   (completion-styles '(orderless basic))
   (completion-category-overrides '((file (styles basic partial-completion)))))
@@ -1936,18 +2061,18 @@ capture was not aborted."
 (use-package ivy
   :when (equal completion-handler 'comphand-ivy-counsel)
   :bind (("C-s" . swiper)
-	  :map ivy-minibuffer-map
-	    ;;; ("TAB" . ivy-alt-done)
-	  ("C-l" . ivy-alt-done)
-	  ("C-j" . ivy-next-line)
-	  ("C-k" . ivy-previous-line)
-	  :map ivy-switch-buffer-map
-	  ("C-k" . ivy-previous-line)
-	  ("C-l" . ivy-done)
-	  ("C-d" . ivy-switch-buffer-kill)
-	  :map ivy-reverse-i-search-map
-	  ("C-k" . ivy-previous-line)
-	  ("C-d" . ivy-reverse-i-search-kill))
+          :map ivy-minibuffer-map
+            ;;; ("TAB" . ivy-alt-done)
+          ("C-l" . ivy-alt-done)
+          ("C-j" . ivy-next-line)
+          ("C-k" . ivy-previous-line)
+          :map ivy-switch-buffer-map
+          ("C-k" . ivy-previous-line)
+          ("C-l" . ivy-done)
+          ("C-d" . ivy-switch-buffer-kill)
+          :map ivy-reverse-i-search-map
+          ("C-k" . ivy-previous-line)
+          ("C-d" . ivy-reverse-i-search-kill))
   :custom
   (enable-recursive-minibuffers t)
   (ivy-use-virtual-buffers t)
@@ -1983,12 +2108,12 @@ capture was not aborted."
 (use-package counsel
   :when (equal completion-handler 'comphand-ivy-counsel)
   :bind ( ("C-M-j" . 'counsel-switch-buffer)
-	  ("M-x" . 'counsel-M-x)
-	  ("M-g o" . 'counsel-outline)
-	  ("C-x C-f" . 'counsel-find-file)
-	  ("C-c C-r" . 'ivy-resume)
-	  :map minibuffer-local-map
-	  ("C-r" . 'counsel-minibuffer-history))
+          ("M-x" . 'counsel-M-x)
+          ("M-g o" . 'counsel-outline)
+          ("C-x C-f" . 'counsel-find-file)
+          ("C-c C-r" . 'ivy-resume)
+          :map minibuffer-local-map
+          ("C-r" . 'counsel-minibuffer-history))
   :custom
   (counsel-linux-app-format-function #'counsel-linux-app-format-function-name-only)
   :config
@@ -2011,23 +2136,23 @@ capture was not aborted."
   :when (equal completion-handler 'comphand-corfu)
   ;; Optional customizations
   :custom
-  (corfu-cycle t)		     ; Allows cycling through candidates
-  (corfu-auto t)		     ; Enable auto completion
+  (corfu-cycle t)                  ; Allows cycling through candidates
+  (corfu-auto t)                   ; Enable auto completion
   (corfu-auto-prefix 2)
   (corfu-auto-delay 0.8)
   (corfu-popupinfo-delay '(0.5 . 0.2))
   (corfu-preview-current 'insert) ; insert previewed candidate
   (corfu-preselect 'prompt)
-  (corfu-on-exact-match nil)	     ; Don't auto expand tempel snippets
+  (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
   ;; Optionally use TAB for cycling, default is `corfu-complete'.
   :bind (:map corfu-map
-	  ("M-SPC"	    . corfu-insert-separator)
-	  ("TAB"	    . corfu-next)
-	  ([tab]	    . corfu-next)
-	  ("S-TAB"	    . corfu-previous)
-	  ([backtab]    . corfu-previous)
-	  ("S-<return>" . corfu-insert)
-	  ("RET"	    . nil))
+        ("M-SPC"          . corfu-insert-separator)
+        ("TAB"            . corfu-next)
+        ([tab]            . corfu-next)
+        ("S-TAB"          . corfu-previous)
+        ([backtab]    . corfu-previous)
+        ("S-<return>" . corfu-insert)
+        ("RET"            . nil))
   :init
   (global-corfu-mode)
   (corfu-history-mode)
@@ -2035,8 +2160,8 @@ capture was not aborted."
   :config
   (add-hook 'eshell-mode-hook
     (lambda () (setq-local corfu-quit-at-boundary t
-		 corfu-quit-no-match t
-		 corfu-auto nil)
+               corfu-quit-no-match t
+               corfu-auto nil)
       (corfu-mode))))
 
 (use-package corfu-prescient
@@ -2060,8 +2185,8 @@ capture was not aborted."
   ;; :bind ("C-x C-f" . ido-find-file)
   ;; Clean up file path when typing
   :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
-	  ;; Make sure vertico state is saved
-	  (minibuffer-setup . vertico-repeat-save)))
+        ;; Make sure vertico state is saved
+        (minibuffer-setup . vertico-repeat-save)))
 
 ;;; --------------------------------------------------------------------------
 
@@ -2121,9 +2246,9 @@ capture was not aborted."
     '(consult--source-hidden-buffer 
        consult--source-buffer
        (:name "Ephemeral" :state consult--buffer-state
-	 :narrow 109 :category buffer
-	 :items ("*Messages*"  "*scratch*" "*vterm*"
-		  "*Async-native-compile-log*" "*dashboard*"))
+       :narrow 109 :category buffer
+       :items ("*Messages*"  "*scratch*" "*vterm*"
+                "*Async-native-compile-log*" "*dashboard*"))
        consult--source-modified-buffer
        consult--source-recent-file)))
 
@@ -2268,37 +2393,39 @@ capture was not aborted."
   (cond
     ((equal custom-ide 'custom-ide-lsp)
       (bind-keys :map python-mode-map
-	("C-c g r" . lsp-find-references)
-	("C-c g o" . xref-find-definitions-other-window)
-	("C-c g g" . xref-find-definitions)
-	("C-c g ?" . eldoc-doc-buffer)))
+        ("C-c g r" . lsp-find-references)
+        ("C-c g o" . xref-find-definitions-other-window)
+        ("C-c g g" . xref-find-definitions)
+        ("C-c g ?" . eldoc-doc-buffer)))
     ((equal custom-ide 'custom-ide-eglot)
       (bind-keys :map python-mode-map
-	("C-c g r" . eglot-find-implementation)
-	("C-c g o" . xref-find-definitions-other-window)
-	("C-c g g" . xref-find-definitions)
-	("C-c g ?" . eldoc-doc-buffer)))
+        ("C-c g r" . eglot-find-implementation)
+        ("C-c g o" . xref-find-definitions-other-window)
+        ("C-c g g" . xref-find-definitions)
+        ("C-c g ?" . eldoc-doc-buffer)))
     ((equal custom-ide 'custom-ide-elpy)
       (elpy-enable)
       (bind-keys :map python-mode-map
-	("C-c g a" . elpy-goto-assignment)
-	("C-c g o" . elpy-goto-definition-other-window)
-	("C-c g g" . elpy-goto-definition)
-	("C-c g ?" . elpy-doc)))
+        ("C-c g a" . elpy-goto-assignment)
+        ("C-c g o" . elpy-goto-definition-other-window)
+        ("C-c g g" . elpy-goto-definition)
+        ("C-c g ?" . elpy-doc)))
     ((equal custom-ide 'custom-ide-lsp-bridge)
       (bind-keys :map python-mode-map
-	("C-c g a" . lsp-bridge-find-reference)
-	("C-c g o" . lsp-bridge-find-def-other-window)
-	("C-c g g" . lsp-bridge-find-def)
-	("C-c g i" . lsp-bridge-find-impl)
-	("C-c g r" . lsp-bridge-rename)
-	("C-c g ?" . lsp-bridge-popup-documentation)))
+        ("C-c g a" . lsp-bridge-find-reference)
+        ("C-c g o" . lsp-bridge-find-def-other-window)
+        ("C-c g g" . lsp-bridge-find-def)
+        ("C-c g i" . lsp-bridge-find-impl)
+        ("C-c g r" . lsp-bridge-rename)
+        ("C-c g ?" . lsp-bridge-popup-documentation)))
     ))
 
 ;;; --------------------------------------------------------------------------
 
 (defun mrf/load-python-file-hook ()
   (python-mode)
+  (when (equal custom-ide 'custom-ide-anaconda)
+    (anaconda-mode 1))
   (message ">>> mrf/load-python-file-hook")
   (setq highlight-indentation-mode -1)
   (setq display-fill-column-indicator-mode t))
@@ -2402,11 +2529,11 @@ capture was not aborted."
   (cond
     ((equal debug-adapter 'debug-adapter-dap-mode)
       (bind-keys :map typescript-mode-map
-	("C-c ." . dap-hydra/body))
+      ("C-c ." . dap-hydra/body))
       (dap-node-setup))
     ((equal debug-adapter 'debug-adapter-dape)
       (bind-keys :map typescript-mode-map
-	("C-c ." . dape-hydra/body)))))
+      ("C-c ." . dape-hydra/body)))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -2436,8 +2563,8 @@ capture was not aborted."
 (use-package js2-mode
   :hook (js-mode . js2-minor-mode)
   :bind (:map js2-mode-map
-	  ("{" . paredit-open-curly)
-	  ("}" . paredit-close-curly-and-newline))
+        ("{" . paredit-open-curly)
+        ("}" . paredit-close-curly-and-newline))
   :mode ("\\.js\\'" "\\.mjs\\'" "\\.json$")
   :custom (js2-highlight-level 3))
 
@@ -2460,10 +2587,10 @@ capture was not aborted."
   (unless (file-exists-p "Makefile")
     (set (make-local-variable 'compile-command)
       (let ((file (file-name-nondirectory buffer-file-name)))
-	(format "%s -o %s %s"
-	  (if  (equal (file-name-extension file) "cpp") "g++" "gcc" )
-	  (file-name-sans-extension file)
-	  file)))
+      (format "%s -o %s %s"
+        (if  (equal (file-name-extension file) "cpp") "g++" "gcc" )
+        (file-name-sans-extension file)
+        file)))
     (compile compile-command)))
 
 (global-set-key [f9] 'code-compile)
@@ -2523,21 +2650,23 @@ capture was not aborted."
   :hook
   (rust-mode . lsp-deferred)
   (rust-mode . (lambda () (setq indent-tabs-mode nil)
-		 (prettify-symbols-mode)))
+                 (prettify-symbols-mode)))
   :config
   (setq rust-format-on-save t))
-					; ;(use-package rust-analyzer)
+
+(use-package rust-playground :ensure t :after rust-mode)
+(use-package toml-mode :ensure t :after rust-mode)
 
 (use-package cargo-mode
   :defer t
   :after rust-mode
   :ensure (:fetcher github :repo "ayrat555/cargo-mode"
-	    :files ("*.el" "*.el.in" "dir" "*.info" "*.texi"
-		     "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
-		     "doc/*.texinfo" "lisp/*.el"
-		     (:exclude ".dir-locals.el" "test.el" "tests.el"
-		       "*-test.el" "*-tests.el" "LICENSE" "README*"
-		       "*-pkg.el"))))
+          :files ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                   "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
+                   "doc/*.texinfo" "lisp/*.el"
+                   (:exclude ".dir-locals.el" "test.el" "tests.el"
+                     "*-test.el" "*-tests.el" "LICENSE" "README*"
+                     "*-pkg.el"))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -2620,16 +2749,16 @@ capture was not aborted."
   (with-eval-after-load
     (add-to-list 'dape-configs
       `(delve
-	 modes (go-mode go-ts-mode)
-	 command "dlv"
-	 command-args ("dap" "--listen" "127.0.0.1:55878")
-	 command-cwd dape-cwd-fn
-	 host "127.0.0.1"
-	 port 55878
-	 :type "debug"	;; needed to set the adapterID correctly as a string type
-	 :request "launch"
-	 :cwd dape-cwd-fn
-	 :program dape-cwd-fn))))
+       modes (go-mode go-ts-mode)
+       command "dlv"
+       command-args ("dap" "--listen" "127.0.0.1:55878")
+       command-cwd dape-cwd-fn
+       host "127.0.0.1"
+       port 55878
+       :type "debug"  ;; needed to set the adapterID correctly as a string type
+       :request "launch"
+       :cwd dape-cwd-fn
+       :program dape-cwd-fn))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -2700,6 +2829,8 @@ capture was not aborted."
   :custom
   (dap-auto-configure-features '(sessions locals breakpoints expressions repl controls tooltip))
   :config
+  (require 'dap-lldb)
+  (require 'dap-gdb-lldb)
   (define-dap-hydra)
   (bind-keys :map prog-mode-map
     ("C-c ." . dap-hydra/body))
@@ -2721,16 +2852,34 @@ capture was not aborted."
   :when (equal debug-adapter 'debug-adapter-dap-mode)
   :defer t
   :after dap-mode
-  :ensure (:package "dap-lldb" :type git :host github :repo "emacs-lsp/dap-mode")
+  :ensure (:package "dap-lldb" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode")
   :custom
-  (dap-lldb-debug-program "~/Developer/command-line-unix/llvm/lldb-build/bin/lldb-dap"))
+  (dap-lldb-debug-program "~/Developer/command-line-unix/llvm/lldb-build/bin/lldb-dap")
+  :config
+  (dap-register-debug-template
+    "Rust::LLDB Run Configuration"
+    (list :type "lldb"
+      :request "launch"
+      :name "LLDB::Run"
+      :gdbpath "rust-lldb"
+      :target nil
+      :cwd nil)))
 
 (use-package dap-gdb-lldb
-  :ensure (:package "dap-gdb-lldb" :type git :host github :repo "emacs-lsp/dap-mode")
+  :when (equal debug-adapter 'debug-adapter-dap-mode)
+  :ensure (:package "dap-gdb-lldb" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode")
   :defer t
   :after dap-lldb
   :config
   (dap-gdb-lldb-setup))
+
+(use-package dap-cpptools
+  :when (equal debug-adapter 'debug-adapter-dap-mode)
+  :defer t
+  :after dap-mode
+  :ensure (:package "dap-cpptools" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode"))
+  ;; :config
+  ;; (dap-cpptools-setup))
 
 (with-eval-after-load 'dap-lldb
   (dap-register-debug-template
@@ -2915,7 +3064,7 @@ capture was not aborted."
   :commands term
   :config
   (setq explicit-shell-file-name "bash") ;; Change this to zsh, etc
-  ;;(setq explicit-zsh-args '())	    ;; Use 'explicit-<shell>-args for shell-specific args
+  ;;(setq explicit-zsh-args '())          ;; Use 'explicit-<shell>-args for shell-specific args
 
   ;; Match the default Bash shell prompt.  Update this if you have a custom prompt
   (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *"))
@@ -2933,7 +3082,7 @@ capture was not aborted."
   :config
   (setq vterm-environment ("PS1=\\u@\\h:\\w \n$"))
   (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *")  ;; Set this to match your custom shell prompt
-  (setq vterm-shell "zsh")			    ;; Set this to customize the shell to launch
+  (setq vterm-shell "zsh")                        ;; Set this to customize the shell to launch
   (setq vterm-max-scrollback 10000))
 
 ;;; --------------------------------------------------------------------------
@@ -2943,7 +3092,7 @@ capture was not aborted."
   (add-hook 'eshell-pre-command-hook 'eshell-save-some-history)
   ;; Truncate buffer for performance
   (add-to-list 'eshell-output-filter-functions 'eshell-truncate-buffer)
-  (setq eshell-history-size	10000
+  (setq eshell-history-size   10000
     eshell-buffer-maximum-lines 10000
     eshell-hist-ignoredups t
     eshell-scroll-to-bottom-on-input t))
@@ -2977,7 +3126,7 @@ capture was not aborted."
   ;; Doesn't work as expected!
   ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
   (setq dired-open-extensions '(("png" . "feh")
-				 ("mkv" . "mpv"))))
+                               ("mkv" . "mpv"))))
 
 (use-package dired-hide-dotfiles
   :after dired-mode
@@ -3024,7 +3173,7 @@ capture was not aborted."
 (use-package solaire-mode
   :after treemacs
   :ensure (:package "solaire-mode" :source "MELPA"
-	   :repo "hlissner/emacs-solaire-mode" :fetcher github)
+         :repo "hlissner/emacs-solaire-mode" :fetcher github)
   :hook (elpaca-after-init . solaire-global-mode)
   :config
   (push '(treemacs-window-background-face . solaire-default-face) solaire-mode-remap-alist)
@@ -3041,21 +3190,29 @@ capture was not aborted."
   (golden-ratio-wide-adjust-factor .4)
   (golden-ratio-max-width 100)
   (golden-ratio-exclude-modes '(
-				 prog-mode
-				 dashboard-mode
-				 ;;inferior-emacs-lisp-mode
-				 ;;inferior-python-mode
-				 comint-mode
-				 ;;lisp-interaction-mode
-				 treemacs-mode
-				 undo-tree-visualizer-mode
-				 vundo-mode
-				 ))
+                               prog-mode
+                               dashboard-mode
+                               ;;inferior-emacs-lisp-mode
+                               ;;inferior-python-mode
+                               comint-mode
+                               ;;lisp-interaction-mode
+                               treemacs-mode
+                               undo-tree-visualizer-mode
+                               vundo-mode
+                               ))
   (golden-ratio-exclude-buffer-regexp '("dap*"
-					 "*dape*"
-					 "*python*"))
+                                       "*dape*"
+                                       "*python*"))
   :config
   (golden-ratio-mode 1))
+
+;;; --------------------------------------------------------------------------
+
+(use-package buffer-move
+  :bind (("C-S-<up>"     . buf-move-up)
+	  ("C-S-<down>"  . buf-move-down)
+	  ("C-S-<left>"  . buf-move-left)
+	  ("C-S-<right>" . buf-move-right)))
 
 ;;; --------------------------------------------------------------------------
 
@@ -3076,7 +3233,7 @@ capture was not aborted."
   (centaur-tabs-set-icons t)
   (centaur-tabs-set-modified-marker t)
   :bind (("C-c <" . centaur-tabs-backward)
-	  ("C-c >" . centaur-tabs-forward))
+        ("C-c >" . centaur-tabs-forward))
   :config ;; Enable centaur-tabs
   (centaur-tabs-mode t))
 
@@ -3101,6 +3258,9 @@ capture was not aborted."
 (use-package rainbow-mode
   :hook (prog-mode . (lambda () (rainbow-mode t))))
 
+(use-package highlight-defined
+  :hook (emacs-lisp-mode . highlight-defined-mode))
+
 (defun mrf/set-fill-column-interactively (num)
   "Asks for the fill column."
   (interactive "nfill-column: ")
@@ -3118,19 +3278,19 @@ capture was not aborted."
   (defvar mmm-keys-minor-mode-map
     (let ((map (make-sparse-keymap)))
       (bind-keys :map map
-	("M-RET p" . pulsar-pulse-line)
-	("M-RET d" . dashboard-open)
-	("M-RET S e" . eshell)
-	("M-RET f" . mrf/set-fill-column-interactively)
+        ("M-RET p" . pulsar-pulse-line)
+        ("M-RET d" . dashboard-open)
+        ("M-RET S e" . eshell)
+        ("M-RET f" . mrf/set-fill-column-interactively)
         ("M-RET r" . repeat-mode)
-	("M-RET S i" . ielm)
-	("M-RET S v" . vterm-other-window)
-	("M-RET t" . treemacs)
-	("M-RET |" . global-display-fill-column-indicator-mode)
-	("M-RET T +" . next-theme)
-	("M-RET T -" . previous-theme)
-	("M-RET T ?" . which-theme)
-	("M-RET ?" . eldoc-box-help-at-point))
+        ("M-RET S i" . ielm)
+        ("M-RET S v" . vterm-other-window)
+        ("M-RET t" . treemacs)
+        ("M-RET |" . global-display-fill-column-indicator-mode)
+        ("M-RET T +" . next-theme)
+        ("M-RET T -" . previous-theme)
+        ("M-RET T ?" . which-theme)
+        ("M-RET ?" . eldoc-box-help-at-point))
       map)
     "mmm-keys-minor-mode keymap.")
 
@@ -3151,13 +3311,13 @@ capture was not aborted."
     (unbind-key "M-RET M-RET" map)
     (cond
       ((equal major-mode 'org-mode)
-  	(bind-keys :map map
-  	  ("M-RET M-RET" . org-insert-heading)
-  	  ("M-RET o f" . mrf/set-org-fill-column-interactively)
-  	  ("M-RET o l" . org-toggle-link-display)))
+      (bind-keys :map map
+        ("M-RET M-RET" . org-insert-heading)
+        ("M-RET o f" . mrf/set-org-fill-column-interactively)
+        ("M-RET o l" . org-toggle-link-display)))
       ((equal major-mode 'python-mode)
-  	(bind-keys :map map
-  	  ("M-RET P" . 'pydoc-at-point))))))
+      (bind-keys :map map
+        ("M-RET P" . 'pydoc-at-point))))))
 
 (defun mrf/mmm-update-menu ()
   (interactive)
@@ -3182,14 +3342,12 @@ capture was not aborted."
   (lambda ()
     (setq-default initial-scratch-message
       (format
-	";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
-	";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))))
+      ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
+      ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))))
 
 (if dashboard-landing-screen
   ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
   (add-hook 'lisp-interaction-mode-hook 'dashboard-open))
-
-;; (add-hook 'lisp-interaction-mode-hook 'use-package-report)
 
 ;;; --------------------------------------------------------------------------
 


### PR DESCRIPTION
* emacs-lisp blocks automatically write to init.el unless overridden.
* Added new toggle, enable-frameset-restore, that will allow for a frameset restore based upon a saved frameset file.
* New save/restore frameset. It will create a new file named saved-frameset.el in the user-emacs-directory. The file is loaded only if the toggle above is non-nil
* re-centering will only occur if forced and/or if enable-frameset-restore toggle is nil. Basically, re-centering will not happen if the frameset is restored.
* Added in 'tron-legacy' theme and deleted 'deeper-blue'.