### PR TITLE
Default Fonts

### DIFF
--- a/emacs-config.org
+++ b/emacs-config.org
@@ -11,6 +11,9 @@ This ORG file will configure the * init.el * file based upon all of the * emacs-
 
 The goal of this Emacs configuration is to make an Emacs configuration that has a good collection of popular options. So far, the following collections of options are included here:
 
+
+| Language 
+
 - Landging Screen Options ::
   + Dashboard
   + IELM (Integrated Emacs Lisp Mode)
@@ -505,7 +508,7 @@ This is a curated selection of themes that I personally like. Most of them are d
     :type 'string
     :group 'mrf-custom-fonts)
 
-  (defcustom variable-pitch-font-family "SF Pro"
+  (defcustom variable-pitch-font-family "Helvetica Neue"
     "The font family used as the default proportional font."
     :type 'string
     :group 'mrf-custom-fonts)
@@ -560,6 +563,61 @@ This is a curated selection of themes that I personally like. Most of them are d
   (defvar custom-default-mono-font-size 170
     "Storage for the current mono-spaced font height.")
 
+#+end_src
+
+*** Verify Default variable-pitch Font
+
+Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
+
+#+begin_src emacs-lisp
+
+  (defun mrf/validate-variable-pitch-font ()
+    (let* ((variable-pitch-font
+             (cond
+  	     ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
+  	     ((x-list-fonts "SF Pro")           "SF Pro")
+  	     ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
+  	     ((x-list-fonts "Ubuntu")           "Ubuntu")
+  	     ((x-list-fonts "Helvetica")        "Helvetica")
+               ((x-list-fonts "Source Sans Pro")  "Source Sans Pro")
+               ((x-list-fonts "Lucida Grande")    "Lucida Grande")
+               ((x-list-fonts "Verdana")          "Verdana")
+               ((x-family-fonts "Sans Serif")     "Sans Serif")
+               (nil (warn "Cannot find a Sans Serif Font.  Install Source Sans Pro.")))))
+      (if variable-pitch-font
+        (when (not (equal variable-pitch-font variable-pitch-font-family))
+  	(setq variable-pitch-font-family variable-pitch-font))
+        (message "---- Can't find a variable-pitch font to use.")))
+
+    (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
+
+#+end_src
+
+
+*** Verify Default monospace / default font
+
+Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
+
+#+begin_src emacs-lisp
+
+  (defun mrf/validate-monospace-font ()
+    (let* ((monospace-font
+             (cond
+  	     ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
+  	     ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
+  	     ((x-list-fonts "Fira Code")         "Fira Code")
+  	     ((x-list-fonts "Source Code Pro")   "Source Code Pro")
+  	     ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
+               ((x-family-fonts "Monospaced")      "Monospaced")
+               (nil (warn "Cannot find a monospaced Font.  Install Source Code Pro.")))))
+      (if monospace-font
+        (when (not (equal monospace-font variable-pitch-font-family))
+  	(setq mono-spaced-font-family monospace-font)
+  	(setq default-font-family monospace-font))
+        (message "---- Can't find a monospace font to use.")))
+
+    (message (format ">>> monospace font is %s" mono-spaced-font-family)))
+  
 #+end_src
 
 
@@ -626,6 +684,11 @@ By default, the =user-emacs-directory= points to the .emacs.d* directory from wh
   (load custom-file 'noerror 'nomessage)
   (setq enable-frameset-restore nil) ;; FORCE UNTIL FRAMESET RESTORE IS DONE
 
+  ;; ensure that the loaded font values are supported by this OS. If not, try
+  ;; to correct them.
+  (mrf/validate-variable-pitch-font)
+  (mrf/validate-monospace-font)
+
 #+end_src
 
 ** Additional Search Paths
@@ -669,6 +732,9 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
                                    "requirements.txt"
                                    "Gemfile"
                                    "package.json"))
+
+  (defconst *is-a-mac* (eq system-type 'darwin))
+
 
 #+end_src
 
@@ -1833,7 +1899,7 @@ This function sets up the fonts faces that are used within org-mode.
                      (org-level-6 . 0.90)
                      (org-level-7 . 0.90)
                      (org-level-8 . 0.90)))
-      (set-face-attribute (car face) nil :font "SF Pro" :weight 'regular
+      (set-face-attribute (car face) nil :font "Helvetica Neue" :weight 'regular
         :height (cdr face))))
 #+end_src
 
@@ -2085,11 +2151,27 @@ To execute or export code in =org-mode= code blocks, you'll need to set up =org-
   (with-eval-after-load 'org
     (org-babel-do-load-languages
       'org-babel-load-languages
-      '((emacs-lisp . t)
-         (js . t)
-         (shell . t)
-         (python . t)))
-
+      (seq-filter
+        (lambda (pair)
+  	(locate-library (concat "ob-" (symbol-name (car pair)))))
+        '((emacs-lisp . t)
+  	 (ditaa . t)
+  	 (dot . t)
+  	 (emacs-lisp . t)
+  	 (gnuplot . t)
+  	 (haskell . nil)
+  	 (latex . t)
+  	 (ledger . t)
+  	 (ocaml . nil)
+  	 (octave . t)
+  	 (plantuml . t)
+  	 (python . t)
+  	 (ruby . t)
+  	 (screen . nil)
+  	 (sh . t) ;; obsolete
+  	 (shell . t)
+  	 (sql . t)
+  	 (sqlite . t))))
     (push '("conf-unix" . conf-unix) org-src-lang-modes))
 #+end_src
 

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -593,7 +593,6 @@ Look for a proportional font that is available on the OS. If the actual default 
 
 #+end_src
 
-
 *** Verify Default monospace / default font
 
 Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
@@ -4882,7 +4881,6 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
 #+end_src
 
 
-
 * Miscellaneous
 
 The following packages are some additional quality of life features.
@@ -5259,6 +5257,26 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
   (if dashboard-landing-screen
     ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
     (add-hook 'lisp-interaction-mode-hook 'dashboard-open))
+
+#+end_src
+
+
+** Exiting and Cleanup
+
+#+begin_src emacs-lisp
+
+  (defun mrf/cleanup-when-exiting ()
+    (let ((backdir (format "%s/config-backup" working-files-directory)))
+      (make-directory backdir t)
+      ;; Backup init.el
+      (copy-file
+        (expand-file-name "init.el" emacs-config-directory)
+        (expand-file-name "init.el" backdir) t)
+      (copy-file
+        (expand-file-name "emacs-config.org" emacs-config-directory)
+        (expand-file-name "emacs-config.org" backdir) +1)))
+
+  (add-hook 'kill-emacs-hook #'mrf/cleanup-when-exiting)
 
 #+end_src
 

--- a/init.el
+++ b/init.el
@@ -3414,6 +3414,19 @@ capture was not aborted."
   ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
   (add-hook 'lisp-interaction-mode-hook 'dashboard-open))
 
+(defun mrf/cleanup-when-exiting ()
+  (let ((backdir (format "%s/config-backup" working-files-directory)))
+    (make-directory backdir t)
+    ;; Backup init.el
+    (copy-file
+      (expand-file-name "init.el" emacs-config-directory)
+      (expand-file-name "init-backup.el" backdir) t)
+    (copy-file
+      (expand-file-name "emacs-config.org" emacs-config-directory)
+      (expand-file-name "emacs-config-backup.org" backdir) t)))
+
+(add-hook 'kill-emacs-hook #'mrf/cleanup-when-exiting)
+
 ;;; --------------------------------------------------------------------------
 
 ;;; init.el ends here.

--- a/init.el
+++ b/init.el
@@ -280,7 +280,7 @@ If additional themes are added, they must be previously installed."
   :type 'string
   :group 'mrf-custom-fonts)
 
-(defcustom variable-pitch-font-family "SF Pro"
+(defcustom variable-pitch-font-family "Helvetica Neue"
   "The font family used as the default proportional font."
   :type 'string
   :group 'mrf-custom-fonts)
@@ -335,6 +335,44 @@ font size is computed + 20 of this value."
 (defvar custom-default-mono-font-size 170
   "Storage for the current mono-spaced font height.")
 
+(defun mrf/validate-variable-pitch-font ()
+  (let* ((variable-pitch-font
+           (cond
+	     ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
+	     ((x-list-fonts "SF Pro")           "SF Pro")
+	     ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
+	     ((x-list-fonts "Ubuntu")           "Ubuntu")
+	     ((x-list-fonts "Helvetica")        "Helvetica")
+             ((x-list-fonts "Source Sans Pro")  "Source Sans Pro")
+             ((x-list-fonts "Lucida Grande")    "Lucida Grande")
+             ((x-list-fonts "Verdana")          "Verdana")
+             ((x-family-fonts "Sans Serif")     "Sans Serif")
+             (nil (warn "Cannot find a Sans Serif Font.  Install Source Sans Pro.")))))
+    (if variable-pitch-font
+      (when (not (equal variable-pitch-font variable-pitch-font-family))
+	(setq variable-pitch-font-family variable-pitch-font))
+      (message "---- Can't find a variable-pitch font to use.")))
+
+  (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
+
+(defun mrf/validate-monospace-font ()
+  (let* ((monospace-font
+           (cond
+	     ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
+	     ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
+	     ((x-list-fonts "Fira Code")         "Fira Code")
+	     ((x-list-fonts "Source Code Pro")   "Source Code Pro")
+	     ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
+             ((x-family-fonts "Monospaced")      "Monospaced")
+             (nil (warn "Cannot find a monospaced Font.  Install Source Code Pro.")))))
+    (if monospace-font
+      (when (not (equal monospace-font variable-pitch-font-family))
+	(setq mono-spaced-font-family monospace-font)
+	(setq default-font-family monospace-font))
+      (message "---- Can't find a monospace font to use.")))
+
+  (message (format ">>> monospace font is %s" mono-spaced-font-family)))
+
 ;;; --------------------------------------------------------------------------
 
 ;; Use shell path
@@ -383,6 +421,11 @@ font size is computed + 20 of this value."
 (load custom-file 'noerror 'nomessage)
 (setq enable-frameset-restore nil) ;; FORCE UNTIL FRAMESET RESTORE IS DONE
 
+;; ensure that the loaded font values are supported by this OS. If not, try
+;; to correct them.
+(mrf/validate-variable-pitch-font)
+(mrf/validate-monospace-font)
+
 ;;; --------------------------------------------------------------------------
 
 (add-to-list 'load-path (expand-file-name "lisp" emacs-config-directory))
@@ -412,6 +455,8 @@ font size is computed + 20 of this value."
                                  "requirements.txt"
                                  "Gemfile"
                                  "package.json"))
+
+(defconst *is-a-mac* (eq system-type 'darwin))
 
 ;;; --------------------------------------------------------------------------
 (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
@@ -1225,7 +1270,7 @@ font size is computed + 20 of this value."
                    (org-level-6 . 0.90)
                    (org-level-7 . 0.90)
                    (org-level-8 . 0.90)))
-    (set-face-attribute (car face) nil :font "SF Pro" :weight 'regular
+    (set-face-attribute (car face) nil :font "Helvetica Neue" :weight 'regular
       :height (cdr face))))
 
 ;; -----------------------------------------------------------------
@@ -1437,11 +1482,27 @@ font size is computed + 20 of this value."
 (with-eval-after-load 'org
   (org-babel-do-load-languages
     'org-babel-load-languages
-    '((emacs-lisp . t)
-       (js . t)
-       (shell . t)
-       (python . t)))
-
+    (seq-filter
+      (lambda (pair)
+	(locate-library (concat "ob-" (symbol-name (car pair)))))
+      '((emacs-lisp . t)
+	 (ditaa . t)
+	 (dot . t)
+	 (emacs-lisp . t)
+	 (gnuplot . t)
+	 (haskell . nil)
+	 (latex . t)
+	 (ledger . t)
+	 (ocaml . nil)
+	 (octave . t)
+	 (plantuml . t)
+	 (python . t)
+	 (ruby . t)
+	 (screen . nil)
+	 (sh . t) ;; obsolete
+	 (shell . t)
+	 (sql . t)
+	 (sqlite . t))))
   (push '("conf-unix" . conf-unix) org-src-lang-modes))
 
 ;;; --------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates the way default, variable-pitch, and monotype fonts are defaulted. Since the ones chosen in this config as "default" may not be available on any specific system, this PR addresses this by checking for many popular alternates. If found, that defaulted value will be used.