### PR TITLE
A lot of cleanup and package maintenance.

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -67,11 +67,11 @@
      ;;; apps are not started from a shell."
   (interactive)
   (setq exec-path '( "/Users/strider/.cargo/bin"
-  		     "/Users/strider/.local/bin"
-  		     "/opt/homebrew/bin" "/opt/homebrew/sbin"
-  		     "/usr/bin" "/bin" "/usr/sbin" "/sbin"
-  		     "/usr/local/bin" "/opt/local/bin"
-  		     "/Library/Frameworks/Python.framework/Versions/Current/bin"))
+                   "/Users/strider/.local/bin"
+                   "/opt/homebrew/bin" "/opt/homebrew/sbin"
+                   "/usr/bin" "/bin" "/usr/sbin" "/sbin"
+                   "/usr/local/bin" "/opt/local/bin"
+                   "/Library/Frameworks/Python.framework/Versions/Current/bin"))
 
   (let ((path-from-exec-path (string-join exec-path path-separator)))
     (setenv "PATH" path-from-exec-path)))

--- a/early-init.el
+++ b/early-init.el
@@ -22,6 +22,13 @@
 (setq package-vc-register-as-project nil) ; Emacs 30
 (add-hook 'package-menu-mode-hook #'hl-line-mode)
 
+;; This allows for a set of PROXY variables/settings to be loaded before
+;; we actually begin the load.
+(let
+  ((file (expand-file-name "early-init-proxy.el" user-emacs-directory)))
+  (if (file-exists-p file)
+    (load "early-init-proxy")))
+
 (setq package-archives
   '(( "gnu-elpa" . "https://elpa.gnu.org/packages/")
      ( "nongnu" . "https://elpa.nongnu.org/nongnu/")
@@ -37,8 +44,8 @@
      ( "gnu-elpa" . 50 )
      ( "melpa-stable" . 40 )
      ( "melpa" . 30 )
-     ( "nongnu" . 10)
      ( "gnu-dev" . 20 )
+     ( "nongnu" . 10)
      ))
 
 (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3") ;; w/o this Emacs freezes when refreshing ELPA

--- a/early-init.el
+++ b/early-init.el
@@ -38,14 +38,6 @@
   use-package-always-demand nil
   use-package-always-defer nil)
 
-(add-hook 'emacs-startup-hook
-  (lambda ()
-    (setq startup-time-message
-      (format "Emacs read in %.2f seconds with %d garbage collections."
-      (float-time (time-subtract after-init-time before-init-time))
-      gcs-done))
-    (message startup-time-message)))
-
 ;; (use-package gcmh
 ;;   :diminish gcmh-mode
 ;;   :config
@@ -55,7 +47,12 @@
 
 (add-hook 'emacs-startup-hook
   (lambda ()
-    (setq gc-cons-percentage 0.1))) ;; Default value for `gc-cons-percentage'
+    (setq gc-cons-percentage 0.1) ;; Default value for `gc-cons-percentage'
+    (setq startup-time-message
+      (format "Emacs read in %.2f seconds with %d garbage collections."
+        (float-time (time-subtract after-init-time before-init-time))
+        gcs-done))
+    (message startup-time-message)))
 
 ;;; ##########################################################################
 (defconst *is-a-mac* (eq system-type 'darwin))
@@ -66,11 +63,11 @@
   ;; most part, the paths are typical on a Mac and with homebrew installed.
   (interactive)
   (setq exec-path '( "/Users/strider/.cargo/bin"
-                   "/Users/strider/.local/bin"
-                   "/opt/homebrew/bin" "/opt/homebrew/sbin"
-                   "/usr/bin" "/bin" "/usr/sbin" "/sbin"
-                   "/usr/local/bin" "/opt/local/bin"
-                   "/Library/Frameworks/Python.framework/Versions/Current/bin"))
+                     "/Users/strider/.local/bin"
+                     "/opt/homebrew/bin" "/opt/homebrew/sbin"
+                     "/usr/bin" "/bin" "/usr/sbin" "/sbin"
+                     "/usr/local/bin" "/opt/local/bin"
+                     "/Library/Frameworks/Python.framework/Versions/Current/bin"))
 
   (let ((path-from-exec-path (string-join exec-path path-separator)))
     (setenv "PATH" path-from-exec-path)))

--- a/early-init.el
+++ b/early-init.el
@@ -57,4 +57,30 @@
   (lambda ()
     (setq gc-cons-percentage 0.1))) ;; Default value for `gc-cons-percentage'
 
+;;; --------------------------------------------------------------------------
+(defconst *is-a-mac* (eq system-type 'darwin))
+
+(defun mifi/setup-exec-path ()
+     ;;; Set up Emacs' `exec-path' and PATH environment variable to match"
+     ;;; that used by the user's shell.
+     ;;; This is particularly useful under Mac OS X and macOS, where GUI
+     ;;; apps are not started from a shell."
+  (interactive)
+  (setq exec-path '( "/Users/strider/.cargo/bin"
+  		     "/Users/strider/.local/bin"
+  		     "/opt/homebrew/bin" "/opt/homebrew/sbin"
+  		     "/usr/bin" "/bin" "/usr/sbin" "/sbin"
+  		     "/usr/local/bin" "/opt/local/bin"
+  		     "/Library/Frameworks/Python.framework/Versions/Current/bin"))
+
+  (let ((path-from-exec-path (string-join exec-path path-separator)))
+    (setenv "PATH" path-from-exec-path)))
+
+(setq browse-url-firefox-program
+  "/Applications/Firefox.app/Contents/MacOS/firefox")
+(setq browse-url-chrome-program
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+
+(add-hook 'before-init-hook #'mifi/setup-exec-path)
+
 ;;; early-init.el ends here.

--- a/early-init.el
+++ b/early-init.el
@@ -61,10 +61,9 @@
 (defconst *is-a-mac* (eq system-type 'darwin))
 
 (defun mifi/setup-exec-path ()
-     ;;; Set up Emacs' `exec-path' and PATH environment variable to match"
-     ;;; that used by the user's shell.
-     ;;; This is particularly useful under Mac OS X and macOS, where GUI
-     ;;; apps are not started from a shell."
+  ;; A list of customized executable paths. This is just something I (mifi)
+  ;; do personally rather than have another package do it for me. For the
+  ;; most part, the paths are typical on a Mac and with homebrew installed.
   (interactive)
   (setq exec-path '( "/Users/strider/.cargo/bin"
                    "/Users/strider/.local/bin"

--- a/early-init.el
+++ b/early-init.el
@@ -1,4 +1,4 @@
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; Adjust garbage collection threshold for early startup (see use of gcmh below)
 (setq gc-cons-threshold (* 100 1024 1024))
@@ -57,7 +57,7 @@
   (lambda ()
     (setq gc-cons-percentage 0.1))) ;; Default value for `gc-cons-percentage'
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 (defconst *is-a-mac* (eq system-type 'darwin))
 
 (defun mifi/setup-exec-path ()

--- a/early-init.el
+++ b/early-init.el
@@ -1,3 +1,14 @@
+;;; early-init.el -*- flycheck-disabled-checkers: (emacs-lisp); lexical-binding: nil -*-
+;;;
+;;; Commentary:
+
+;; Settings/Packages that need to be used early in the initialization process
+;; of the Emacs startup. This file is executed before init.el.
+;;
+;; DO NOT MODIFY this file directly as changes will be overwritten.
+
+;;; Code:
+
 ;;; ##########################################################################
 
 ;; Adjust garbage collection threshold for early startup (see use of gcmh below)

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -106,7 +106,7 @@ Standard fare and good practice.
 ** Package archives
 
 #+begin_src emacs-lisp :tangle "early-init.el" 
-  ;;; ##########################################################################
+    ;;; ##########################################################################
 
   ;; Adjust garbage collection threshold for early startup (see use of gcmh below)
   (setq gc-cons-threshold (* 100 1024 1024))
@@ -118,6 +118,13 @@ Standard fare and good practice.
 
   (setq package-vc-register-as-project nil) ; Emacs 30
   (add-hook 'package-menu-mode-hook #'hl-line-mode)
+
+  ;; This allows for a set of PROXY variables/settings to be loaded before
+  ;; we actually begin the load.
+  (let
+    ((file (expand-file-name "early-init-proxy.el" user-emacs-directory)))
+    (if (file-exists-p file)
+      (load "early-init-proxy")))
 
   (setq package-archives
     '(( "gnu-elpa" . "https://elpa.gnu.org/packages/")
@@ -134,8 +141,8 @@ Standard fare and good practice.
        ( "gnu-elpa" . 50 )
        ( "melpa-stable" . 40 )
        ( "melpa" . 30 )
-       ( "nongnu" . 10)
        ( "gnu-dev" . 20 )
+       ( "nongnu" . 10)
        ))
 
   (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3") ;; w/o this Emacs freezes when refreshing ELPA
@@ -307,7 +314,7 @@ Elpaca:
   (elpaca elpaca-use-package
     (elpaca-use-package-mode 1)
     (setq elpaca-use-package-by-default t))
-  ;; (use-package emacs :ensure nil :config (setq ring-bell-function #'ignore))
+  ;;    (use-package emacs :ensure nil :config (setq ring-bell-function #'ignore))
 
 #+end_src
 
@@ -1663,7 +1670,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
   ;; Add extensions
   (use-package cape
     :when (equal completion-handler 'comphand-corfu)
-    :after corfu
+    :after curfu
     ;; Bind dedicated completion commands
     ;; Alternative prefix keys: C-c p, M-p, M-+, ...
     :bind ( ("C-c C-p p" . completion-at-point) ;; capf
@@ -1935,7 +1942,7 @@ Embark makes it easy to choose a command to run based on what is near point, bot
 
 We also use [[https://github.com/sebastiencs/company-box][company-box]] to further enhance the look of the completions with icons and better overall presentation.
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; ##########################################################################
 
   ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
@@ -1952,7 +1959,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 #+end_src
 
 
-#+begin_src emacs-lisp :tangle no
+#+begin_src emacs-lisp
   ;;; ##########################################################################
 
   ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
@@ -1993,7 +2000,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 
   (use-package company-jedi
     :when  (equal custom-ide 'custom-ide-elpy)
-    :after python company
+    :after (:all python company)
     :config
     (jedi:setup)
     (defun my/company-jedi-python-mode-hook ()
@@ -2002,7 +2009,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 
   (use-package company-anaconda
     :when (equal custom-ide 'custom-ide-anaconda)
-    :after anaconda company
+    :after (:all anaconda company)
     :hook (python-mode . anaconda-mode)
     :config
     (eval-after-load "company"
@@ -3247,7 +3254,6 @@ This section contains the basic configuration for =org-mode= plus the configurat
   ;;; ##########################################################################
 
   (use-package org
-    :pin gnu-elpa
     :preface
     (mifi/org-theme-override-values)
     :commands (org-capture org-agenda)

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -132,6 +132,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 #+end_src
 
 ** Garbage Collection
+
 #+begin_src emacs-lisp :tangle "early-init.el" 
 
   ;; (use-package gcmh
@@ -144,6 +145,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 #+end_src
 
 ** Calculate startup time
+
 #+begin_src emacs-lisp :tangle "early-init.el" 
 
   (add-hook 'emacs-startup-hook
@@ -554,7 +556,7 @@ This is a curated selection of themes that I personally like. Most of them are d
     :type 'string
     :group 'mifi-custom-fonts)
 
-  (defcustom variable-pitch-font-family "Helvetica Neue"
+  (defcustom variable-pitch-font-family "Helvetica"
     "The font family used as the default proportional font."
     :type 'string
     :group 'mifi-custom-fonts)
@@ -2370,6 +2372,9 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
 
 
 * Visuals
+
+These packages and functions are used to select from a list of curated themes and also to handle frame size changes.
+
 ** Theme List and Selection
 
 This bit of code contains a list of themes that I like personally and then allows them to be switched between themselves. The index of ~theme-selector~ is what is set in order to access a theme via the ~mifi/load-theme-from-selector()~ function.
@@ -2429,9 +2434,30 @@ This is the main function that allows cycling (up or down) through the list of t
 
 This function simply loads the theme from the theme-list indexed by the ~theme-selector~ variable. Note the advice for ~load-theme~ that deactivates the current theme before activating the new theme. This is done to reset all the colors, a clean slate, before the new theme is activated.
 
+**** Reset spacious-padding
+
+This function is used to reset spacious-padding-mode if it is loaded and active. Reset is performed by turning spacious-padding off and then restoring it to it's original state. The reason for this is that spacious-padding can sometimes get confused and have weird spacing when font-sizes changes - like after a theme switch or display-font change.
+
 #+begin_src emacs-lisp
   ;;; ##########################################################################
 
+  (defun mifi/reset-if-spacious-padding-mode ()
+    (interactive)
+    (when-let ((spm? (featurep 'spacious-padding))
+  	      (spm-on-off (default-value 'spacious-padding-mode)))
+      (spacious-padding-mode 0)
+      (run-with-timer 0.2 nil
+        (lambda (on-off) (spacious-padding-mode on-off)) spm-on-off)))
+  
+#+end_src
+
+**** Load Theme From Selector
+
+This function loads the theme from the =theme-list= indexed by =theme-selector=. Once the theme is loaded, the variable ~theme-did-load~ is set to t, or nil if the theme failed to load.
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+  
   (defvar theme-did-load nil
     "Set to true if the last Theme was loaded.")
 
@@ -2439,27 +2465,19 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
     "Load the theme in `theme-list' indexed by `theme-selector'."
     (interactive)
     ;; Save value of spacious-padding-mode
-    (let ((spm? (featurep 'spacious-padding)))
-      (if spm?
-        (setq mifi/spm-on-off (default-value 'spacious-padding-mode))
-        (setq mifi/spm-on-off nil))
-      (setq theme-cycle-step nil)
-      (cond
-        ((or (eq step nil) (eq step 0)) (setq theme-cycle-step 0))
-        ((> step 0) (setq theme-cycle-step 1))
-        ((< step 0) (setq theme-cycle-step -1)))
-      (when loaded-theme
-        (when spm?
-  	(spacious-padding-mode 0))
-        (disable-theme (intern loaded-theme)))
-      (setq loaded-theme (nth theme-selector theme-list))
-      (setq theme-did-load (load-theme (intern loaded-theme) t))
-      (when (featurep 'org)
-        (mifi/org-font-setup))
-      (when spm?
-        (spacious-padding-mode mifi/spm-on-off))
-      (set-face-foreground 'line-number "SkyBlue4")))
-
+    (setq theme-cycle-step nil)
+    (cond
+      ((or (eq step nil) (eq step 0)) (setq theme-cycle-step 0))
+      ((> step 0) (setq theme-cycle-step 1))
+      ((< step 0) (setq theme-cycle-step -1)))
+    (when loaded-theme
+      (disable-theme (intern loaded-theme)))
+    (setq loaded-theme (nth theme-selector theme-list))
+    (setq theme-did-load (load-theme (intern loaded-theme) t))
+    (when (featurep 'org)
+      (mifi/org-font-setup))
+    (mifi/reset-if-spacious-padding-mode)
+    (set-face-foreground 'line-number "SkyBlue4"))
 #+end_src
 
 *** Theme selection helper functions.
@@ -2864,24 +2882,28 @@ These functions resize the font to some pre-defined values and will optiononally
   (defun use-small-display-font (&optional force-recenter)
     (interactive)
     (mifi/set-frame-font 0)
+    (mifi/reset-if-spacious-padding-mode)
     (mifi/should-recenter force-recenter))
 
 
   (defun use-medium-display-font (&optional force-recenter)
     (interactive)
     (mifi/set-frame-font 1)
+    (mifi/reset-if-spacious-padding-mode)
     (mifi/should-recenter force-recenter))
 
 
   (defun use-large-display-font (&optional force-recenter)
     (interactive)
     (mifi/set-frame-font 2)
+    (mifi/reset-if-spacious-padding-mode)
     (mifi/should-recenter force-recenter))
 
 
   (defun use-x-large-display-font (&optional force-recenter)
     (interactive)
     (mifi/set-frame-font 3)
+    (mifi/reset-if-spacious-padding-mode)
     (mifi/should-recenter force-recenter))
 
 #+end_src
@@ -3153,7 +3175,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
     "Setup the org TODO keywords and colors."
     (setq org-todo-keywords
       '((type
-          "TODO(t)" "WAITING(w)" "IN-PROGRESS(i)"
+          "TODO(t)" "IN-PROGRESS(i)" "WAITING(w)" 
           "RESEARCH(r)" "SOMEDAY(-)" "READING(e)"
           "CONTACT(c)" "|" "DONE(d)" "CANCELLED(C@)")))
 
@@ -3242,44 +3264,25 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+end_src
 
 
-*** Better Bullets
-[[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
+*** Org-appear
 
-#+begin_src emacs-lisp :tangle no
-    ;;; ##########################################################################
+Org-mode provides a way to toggle visibility of hidden elements such as emphasis markers, links, etc. by customising specific variables, e.g., org-hide-emphasis-markers. However, it is currently not possible to do this interactively and on an element-by-element basis. This package, inspired by org-fragtog, enables automatic visibility toggling depending on cursor position. Hidden element parts appear when the cursor enters an element and disappear when it leaves.
 
-  (use-package org-superstar
-    :after org
-    :custom
-    (org-superstar-leading-bullet " ")
-    (org-superstar-special-todo-items t)
-    (org-superstar-todo-bullet-alist '( ("TODO" . 9744)
-                                        ("INPROG-TODO" . 9744)
-                                        ("HW" . 9744)
-                                        ("STUDY" . 9744)
-                                        ("SOMEDAY" . 9744)
-                                        ("READ" . 9744)
-                                        ("PROJ" . 9744)
-                                        ("CONTACT" . 9744)
-                                        ("DONE" . 9745)))
-    ;; (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
-    :hook (org-mode . org-superstar-mode))
-
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+  
   (use-package org-appear
+    :after org
     :init
     (setq org-hide-emphasis-markers t)
     (setq org-appear-autoemphasis t) ;; Enable org-appear on emphasis
     (setq org-appear-autolinks t) ;; Enable on links
     (setq org-appear-autosubmarkers t) ;; Enable on sub and superscript
     :commands (org-appear-mode)
-    :hook (or-mode . org-appear-mode))
-
-  ;; Automatically change bullet type when indenting
-  ;; Ex: indenting a + makes the bullet a *.
-  (setq org-list-demote-modify-bullet
-    '(("+" ・ "*"）（"*" ・ "-"）（"-" . "+")))
+    :hook (org-mode . org-appear-mode))
 
 #+end_src
+
 
 *** Export Code
 To execute or export code in =org-mode= code blocks, you'll need to set up =org-babel-load-languages= for each language you'd like to use.  [[https://orgmode.org/worg/org-contrib/babel/languages.html][Babel]] documents all of the languages that you can use with =org-babel=.
@@ -3365,6 +3368,9 @@ Note that org-modern is a full replacement for both org-superstar and org-bullet
       (face-spec-reset-face face)
       (set-face-foreground face (face-attribute 'default :background nil)))
     (set-face-background 'fringe (face-attribute 'default :background nil))
+    (set-face-attribute 'default nil :family "Menlo")
+    (set-face-attribute 'variable-pitch nil :family "Helvetica")
+    (set-face-attribute 'org-modern-symbol nil :family "DejaVu Sans Mono")
     (setq
       ;;   ;; Edit settings
       ;;   org-auto-align-tags nil
@@ -3372,22 +3378,24 @@ Note that org-modern is a full replacement for both org-superstar and org-bullet
       org-catch-invisible-edits 'show-and-error
       org-special-ctrl-a/e t
       org-insert-heading-respect-content t
+      org-modern-star 'replace
 
       ;;   ;; Org styling, hide markup etc.
       org-hide-emphasis-markers nil
       org-pretty-entities t
       org-ellipsis "…"
 
-      ;;   ;; Agenda styling
-      ;;   org-agenda-tags-column 0
-      ;;   org-agenda-block-separator ?─
-      ;;   org-agenda-time-grid
-      ;;   '((daily today require-timed)
-      ;;      (800 1000 1200 1400 1600 1800 2000)
-      ;;      " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
-      ;;   org-agenda-current-time-string
-      ;;   "◀── now ─────────────────────────────────────────────────"
+      ;; Agenda styling
+      org-agenda-tags-column 0
+      org-agenda-block-separator ?─
+      org-agenda-time-grid
+      '((daily today require-timed)
+         (800 1000 1200 1400 1600 1800 2000)
+         " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
+      org-agenda-current-time-string
+      "◀── now ─────────────────────────────────────────────────"
       )
+    (mifi/reset-if-spacious-padding-mode)
     (global-org-modern-mode))
 
 #+end_src

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -128,19 +128,6 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
     use-package-always-ensure nil
     use-package-always-demand nil
     use-package-always-defer nil)
-  
-#+end_src
-
-** Calculate startup time
-#+begin_src emacs-lisp :tangle "early-init.el" 
-
-  (add-hook 'emacs-startup-hook
-    (lambda ()
-      (setq startup-time-message
-        (format "Emacs read in %.2f seconds with %d garbage collections."
-        (float-time (time-subtract after-init-time before-init-time))
-        gcs-done))
-      (message startup-time-message)))
 
 #+end_src
 
@@ -154,9 +141,19 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
   ;;     gcmh-high-cons-threshold (* 16 1024 1024))      ; 16mb
   ;;   (gcmh-mode 1))
 
+#+end_src
+
+** Calculate startup time
+#+begin_src emacs-lisp :tangle "early-init.el" 
+
   (add-hook 'emacs-startup-hook
     (lambda ()
-      (setq gc-cons-percentage 0.1))) ;; Default value for `gc-cons-percentage'
+      (setq gc-cons-percentage 0.1) ;; Default value for `gc-cons-percentage'
+      (setq startup-time-message
+        (format "Emacs read in %.2f seconds with %d garbage collections."
+          (float-time (time-subtract after-init-time before-init-time))
+          gcs-done))
+      (message startup-time-message)))
 
 #+end_src
 
@@ -174,11 +171,11 @@ Because in macOS, Emacs could be started outside of a shell (like an application
     ;; most part, the paths are typical on a Mac and with homebrew installed.
     (interactive)
     (setq exec-path '( "/Users/strider/.cargo/bin"
-                     "/Users/strider/.local/bin"
-                     "/opt/homebrew/bin" "/opt/homebrew/sbin"
-                     "/usr/bin" "/bin" "/usr/sbin" "/sbin"
-                     "/usr/local/bin" "/opt/local/bin"
-                     "/Library/Frameworks/Python.framework/Versions/Current/bin"))
+                       "/Users/strider/.local/bin"
+                       "/opt/homebrew/bin" "/opt/homebrew/sbin"
+                       "/usr/bin" "/bin" "/usr/sbin" "/sbin"
+                       "/usr/local/bin" "/opt/local/bin"
+                       "/Library/Frameworks/Python.framework/Versions/Current/bin"))
 
     (let ((path-from-exec-path (string-join exec-path path-separator)))
       (setenv "PATH" path-from-exec-path)))
@@ -239,7 +236,7 @@ Elpaca:
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (defvar elpaca-installer-version 0.7)
   (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
   (defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
@@ -438,9 +435,9 @@ These are features that basically have multiple-choice options instead of being 
 
   Finally, the standard undo handler can also be chosen."
     :type '(radio
-           (const :tag "Vundo (default)" undo-handler-vundo)
-           (const :tag "Undo-tree" undo-handler-undo-tree)
-           (const :tag "Built-in" undo-handler-built-in))
+             (const :tag "Vundo (default)" undo-handler-vundo)
+             (const :tag "Undo-tree" undo-handler-undo-tree)
+             (const :tag "Built-in" undo-handler-built-in))
     :group 'mifi-custom-features)
 
   (defcustom completion-handler 'comphand-vertico
@@ -456,10 +453,10 @@ These are features that basically have multiple-choice options instead of being 
   commands that are customised to make the best use of Ivy.  Swiper is an
   alternative to isearch that uses Ivy to show an overview of all matches."
     :type '(radio
-           (const :tag "Vertico completion system." comphand-vertico)
-           (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
-           (const :tag "Cofu completion systems" comphand-corfu)
-           (const :tag "Built-in Ido" comphand-built-in))
+             (const :tag "Vertico completion system." comphand-vertico)
+             (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
+             (const :tag "Cofu completion systems" comphand-corfu)
+             (const :tag "Built-in Ido" comphand-built-in))
     :group 'mifi-custom-features)
 
   (defcustom debug-adapter 'debug-adapter-dape
@@ -473,8 +470,8 @@ These are features that basically have multiple-choice options instead of being 
   with DAPE. DAPE supports most popular languages, however, not as many as
   dap-mode."
     :type '(radio
-           (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
-           (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
+             (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
+             (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
     :group 'mifi-custom-features)
 
   (defcustom custom-ide 'custom-ide-eglot
@@ -494,11 +491,11 @@ These are features that basically have multiple-choice options instead of being 
   Anaconda-mode is another IDE for Python very much like Elpy. It is not as
   configurable but has a host of great feaures that just work."
     :type '(radio
-           (const :tag "Elpy: Emacs Lisp Python Environment" custom-ide-elpy)
-           (const :tag "Emacs Polyglot (Eglot)" custom-ide-eglot)
-           (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
-           (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
-           (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
+             (const :tag "Elpy: Emacs Lisp Python Environment" custom-ide-elpy)
+             (const :tag "Emacs Polyglot (Eglot)" custom-ide-eglot)
+             (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
+             (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
+             (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
     :group 'mifi-custom-features)
 
   (defcustom custom-project-handler 'custom-project-project
@@ -620,15 +617,15 @@ Look for a proportional font that is available on the OS. If the actual default 
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (defun mifi/validate-variable-pitch-font ()
     (let* ((variable-pitch-font
              (cond
-             ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
-             ((x-list-fonts "SF Pro")           "SF Pro")
-             ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
-             ((x-list-fonts "Ubuntu")           "Ubuntu")
-             ((x-list-fonts "Helvetica")        "Helvetica")
+               ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
+               ((x-list-fonts "SF Pro")           "SF Pro")
+               ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
+               ((x-list-fonts "Ubuntu")           "Ubuntu")
+               ((x-list-fonts "Helvetica")        "Helvetica")
                ((x-list-fonts "Source Sans Pro")  "Source Sans Pro")
                ((x-list-fonts "Lucida Grande")    "Lucida Grande")
                ((x-list-fonts "Verdana")          "Verdana")
@@ -636,7 +633,7 @@ Look for a proportional font that is available on the OS. If the actual default 
                (nil (warn "Cannot find a Sans Serif Font.  Install Source Sans Pro.")))))
       (if variable-pitch-font
         (when (not (equal variable-pitch-font variable-pitch-font-family))
-        (setq variable-pitch-font-family variable-pitch-font))
+          (setq variable-pitch-font-family variable-pitch-font))
         (message "---- Can't find a variable-pitch font to use.")))
 
     (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
@@ -649,21 +646,21 @@ Look for a proportional font that is available on the OS. If the actual default 
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (defun mifi/validate-monospace-font ()
     (let* ((monospace-font
              (cond
-             ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
-             ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
-             ((x-list-fonts "Fira Code")         "Fira Code")
-             ((x-list-fonts "Source Code Pro")   "Source Code Pro")
-             ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
+               ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
+               ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
+               ((x-list-fonts "Fira Code")         "Fira Code")
+               ((x-list-fonts "Source Code Pro")   "Source Code Pro")
+               ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
                ((x-family-fonts "Monospaced")      "Monospaced")
                (nil (warn "Cannot find a monospaced Font.  Install Source Code Pro.")))))
       (if monospace-font
         (when (not (equal monospace-font variable-pitch-font-family))
-        (setq mono-spaced-font-family monospace-font)
-        (setq default-font-family monospace-font))
+          (setq mono-spaced-font-family monospace-font)
+          (setq default-font-family monospace-font))
         (message "---- Can't find a monospace font to use.")))
 
     (message (format ">>> monospace font is %s" mono-spaced-font-family)))
@@ -735,11 +732,11 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
       ;; Add every non-hidden subdir of PARENT-DIR to `load-path'.
       (let ((default-directory site-lisp-dir))
         (setq load-path
-            (append
-             (cl-remove-if-not
+          (append
+            (cl-remove-if-not
               #'file-directory-p
-               (directory-files (expand-file-name site-lisp-dir) t "^[^\\.]"))
-              load-path)))))
+              (directory-files (expand-file-name site-lisp-dir) t "^[^\\.]"))
+            load-path)))))
 
 #+end_src
 
@@ -771,9 +768,9 @@ These are global variables that effect the behavior of Emacs in general.
     fill-column 79             ;; Default line limit for fills
     ;; Triggers project for directories with any of the following files:
     project-vc-extra-root-markers '(".dir-locals.el"
-                                   "requirements.txt"
-                                   "Gemfile"
-                                   "package.json"))
+                                     "requirements.txt"
+                                     "Gemfile"
+                                     "package.json"))
 
 #+end_src
 
@@ -789,9 +786,9 @@ Keeps a persistent history file across Emacs restarts. It's also saved into the 
   (setq history-delete-duplicates t)
   (setq savehist-save-minibuffer-history 1)
   (setq savehist-additional-variables
-        '(kill-ring
-          search-ring
-          regexp-search-ring))
+    '(kill-ring
+       search-ring
+       regexp-search-ring))
 
 #+end_src
 
@@ -850,7 +847,7 @@ These functions will save and restore Emacs framework. These are normally called
         (insert (format
                   "(setq desktop-saved-frameset %S)"
                   desktop-saved-frameset)))))
-  
+
   (add-hook 'kill-emacs-hook 'mifi/save-desktop-frameset)
 
   ;;; ##########################################################################
@@ -861,14 +858,14 @@ These functions will save and restore Emacs framework. These are normally called
         ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
         (desktop-save-mode 0)
         (if (file-exists-p file)
-        (progn
-          (load file)
-          (desktop-restore-frameset)
-          (when (featurep 'spacious-padding)
+          (progn
+            (load file)
+            (desktop-restore-frameset)
+            (when (featurep 'spacious-padding)
               (when spacious-padding-mode
                 (spacious-padding-mode 0)
                 (spacious-padding-mode 1))))
-        (use-medium-display-font t)))))
+          (use-medium-display-font t)))))
 
 #+end_src
 
@@ -956,7 +953,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
   (use-package dumb-jump
     :config
     (add-hook 'xref-backend-functions #'dumb-jump-xref-activate))
-  
+
 #+end_src
 
 ** Which Key
@@ -987,9 +984,9 @@ Multiple cursors for Emacs. This is some pretty crazy functionality, so yes, the
 
   (use-package multiple-cursors
     :bind (("C-S-c C-S-c" . mc/edit-lines)
-          ("C->" . mc/mark-next-like-this)
-          ("C-<" . mc/mark-previous-like-this)
-          ("C-c C-<" . mc/mark-all-like-this)))
+            ("C->" . mc/mark-next-like-this)
+            ("C-<" . mc/mark-previous-like-this)
+            ("C-c C-<" . mc/mark-all-like-this)))
 
 #+end_src
 
@@ -1014,7 +1011,7 @@ anzu.el is an Emacs port of anzu.vim. anzu.el provides a minor mode which displa
       [remap isearch-query-replace]  #'anzu-isearch-query-replace)
     (define-key isearch-mode-map
       [remap isearch-query-replace-regexp] #'anzu-isearch-query-replace-regexp))
-  
+
 #+end_src
 
 ** Visual Fill
@@ -1032,7 +1029,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package default-text-scale
     :hook (elpaca-after-init . default-text-scale-mode))
 
@@ -1046,10 +1043,10 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
   ;; Macintosh specific configurations.
   (when *is-a-mac*
     (setq mac-command-modifier       'meta
-          mac-option-modifier         nil
-          mac-control-modifier       'control
-          mac-right-command-modifier 'super
-          mac-right-control-modifier 'hyper))
+      mac-option-modifier         nil
+      mac-control-modifier       'control
+      mac-right-command-modifier 'super
+      mac-right-control-modifier 'hyper))
 
 #+end_src
 
@@ -1066,10 +1063,10 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
     ;; We display [CRM<separator>], e.g., [CRM,] if the separator is a comma.
     (defun crm-indicator (args)
       (cons (format "[CRM%s] %s"
-            (replace-regexp-in-string
-              "\\`\\[.*?]\\*\\|\\[.*?]\\*\\'" ""
-              crm-separator)
-            (car args))
+              (replace-regexp-in-string
+                "\\`\\[.*?]\\*\\|\\[.*?]\\*\\'" ""
+                crm-separator)
+              (car args))
         (cdr args)))
     (advice-add #'completing-read-multiple :filter-args #'crm-indicator)
 
@@ -1180,7 +1177,7 @@ These are useful snippets of code that are commonly used in various languages. Y
 
   (use-package yasnippet
     :bind (:map yas-minor-mode-map
-          ("<C-'>" . yas-expand))
+            ("<C-'>" . yas-expand))
     :config
     (setq yas-global-mode t)
     (setq yas-minor-mode t)
@@ -1239,15 +1236,15 @@ Features:
   (use-package auto-complete)
 
   (defvar ac-directory (unless (file-exists-p "auto-complete")
-                       (make-directory "auto-complete")))
+                         (make-directory "auto-complete")))
   (add-to-list 'load-path ac-directory)
 
   (global-auto-complete-mode 1)
   (setq-default ac-sources '(ac-source-pycomplete
-                            ac-source-yasnippet
-                            ac-source-abbrev
-                            ac-source-dictionary
-                            ac-source-words-in-same-mode-buffers))
+                              ac-source-yasnippet
+                              ac-source-abbrev
+                              ac-source-dictionary
+                              ac-source-words-in-same-mode-buffers))
 
   (ac-set-trigger-key "TAB")
   (ac-set-trigger-key "<tab>")
@@ -1337,7 +1334,7 @@ Jinx requires the library ~libenchant~ or ~enchant~ installed. This can be done 
     :ensure (:host github :repo "minad/jinx")
     ;;:hook (emacs-startup . global-jinx-mode)
     :bind (("C-c C-$" . jinx-correct)
-           ("C-x C-$" . jinx-languages))
+            ("C-x C-$" . jinx-languages))
     :config
     (dolist (hook '(text-mode-hook prog-mode-hook org-mode-hook))
       (add-hook hook #'jinx-mode)))
@@ -1370,7 +1367,7 @@ These are packages located in the ~"lisp"~ directory within the emacs-config-dir
   ;;; ##########################################################################
   ;; These are packages located in the site-lisp or lisp directories in the
   ;; 'emacs-config-directory'
-  
+
 
 #+end_src
 
@@ -1411,7 +1408,7 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
   (defun undo-tree-split-side-by-side (original-function &rest args)
     "Split undo-tree side-by-side"
     (let ((split-height-threshold nil)
-         (split-width-threshold 0))
+           (split-width-threshold 0))
       (apply original-function args)))
 
   ;;; ##########################################################################
@@ -1460,7 +1457,7 @@ TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package prescient)
 
 #+end_src
@@ -1612,13 +1609,13 @@ Counsel takes this further, providing versions of common Emacs commands that are
     (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
     ;; Optionally use TAB for cycling, default is `corfu-complete'.
     :bind (:map corfu-map
-          ("M-SPC"          . corfu-insert-separator)
-          ("TAB"            . corfu-next)
-          ([tab]            . corfu-next)
-          ("S-TAB"          . corfu-previous)
-          ([backtab]    . corfu-previous)
-          ("S-<return>" . corfu-insert)
-          ("RET"            . nil))
+            ("M-SPC"          . corfu-insert-separator)
+            ("TAB"            . corfu-next)
+            ([tab]            . corfu-next)
+            ("S-TAB"          . corfu-previous)
+            ([backtab]    . corfu-previous)
+            ("S-<return>" . corfu-insert)
+            ("RET"            . nil))
     :init
     (global-corfu-mode)
     (corfu-history-mode)
@@ -1626,10 +1623,10 @@ Counsel takes this further, providing versions of common Emacs commands that are
     :config
     (add-hook 'eshell-mode-hook
       (lambda () (setq-local corfu-quit-at-boundary t
-                 corfu-quit-no-match t
-                 corfu-auto nil)
+                   corfu-quit-no-match t
+                   corfu-auto nil)
         (corfu-mode))))
-  
+
 #+end_src
 
 **** Cape Configuration
@@ -1684,7 +1681,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package corfu-prescient
     :when (equal completion-handler 'comphand-corfu)
     :after (corfu prescient))
@@ -1713,9 +1710,9 @@ Counsel takes this further, providing versions of common Emacs commands that are
     ;; :bind ("C-x C-f" . ido-find-file)
     ;; Clean up file path when typing
     :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
-          ;; Make sure vertico state is saved
-          (minibuffer-setup . vertico-repeat-save)))
-  
+            ;; Make sure vertico state is saved
+            (minibuffer-setup . vertico-repeat-save)))
+
 #+end_src
 
 **** Marginalia
@@ -1734,7 +1731,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
     (marginalia-annotators '(marginalia-annotators-heavy marginalia-annotators-light nil))
     :config
     (marginalia-mode t))
-  
+
 #+end_src
 
 **** Icons for Marginalia
@@ -1797,9 +1794,9 @@ Consult provides search and navigation commands based on the Emacs completion fu
       '(consult--source-hidden-buffer 
          consult--source-buffer
          (:name "Ephemeral" :state consult--buffer-state
-         :narrow 109 :category buffer
-         :items ("*Messages*"  "*scratch*" "*vterm*"
-                  "*Async-native-compile-log*" "*dashboard*"))
+           :narrow 109 :category buffer
+           :items ("*Messages*"  "*scratch*" "*vterm*"
+                    "*Async-native-compile-log*" "*dashboard*"))
          consult--source-modified-buffer
          consult--source-recent-file)))
 
@@ -1813,7 +1810,7 @@ Consult provides search and navigation commands based on the Emacs completion fu
   (use-package vertico-prescient
     :when (equal completion-handler 'comphand-vertico)
     :after vertico prescient)
-  
+
 #+end_src
 
 vertico-posframe is an vertico extension, which lets vertico use posframe to show its candidate menu.
@@ -1840,7 +1837,7 @@ vertico-posframe is an vertico extension, which lets vertico use posframe to sho
     (setq vertico-posframe-parameters
       '((left-fringe . 8)
          (right-fringe . 8))))
-  
+
 #+end_src
 
 *** Built-In (Ido)
@@ -1916,7 +1913,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 
   ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
   ;; features. They actually collide.
-  
+
   (use-package company
     :unless (equal custom-ide 'custom-ide-lsp-bridge)
     :custom
@@ -2027,7 +2024,7 @@ The =eterm-256color= package enhances the output of =term-mode= to enable handli
 
   (use-package eterm-256color
     :hook (term-mode . eterm-256color-mode))
-  
+
 #+end_src
 
 *** vterm
@@ -2169,10 +2166,10 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 #+begin_src emacs-lisp
   ;;; ##########################################################################
 
-    ;; Prefer g-prefixed coreutils version of standard utilities when available
+  ;; Prefer g-prefixed coreutils version of standard utilities when available
   (let ((gls (executable-find "gls")))
     (when gls (setq-default insert-directory-program gls
-              dired-use-ls-dired t
+                dired-use-ls-dired t
                 ;; Needed to fix an issue on Mac which causes dired to fail
                 dired-listing-switches "-al --group-directories-first")))
 
@@ -2186,7 +2183,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
     ;; Doesn't work as expected!
     ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
     (setq dired-open-extensions '(("png" . "feh")
-                                 ("mkv" . "mpv"))))
+                                   ("mkv" . "mpv"))))
 
   (use-package dired-hide-dotfiles
     :after dired-mode
@@ -2261,8 +2258,8 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
       treemacs-no-delete-other-windows   t
       treemacs-project-follow-cleanup            nil
       treemacs-persist-file                      (expand-file-name
-                                                     ".cache/treemacs-persist"
-                                                     user-emacs-directory)
+                                                   ".cache/treemacs-persist"
+                                                   user-emacs-directory)
       treemacs-position                  'left
       treemacs-read-string-input                 'from-child-frame
       treemacs-recenter-distance                 0.1
@@ -2271,9 +2268,9 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
       treemacs-recenter-after-project-jump       'always
       treemacs-recenter-after-project-expand     'on-distance
       treemacs-litter-directories                '("/node_modules"
-                                              "/.venv"
-                                              "/.cask"
-                                              "/__pycache__")
+                                                    "/.venv"
+                                                    "/.cask"
+                                                    "/__pycache__")
       treemacs-project-follow-into-home  nil
       treemacs-show-cursor                       nil
       treemacs-show-hidden-files                 t
@@ -2414,11 +2411,11 @@ This is the main function that allows cycling (up or down) through the list of t
     (when (not (eq theme-cycle-step nil))
       (let ((step theme-cycle-step) (result 0))
         (when step
-        (setq result (+ step theme-selector))
-        (when (< result 0)
-          (setq result (- (length theme-list) 1)))
-        (when (> result (- (length theme-list) 1))
-          (setq result 0)))
+          (setq result (+ step theme-selector))
+          (when (< result 0)
+            (setq result (- (length theme-list) 1)))
+          (when (> result (- (length theme-list) 1))
+            (setq result 0)))
         (setq-default theme-selector result))))
 
   ;; This is used to trigger the cycling of the theme-selector
@@ -2460,7 +2457,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (defun mifi/print-custom-theme-name ()
     "Print the current loaded theme from the `theme-list' on the modeline."
     (interactive)
@@ -2580,14 +2577,14 @@ This includes the theme to use in both graphical and non-graphical.
     (progn
       (if (not elpaca-after-init-time)
         (add-hook 'elpaca-after-init-hook
-        (lambda ()
-          (unless theme-did-load
-            (mifi/load-theme-from-selector))))
+          (lambda ()
+            (unless theme-did-load
+              (mifi/load-theme-from-selector))))
         ;; else
         (add-hook 'window-setup-hook
-        (lambda ()
-          (unless theme-did-load
-            (mifi/load-theme-from-selector))))
+          (lambda ()
+            (unless theme-did-load
+              (mifi/load-theme-from-selector))))
         )))
 
 #+end_src
@@ -2645,7 +2642,7 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
     :config
     (dolist (face '(org-date org-priority org-special-keyword org-tag))
       (add-to-list 'mixed-pitch-fixed-pitch-faces face)))
-    
+
 #+end_src
 
 *** Functions to set the frame size
@@ -2737,9 +2734,9 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
       (when (display-graphic-p)
         (mifi/update-face-attribute)
         (unless (daemonp)
-        (if enable-frameset-restore
+          (if enable-frameset-restore
             (mifi/restore-desktop-frameset)
-          (mifi/frame-recenter)))
+            (mifi/frame-recenter)))
         )))
 
 #+end_src
@@ -2774,27 +2771,27 @@ This little function toggles between a larger font size and the default font siz
     (cond
       ((equal mifi/font-size-slot 3)
         (setq custom-default-font-size mifi/x-large-font-size
-              custom-default-mono-font-size mifi/x-large-mono-font-size
-              mifi/default-variable-font-size (+ custom-default-font-size 20)
-              mifi/font-size-slot 2)
+          custom-default-mono-font-size mifi/x-large-mono-font-size
+          mifi/default-variable-font-size (+ custom-default-font-size 20)
+          mifi/font-size-slot 2)
         (mifi/update-face-attribute))
       ((equal mifi/font-size-slot 2)
         (setq custom-default-font-size mifi/large-font-size
-              custom-default-mono-font-size mifi/large-mono-font-size
-              mifi/default-variable-font-size (+ custom-default-font-size 20)
-              mifi/font-size-slot 1)
+          custom-default-mono-font-size mifi/large-mono-font-size
+          mifi/default-variable-font-size (+ custom-default-font-size 20)
+          mifi/font-size-slot 1)
         (mifi/update-face-attribute))
       ((equal mifi/font-size-slot 1)
         (setq custom-default-font-size mifi/medium-font-size
-              custom-default-mono-font-size mifi/medium-mono-font-size
-              mifi/default-variable-font-size (+ custom-default-font-size 20)
-              mifi/font-size-slot 0)
+          custom-default-mono-font-size mifi/medium-mono-font-size
+          mifi/default-variable-font-size (+ custom-default-font-size 20)
+          mifi/font-size-slot 0)
         (mifi/update-face-attribute))
       ((equal mifi/font-size-slot 0)
         (setq custom-default-font-size mifi/small-font-size
-              custom-default-mono-font-size mifi/small-mono-font-size
-              mifi/default-variable-font-size (+ custom-default-font-size 20)
-              mifi/font-size-slot 3)
+          custom-default-mono-font-size mifi/small-mono-font-size
+          mifi/default-variable-font-size (+ custom-default-font-size 20)
+          mifi/font-size-slot 3)
         (mifi/update-face-attribute))))
 
 #+end_src
@@ -2824,7 +2821,7 @@ Some key kindings to switch to different screen resolutions.
     (which-key-add-key-based-replacements "C-S-c 2" "recenter-with-medium-font")
     (which-key-add-key-based-replacements "C-S-c 3" "recenter-with-large-font")
     (which-key-add-key-based-replacements "C-S-c 4" "recenter-with-x-large-font")
-  )
+    )
 
 #+end_src
 
@@ -2845,7 +2842,7 @@ These functions are used to configure the main frame font size. Based upon a mon
       (mifi/frame-recenter)
       ;;else
       (unless enable-frameset-restore (mifi/frame-recenter))))
-  
+
 #+end_src
 
 ***** Select Display Font and optionally Recenter
@@ -2877,7 +2874,7 @@ These functions resize the font to some pre-defined values and will optiononally
     (interactive)
     (mifi/set-frame-font 3)
     (mifi/should-recenter force-recenter))
-  
+
 #+end_src
 
 ***** Early Display Resize
@@ -2891,8 +2888,8 @@ Apply saved font/window-size early in the startup process.
     (add-hook 'elpaca-after-init-hook
       (lambda ()
         (progn
-        (mifi/update-face-attribute)
-        (unless (daemonp)
+          (mifi/update-face-attribute)
+          (unless (daemonp)
             (unless enable-frameset-restore (mifi/frame-recenter))))
         )))
 #+end_src
@@ -3111,31 +3108,31 @@ This section contains the basic configuration for =org-mode= plus the configurat
     (setq org-capture-templates
       `(("t" "Tasks / Projects")
          ("tt" "Task" entry (file+olp "~/Projects/Code/emacs-from-scratch/OrgFiles/Tasks.org" "Inbox")
-         "* TODO %?\n  %U\n  %a\n        %i" :empty-lines 1)
+           "* TODO %?\n  %U\n  %a\n        %i" :empty-lines 1)
 
          ("j" "Journal Entries")
          ("jj" "Journal" entry
-         (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-         "\n* %<%I:%M %p> - Journal :journal:\n\n%?\n\n"
-         ;; ,(dw/read-file-as-string "~/Notes/Templates/Daily.org")
-         :clock-in :clock-resume
-         :empty-lines 1)
+           (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+           "\n* %<%I:%M %p> - Journal :journal:\n\n%?\n\n"
+           ;; ,(dw/read-file-as-string "~/Notes/Templates/Daily.org")
+           :clock-in :clock-resume
+           :empty-lines 1)
          ("jm" "Meeting" entry
-         (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-         "* %<%I:%M %p> - %a :meetings:\n\n%?\n\n"
-         :clock-in :clock-resume
-         :empty-lines 1)
+           (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+           "* %<%I:%M %p> - %a :meetings:\n\n%?\n\n"
+           :clock-in :clock-resume
+           :empty-lines 1)
 
          ("w" "Workflows")
          ("we" "Checking Email" entry (file+olp+datetree
-                                      "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-         "* Checking Email :email:\n\n%?" :clock-in :clock-resume :empty-lines 1)
+                                        "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+           "* Checking Email :email:\n\n%?" :clock-in :clock-resume :empty-lines 1)
 
          ("m" "Metrics Capture")
          ("mw" "Weight" table-line (file+headline
-                                   "~/Projects/Code/emacs-from-scratch/OrgFiles/Metrics.org"
-                                   "Weight")
-         "| %U | %^{Weight} | %^{Notes} |" :kill-buffer t))))
+                                     "~/Projects/Code/emacs-from-scratch/OrgFiles/Metrics.org"
+                                     "Weight")
+           "| %U | %^{Weight} | %^{Notes} |" :kill-buffer t))))
 
 #+end_src
 
@@ -3169,19 +3166,19 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+begin_src emacs-lisp
 
   (custom-theme-set-faces
-   'user
-   '(org-block ((t (:inherit fixed-pitch))))
-   '(org-code ((t (:inherit (shadow fixed-pitch)))))
-   '(org-document-info ((t (:foreground "dark orange"))))
-   '(org-document-info-keyword ((t (:inherit (shadow fixed-pitch)))))
-   '(org-indent ((t (:inherit (org-hide fixed-pitch)))))
-   '(org-link ((t (:foreground "royal blue" :underline t))))
-   '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
-   '(org-property-value ((t (:inherit fixed-pitch))) t)
-   '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
-   '(org-table ((t (:inherit fixed-pitch :foreground "#83a598"))))
-   '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
-   '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
+    'user
+    '(org-block ((t (:inherit fixed-pitch))))
+    '(org-code ((t (:inherit (shadow fixed-pitch)))))
+    '(org-document-info ((t (:foreground "dark orange"))))
+    '(org-document-info-keyword ((t (:inherit (shadow fixed-pitch)))))
+    '(org-indent ((t (:inherit (org-hide fixed-pitch)))))
+    '(org-link ((t (:foreground "royal blue" :underline t))))
+    '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+    '(org-property-value ((t (:inherit fixed-pitch))) t)
+    '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+    '(org-table ((t (:inherit fixed-pitch :foreground "#83a598"))))
+    '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
+    '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
 
 #+end_src
 
@@ -3242,36 +3239,36 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+begin_src emacs-lisp :tangle no
     ;;; ##########################################################################
 
-    (use-package org-superstar
-      :after org
-      :custom
-      (org-superstar-leading-bullet " ")
-      (org-superstar-special-todo-items t)
-      (org-superstar-todo-bullet-alist '( ("TODO" . 9744)
-                                      ("INPROG-TODO" . 9744)
-                                      ("HW" . 9744)
-                                      ("STUDY" . 9744)
-                                      ("SOMEDAY" . 9744)
-                                      ("READ" . 9744)
-                                      ("PROJ" . 9744)
-                                      ("CONTACT" . 9744)
-                                      ("DONE" . 9745)))
-      ;; (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
-      :hook (org-mode . org-superstar-mode))
+  (use-package org-superstar
+    :after org
+    :custom
+    (org-superstar-leading-bullet " ")
+    (org-superstar-special-todo-items t)
+    (org-superstar-todo-bullet-alist '( ("TODO" . 9744)
+                                        ("INPROG-TODO" . 9744)
+                                        ("HW" . 9744)
+                                        ("STUDY" . 9744)
+                                        ("SOMEDAY" . 9744)
+                                        ("READ" . 9744)
+                                        ("PROJ" . 9744)
+                                        ("CONTACT" . 9744)
+                                        ("DONE" . 9745)))
+    ;; (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
+    :hook (org-mode . org-superstar-mode))
 
-    (use-package org-appear
-      :init
-      (setq org-hide-emphasis-markers t)
-      (setq org-appear-autoemphasis t) ;; Enable org-appear on emphasis
-      (setq org-appear-autolinks t) ;; Enable on links
-      (setq org-appear-autosubmarkers t) ;; Enable on sub and superscript
-      :commands (org-appear-mode)
-      :hook (or-mode . org-appear-mode))
+  (use-package org-appear
+    :init
+    (setq org-hide-emphasis-markers t)
+    (setq org-appear-autoemphasis t) ;; Enable org-appear on emphasis
+    (setq org-appear-autolinks t) ;; Enable on links
+    (setq org-appear-autosubmarkers t) ;; Enable on sub and superscript
+    :commands (org-appear-mode)
+    :hook (or-mode . org-appear-mode))
 
   ;; Automatically change bullet type when indenting
   ;; Ex: indenting a + makes the bullet a *.
   (setq org-list-demote-modify-bullet
-  '(("+" ・ "*"）（"*" ・ "-"）（"-" . "+")))
+    '(("+" ・ "*"）（"*" ・ "-"）（"-" . "+")))
 
 #+end_src
 
@@ -3286,27 +3283,27 @@ To execute or export code in =org-mode= code blocks, you'll need to set up =org-
       'org-babel-load-languages
       (seq-filter
         (lambda (pair)
-        (locate-library (concat "ob-" (symbol-name (car pair)))))
+          (locate-library (concat "ob-" (symbol-name (car pair)))))
         '((emacs-lisp . t)
-         (ditaa . t)
-         (dot . t)
-         (emacs-lisp . t)
-         (gnuplot . t)
-         (haskell . nil)
-         (latex . t)
-         (ledger . t)
-         (ocaml . nil)
-         (octave . t)
-         (plantuml . t)
-         (python . t)
-         (ruby . t)
-         (screen . nil)
-         (sh . t) ;; obsolete
-         (shell . t)
-         (sql . t)
-         (sqlite . t))))
+           (ditaa . t)
+           (dot . t)
+           (emacs-lisp . t)
+           (gnuplot . t)
+           (haskell . nil)
+           (latex . t)
+           (ledger . t)
+           (ocaml . nil)
+           (octave . t)
+           (plantuml . t)
+           (python . t)
+           (ruby . t)
+           (screen . nil)
+           (sh . t) ;; obsolete
+           (shell . t)
+           (sql . t)
+           (sqlite . t))))
     (push '("conf-unix" . conf-unix) org-src-lang-modes))
-  
+
 #+end_src
 
 *** Structure Templates
@@ -3354,8 +3351,8 @@ Note that org-modern is a full replacement for both org-superstar and org-bullet
       '((right-divider-width . 40)
          (internal-border-width . 40)))
     (dolist (face '(window-divider
-                   window-divider-first-pixel
-                   window-divider-last-pixel))
+                     window-divider-first-pixel
+                     window-divider-last-pixel))
       (face-spec-reset-face face)
       (set-face-foreground face (face-attribute 'default :background nil)))
     (set-face-background 'fringe (face-attribute 'default :background nil))
@@ -3404,7 +3401,7 @@ Org Roam solves these problems by making it easy to create topic-focused Org Fil
 
   (use-package emacsql :demand t :ensure t :after org)
   (use-package emacsql-sqlite :demand t :ensure t :after org)
-   
+
 #+end_src
 
 **** Org Agenda from Roam Notes
@@ -3471,11 +3468,11 @@ This means that we can automatically create a new note with our project capture 
       (mifi/org-roam-filter-by-tag "Project")
       :templates
       '(("p" "project" plain "* Goals\n\n%?\n\n* Tasks\n\n** TODO Add initial tasks\n\n* Dates\n\n"
-        :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" "#+title: ${title}\n#+category: ${title}\n#+filetags: Project")
-        :unnarrowed t))))
+          :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" "#+title: ${title}\n#+category: ${title}\n#+filetags: Project")
+          :unnarrowed t))))
 
   ;; (global-set-key (kbd "C-c n p") #'mifi/org-roam-find-project)
-  
+
 #+end_src
 
 **** Keep and inbox of notes and tasks
@@ -3489,21 +3486,21 @@ Even though this file won’t have the timestamped filename, it will still be tr
     (interactive)
     (org-roam-capture- :node (org-roam-node-create)
       :templates '(("i" "inbox" plain "* %?"
-                   :if-new (file+head "Inbox.org" "#+title: Inbox\n")))))
-  
+                     :if-new (file+head "Inbox.org" "#+title: Inbox\n")))))
+
 #+end_src
 
 **** Insert a node immediately
 
 #+begin_src emacs-lisp :tangle no
   ;;; ##########################################################################
-  
+
   (defun mifi/org-roam-node-insert-immediate (arg &rest args)
     (interactive "P")
     (let ((args (push arg args))
-         (org-roam-capture-templates
-           (list (append (car org-roam-capture-templates)
-                   '(:immediate-finish t)))))
+           (org-roam-capture-templates
+             (list (append (car org-roam-capture-templates)
+                     '(:immediate-finish t)))))
       (apply #'org-roam-node-insert args)))
 #+end_src
 
@@ -3522,12 +3519,12 @@ Much like the example before, we can either select a project that exists or auto
 
     ;; Capture the new task, creating the project file if necessary
     (org-roam-capture- :node (org-roam-node-read nil
-                             (mifi/org-roam-filter-by-tag "Project"))
+                               (mifi/org-roam-filter-by-tag "Project"))
       :templates '(("p" "project" plain "** TODO %?"
-                   :if-new
-                   (file+head+olp "%<%Y%m%d%H%M%S>-${slug}.org"
-                     "#+title: ${title}\n#+category: ${title}\n#+filetags: Project"
-                     ("Tasks"))))))
+                     :if-new
+                     (file+head+olp "%<%Y%m%d%H%M%S>-${slug}.org"
+                       "#+title: ${title}\n#+category: ${title}\n#+filetags: Project"
+                       ("Tasks"))))))
 #+end_src
 
 **** Todo
@@ -3539,11 +3536,11 @@ The following snippet sets up a hook for all Org task state changes and then cop
   (defun mifi/org-roam-copy-todo-to-today ()
     (interactive)
     (let ((org-refile-keep t) ;; Set this to nil to delete the original!
-         (org-roam-dailies-capture-templates
-           '(("t" "tasks" entry "%?"
-               :if-new (file+head+olp "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d>\n" ("Tasks")))))
-         (org-after-refile-insert-hook #'save-buffer)
-         today-file pos)
+           (org-roam-dailies-capture-templates
+             '(("t" "tasks" entry "%?"
+                 :if-new (file+head+olp "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d>\n" ("Tasks")))))
+           (org-after-refile-insert-hook #'save-buffer)
+           today-file pos)
       (save-window-excursion
         (org-roam-dailies--capture (current-time) t)
         (setq today-file (buffer-file-name))
@@ -3551,7 +3548,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
       ;; Only refile if the target file is different than the current file
       (unless (equal (file-truename today-file)
-              (file-truename (buffer-file-name)))
+                (file-truename (buffer-file-name)))
         (org-refile nil nil (list "Tasks" today-file nil pos)))))
 
 #+end_src
@@ -3559,14 +3556,14 @@ The following snippet sets up a hook for all Org task state changes and then cop
 **** Table-of-contents
 #+begin_src emacs-lisp :tangle no
   ;;; ##########################################################################
-  
+
   (use-package toc-org
     :after org markdown-mode
     :hook
     (org-mode . toc-org-mode)
     (markdown-mode-hook . toc-org-mode)
     :bind (:map markdown-mode-map
-          ("C-c C-o" . toc-org-markdown-follow-thing-at-point)))
+            ("C-c C-o" . toc-org-markdown-follow-thing-at-point)))
 
 #+end_src
 
@@ -3574,7 +3571,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 #+begin_src emacs-lisp :tangle no
   ;;; ##########################################################################
-  
+
   (use-package org-roam
     ;; :demand t  ;; Ensure org-roam is loaded by default
     :defer t
@@ -3588,17 +3585,17 @@ The following snippet sets up a hook for all Org task state changes and then cop
     (org-roam-directory (expand-file-name "org-roam-notes" user-emacs-directory))
     (org-roam-completion-everywhere t)
     :bind ( ("C-c n l" . org-roam-buffer-toggle)
-          ("C-c n f" . org-roam-node-find)
-          ("C-c n i" . org-roam-node-insert)
-          ("C-c n I" . mifi/org-roam-node-insert-immediate)
-          ("C-c n p" . mifi/org-roam-find-project)
-          ("C-c n t" . mifi/org-roam-capture-task)
-          ("C-c n b" . mifi/org-roam-capture-inbox)
-          :map org-mode-map
-          ("C-M-i" . completion-at-point)
-          :map org-roam-dailies-map
-          ("Y" . org-roam-dailies-capture-yesterday)
-          ("T" . org-roam-dailies-capture-tomorrow))
+            ("C-c n f" . org-roam-node-find)
+            ("C-c n i" . org-roam-node-insert)
+            ("C-c n I" . mifi/org-roam-node-insert-immediate)
+            ("C-c n p" . mifi/org-roam-find-project)
+            ("C-c n t" . mifi/org-roam-capture-task)
+            ("C-c n b" . mifi/org-roam-capture-inbox)
+            :map org-mode-map
+            ("C-M-i" . completion-at-point)
+            :map org-roam-dailies-map
+            ("Y" . org-roam-dailies-capture-yesterday)
+            ("T" . org-roam-dailies-capture-tomorrow))
     :bind-keymap
     ("C-c n d" . org-roam-dailies-map)
     :config
@@ -3607,7 +3604,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
     (add-to-list 'org-after-todo-state-change-hook
       (lambda ()
         (when (equal org-state "DONE")
-        (mifi/org-roam-copy-todo-to-today))))
+          (mifi/org-roam-copy-todo-to-today))))
     (org-roam-db-autosync-mode))
 
 #+end_src
@@ -3628,7 +3625,6 @@ Org-transclusion lets you insert a copy of text content via a file link or ID li
     (define-key global-map (kbd "C-n t") #'org-transclusion-mode))
 
 #+end_src
-
 
 ** Denote
 
@@ -3691,7 +3687,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 #+begin_src  emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package denote
     :custom
     (denote-directory (expand-file-name "notes" user-emacs-directory))
@@ -3825,7 +3821,7 @@ The following are configured for Python development and provide an <<<IDE>>> typ
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package eglot
     :when (equal custom-ide 'custom-ide-eglot)
     ;; :ensure (:repo "https://github.com/emacs-mirror/emacs" :local-repo "eglot" :branch "master"
@@ -3893,7 +3889,7 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
         ("<tab>" . company-indent-or-complete-common)))
     (mifi/define-rust-lsp-values)
     (lsp-enable-which-key-integration t))
-  
+
 #+end_src
 
 *** LSP UI
@@ -3924,7 +3920,7 @@ This package contains all the higher level UI modules of lsp-mode, like flycheck
     :bind (:map lsp-ui-mode-map
             ("C-c l d" . lsp-ui-doc-focus-frame))
     :hook (lsp-mode . lsp-ui-mode))
-  
+
 #+end_src
 
 *** LSP Treemacs integration
@@ -3972,7 +3968,7 @@ This function is called from the lsp-mode-hook when enering or leaving LSP mode.
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (defun mifi/define-rust-lsp-values ()
     (setq-default lsp-rust-analyzer-cargo-watch-command "clippy")
     (setq-default lsp-eldoc-render-all t)
@@ -4014,8 +4010,8 @@ Advantages of lsp-bridge:
   (use-package lsp-bridge
     :when (equal custom-ide 'custom-ide-lsp-bridge)
     :ensure ( :host github :repo "manateelazycat/lsp-bridge"
-            :files (:defaults "*.el" "*.py" "acm" "core" "langserver"
-                     "multiserver" "resources") :build (:not compile))
+              :files (:defaults "*.el" "*.py" "acm" "core" "langserver"
+                       "multiserver" "resources") :build (:not compile))
     :custom
     (lsp-bridge-python-lsp-server "pylsp")
     :config
@@ -4026,7 +4022,7 @@ Advantages of lsp-bridge:
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package markdown-mode
     :when (equal custom-ide 'custom-ide-lsp-bridge))
 
@@ -4049,9 +4045,9 @@ Anaconda-mode provides Code navigation, documentation lookup and completion for 
   (use-package anaconda-mode
     :when (equal custom-ide 'custom-ide-anaconda)
     :bind (:map python-mode-map
-          ("C-c g o" . anaconda-mode-find-definitions-other-frame)
-          ("C-c g g" . anaconda-mode-find-definitions)
-          ("C-c C-x" . next-error))
+            ("C-c g o" . anaconda-mode-find-definitions-other-frame)
+            ("C-c g g" . anaconda-mode-find-definitions)
+            ("C-c C-x" . next-error))
     :config
     (which-key-add-key-based-replacements "C-c g o" "find-defitions-other-window")
     (which-key-add-key-based-replacements "C-c g g" "find-defitions")
@@ -4086,10 +4082,10 @@ C-c C-d displays documentation for the thing under cursor. The documentation wil
     (display-fill-column-indicator-mode 1)
     (highlight-indentation-mode nil)
     :bind (:map python-mode-map
-          ("C-c g a" . elpy-goto-assignment)
-          ("C-c g o" . elpy-goto-definition-other-window)
-          ("C-c g g" . elpy-goto-definition)
-          ("C-c g ?" . elpy-doc))
+            ("C-c g a" . elpy-goto-assignment)
+            ("C-c g o" . elpy-goto-definition-other-window)
+            ("C-c g g" . elpy-goto-definition)
+            ("C-c g ?" . elpy-doc))
     :config
     (use-package jedi)
     (use-package flycheck
@@ -4156,7 +4152,7 @@ Some functions that are used during the initialization of tree-sitter.
   (defun lsp-go-install-save-hooks ()
     (add-hook 'before-save-hook #'lsp-format-buffer t t)
     (add-hook 'before-save-hook #'lsp-organize-imports t t))
-  
+
 #+end_src
 
 **** The main Tree-sitter setup
@@ -4385,6 +4381,9 @@ autopep8 automatically formats Python code to conform to the `PEP 8` style guide
   (defalias 'quote-region
     (kmacro "C-w \" \" <left> C-y <right>"))
 
+  (defalias 'reformat-src-block
+    (kmacro "C-s b e g i n _ s r c SPC e m a c s - l i s p <return> <down> C-c ' C-x h C-c ] C-x h M-x u n t a b <return> C-c ' C-s e n d _ s r c <return> <down>"))
+
   (eval-after-load "python"
     #'(bind-keys :map python-mode-map
         ("C-c C-q" . quote-region)
@@ -4437,11 +4436,11 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
     (cond
       ((equal debug-adapter 'debug-adapter-dap-mode)
         (bind-keys :map typescript-mode-map
-        ("C-c ." . dap-hydra/body))
+          ("C-c ." . dap-hydra/body))
         (dap-node-setup))
       ((equal debug-adapter 'debug-adapter-dape)
         (bind-keys :map typescript-mode-map
-        ("C-c ." . dape-hydra/body)))))
+          ("C-c ." . dape-hydra/body)))))
 
 #+end_src
 
@@ -4480,8 +4479,8 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
   (use-package js2-mode
     :hook (js-mode . js2-minor-mode)
     :bind (:map js2-mode-map
-          ("{" . paredit-open-curly)
-          ("}" . paredit-close-curly-and-newline))
+            ("{" . paredit-open-curly)
+            ("}" . paredit-close-curly-and-newline))
     :mode ("\\.js\\'" "\\.mjs\\'" "\\.json$")
     :custom (js2-highlight-level 3))
 
@@ -4508,10 +4507,10 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
     (unless (file-exists-p "Makefile")
       (set (make-local-variable 'compile-command)
         (let ((file (file-name-nondirectory buffer-file-name)))
-        (format "%s -o %s %s"
-          (if  (equal (file-name-extension file) "cpp") "g++" "gcc" )
-          (file-name-sans-extension file)
-          file)))
+          (format "%s -o %s %s"
+            (if  (equal (file-name-extension file) "cpp") "g++" "gcc" )
+            (file-name-sans-extension file)
+            file)))
       (compile compile-command)))
 
   (global-set-key [f9] 'code-compile)
@@ -4648,12 +4647,12 @@ Much of this configuration was taken from the [[https://robert.kra.hn/posts/rust
     :defer t
     :after rust-mode
     :ensure (:fetcher github :repo "ayrat555/cargo-mode"
-            :files ("*.el" "*.el.in" "dir" "*.info" "*.texi"
-                     "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
-                     "doc/*.texinfo" "lisp/*.el"
-                     (:exclude ".dir-locals.el" "test.el" "tests.el"
-                       "*-test.el" "*-tests.el" "LICENSE" "README*"
-                       "*-pkg.el"))))
+              :files ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                       "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
+                       "doc/*.texinfo" "lisp/*.el"
+                       (:exclude ".dir-locals.el" "test.el" "tests.el"
+                         "*-test.el" "*-tests.el" "LICENSE" "README*"
+                         "*-pkg.el"))))
 
 #+end_src
 
@@ -4684,7 +4683,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
     :custom
     (compile-command "go build -v && go test -v && go vet")
     :bind (:map go-mode-map
-          ("C-c C-c" . 'compile))
+            ("C-c C-c" . 'compile))
     :config
     (eglot-format-buffer-on-save)
     (define-key (current-local-map) "\C-c\C-c" 'compile)
@@ -4694,7 +4693,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
         (add-hook 'go-mode-hook #'elot-format-buffer-on-save))
       ((equal custom-ide 'custom-ide-lsp)
         (add-hook 'go-mode-hook 'lsp-deferred))))
-  
+
 #+end_src
 
 *** go-eldoc config
@@ -4713,7 +4712,7 @@ for variable, functions and current argument position of function.
     (set-face-attribute 'eldoc-highlight-function-argument nil
       :underline t :foreground "green"
       :weight 'bold))
-  
+
 #+end_src
 
 *** go-guru config
@@ -4726,7 +4725,7 @@ Integration of the Go 'guru' analysis tool into Emacs.
   (use-package go-guru
     :after go-mode
     :hook (go-mode . go-guru-hl-identifier-mode))
-  
+
 #+end_src
 
 ** Other Languages
@@ -4851,7 +4850,7 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
     (bind-keys :map prog-mode-map
       ("C-c ." . dape-hydra/body))
     (mifi/additional-dape-configs))
-  
+
 #+end_src
 
 **** DAPE for TypeScript
@@ -4897,16 +4896,16 @@ This is meant to be evaluated and run once. Calling this function will clone the
     (with-eval-after-load
       (add-to-list 'dape-configs
         `(delve
-         modes (go-mode go-ts-mode)
-         command "dlv"
-         command-args ("dap" "--listen" "127.0.0.1:55878")
-         command-cwd dape-cwd-fn
-         host "127.0.0.1"
-         port 55878
-         :type "debug"  ;; needed to set the adapterID correctly as a string type
-         :request "launch"
-         :cwd dape-cwd-fn
-         :program dape-cwd-fn))))
+           modes (go-mode go-ts-mode)
+           command "dlv"
+           command-args ("dap" "--listen" "127.0.0.1:55878")
+           command-cwd dape-cwd-fn
+           host "127.0.0.1"
+           port 55878
+           :type "debug"  ;; needed to set the adapterID correctly as a string type
+           :request "launch"
+           :cwd dape-cwd-fn
+           :program dape-cwd-fn))))
 
 #+end_src
 
@@ -4929,7 +4928,7 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
     (interactive)
     (dape-breakpoint-remove-all)
     (mifi/dape-end-debug-session))
-  
+
 #+end_src
 
 ***** DAPE Hydra Definition
@@ -4978,7 +4977,7 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
       ("x" nil "exit Hydra" :color yellow)
       ("q" mifi/dape-end-debug-session "quit" :color blue)
       ("Q" mifi/dape-delete-all-debug-sessions :color red)))
-  
+
 #+end_src
 
 *** Debug Adapter Protocol (<<<DAP>>>)
@@ -5025,7 +5024,7 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
     :config
     (setq dap-python-executable "python3") ;; Otherwise it looks for 'python' else error.
     (setq dap-python-debugger 'debugpy))
-  
+
 #+end_src
 
 **** DAP Setup for Rust and Go :Rust:Go:
@@ -5065,8 +5064,8 @@ Something that is needed for Rust and Go debugging.
     :defer t
     :after dap-mode
     :ensure (:package "dap-cpptools" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode"))
-    ;; :config
-    ;; (dap-cpptools-setup))
+  ;; :config
+  ;; (dap-cpptools-setup))
 
 #+end_src
 
@@ -5084,7 +5083,7 @@ Something that is needed for Rust and Go debugging.
     :when (equal debug-adapter 'debug-adapter-dap-mode)
     :disabled
     :hook ((typescript-mode . mifi/setup-dap-node)
-          (js2-mode . mifi/setup-dap-node))
+            (js2-mode . mifi/setup-dap-node))
     ;;:ensure (:host github :repo "emacs-lsp/dap-mode" :files (:defaults "icons" "dap-mode-pkg.el"))
     :after dap-mode
     :config
@@ -5131,7 +5130,7 @@ Something that is needed for Rust and Go debugging.
         :program nil
         :request "launch"
         :name "Python :: Run file (buffer)")))
-  
+
 #+end_src
 
 **** DAP Hydra
@@ -5223,8 +5222,6 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 
 #+end_src
 
-z
-
 
 * Miscellaneous
 
@@ -5278,11 +5275,11 @@ The following packages are some additional quality of life features.
     :config
     ;; window on the right side
     (add-to-list 'display-buffer-alist '(,mw-thesaurus-buffer-name
-                                        (display-buffer-reuse-window
-                                          display-buffer-in-direction)
-                                        (direction . right)
-                                        (window . root)
-                                        (window-width . 0.3))))
+                                          (display-buffer-reuse-window
+                                            display-buffer-in-direction)
+                                          (direction . right)
+                                          (window . root)
+                                          (window-width . 0.3))))
 
 #+end_src
 
@@ -5293,7 +5290,7 @@ The following packages are some additional quality of life features.
   (use-package solaire-mode
     :after treemacs
     :ensure (:package "solaire-mode" :source "MELPA"
-           :repo "hlissner/emacs-solaire-mode" :fetcher github)
+              :repo "hlissner/emacs-solaire-mode" :fetcher github)
     :hook (elpaca-after-init . solaire-global-mode)
     :config
     (push '(treemacs-window-background-face . solaire-default-face) solaire-mode-remap-alist)
@@ -5314,35 +5311,36 @@ The following packages are some additional quality of life features.
     (golden-ratio-wide-adjust-factor .4)
     (golden-ratio-max-width 100)
     (golden-ratio-exclude-modes '(
-                                 prog-mode
-                                 dashboard-mode
-                                 ;;inferior-emacs-lisp-mode
-                                 ;;inferior-python-mode
-                                 comint-mode
-                                 ;;lisp-interaction-mode
-                                 treemacs-mode
-                                 undo-tree-visualizer-mode
-                                 vundo-mode
-                                 ))
+                                   prog-mode
+                                   dashboard-mode
+                                   ;;inferior-emacs-lisp-mode
+                                   ;;inferior-python-mode
+                                   comint-mode
+                                   ;;lisp-interaction-mode
+                                   treemacs-mode
+                                   undo-tree-visualizer-mode
+                                   vundo-mode
+                                   ))
     (golden-ratio-exclude-buffer-regexp '("dap*"
-                                         "*dape*"
-                                         "*python*"))
+                                           "*dape*"
+                                           "*python*"))
     :config
     (golden-ratio-mode 1))
 
 #+end_src
+
 ** Swap Buffers
 
 This file is for lazy people wanting to swap buffers without typing C-x b on each window.
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (use-package buffer-move
     :bind (("C-S-<up>"     . buf-move-up)
-          ("C-S-<down>"  . buf-move-down)
-          ("C-S-<left>"  . buf-move-left)
-          ("C-S-<right>" . buf-move-right)))
+            ("C-S-<down>"  . buf-move-down)
+            ("C-S-<left>"  . buf-move-left)
+            ("C-S-<right>" . buf-move-right)))
 
 #+end_src
 
@@ -5390,7 +5388,7 @@ Here are some helpful functions.
     (centaur-tabs-set-icons t)
     (centaur-tabs-set-modified-marker t)
     :bind (("C-c <" . centaur-tabs-backward)
-          ("C-c >" . centaur-tabs-forward))
+            ("C-c >" . centaur-tabs-forward))
     :config ;; Enable centaur-tabs
     (centaur-tabs-mode t))
 
@@ -5458,8 +5456,8 @@ Designate any buffer to “popup” status, and it will stay out of your way. Di
 
   (use-package popper
     :bind (("C-`"   . popper-toggle)
-          ("M-`"   . popper-cycle)
-          ("C-M-`" . popper-toggle-type))
+            ("M-`"   . popper-cycle)
+            ("C-M-`" . popper-toggle-type))
     :init
     (setq popper-reference-buffers
       '("\\*Messages\\*"
@@ -5504,13 +5502,13 @@ Instant Github-flavored Markdown/Org preview using Grip (GitHub Readme Instant P
   (use-package grip-mode
     :ensure t
     :bind (:map markdown-mode-command-map
-           ("g" . grip-mode)))
+            ("g" . grip-mode)))
 
   ;; Or using hooks
   (use-package grip-mode
     :ensure t
     :hook ((markdown-mode org-mode) . grip-mode))
-  
+
 #+end_src
 
 ** MiFi's Minor Mode (MmM)
@@ -5596,18 +5594,18 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
     (when winframe
       (let ((map mmm-keys-minor-mode-map))
         (when enable-thesaurus
-        (bind-keys :map map
+          (bind-keys :map map
             ("M-RET m t" . mw-thesaurus-lookup-dwim)))
         (cond
-        ((equal major-mode 'org-mode)
+          ((equal major-mode 'org-mode)
             (bind-keys :map map
               ("M-RET M-RET" . org-insert-heading)
               ("M-RET o f" . mifi/set-org-fill-column-interactively)
               ("M-RET o l" . org-toggle-link-display)))
-        ((equal major-mode 'python-mode)
+          ((equal major-mode 'python-mode)
             (bind-keys :map map
               ("M-RET P" . 'pydoc-at-point)))
-        (t   ;; Default 
+          (t   ;; Default 
             (unbind-key "M-RET o f" map)
             (unbind-key "M-RET o l" map)
             (unbind-key "M-RET P ?" map)
@@ -5628,7 +5626,7 @@ What's also important with this function is that it calls the ~mifi/mmm-handle-c
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   (defun mifi/mmm-update-menu (&optional winframe)
     (interactive)
     (mifi/mmm-handle-context-keys nil)
@@ -5650,7 +5648,7 @@ These are the hools that update the context-aware menu triggered by various stat
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
-  
+
   ;; Check the keys when:
   ;; - the whick-key menu is displayed
   (add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)
@@ -5675,15 +5673,15 @@ These are the hools that update the context-aware menu triggered by various stat
     (lambda ()
       (setq-default initial-scratch-message
         (format
-        ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
-        ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
+          ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
+          ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
       (when dashboard-landing-screen (dashboard-open))))
 
   (when dashboard-landing-screen
     ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
     (add-hook 'elpaca-after-init-hook
-        (lambda ()
-          (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
+      (lambda ()
+        (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
 
 #+end_src
 
@@ -5699,9 +5697,9 @@ These are the hools that update the context-aware menu triggered by various stat
       (copy-file
         (expand-file-name "init.el" emacs-config-directory)
         (expand-file-name "init.el" backdir) t)))
-      ;; (copy-file
-      ;;   (expand-file-name "emacs-config.org" emacs-config-directory)
-      ;;   (expand-file-name "emacs-config.org" backdir) t)))
+  ;; (copy-file
+  ;;   (expand-file-name "emacs-config.org" emacs-config-directory)
+  ;;   (expand-file-name "emacs-config.org" backdir) t)))
 
   (add-hook 'kill-emacs-hook #'mifi/cleanup-when-exiting)
 
@@ -5732,7 +5730,7 @@ The following is a list of major mode-hooks variables that are set so that they 
                      treemacs-mode-hook
                      vterm-mode-hook))
       (add-hook mode (lambda () (display-line-numbers-mode 0)))))
-  
+
 #+end_src
 
 ** Supress common warnings
@@ -5746,7 +5744,7 @@ The following is a list of major mode-hooks variables that are set so that they 
                                   (package)
                                   (use-package)
                                   (python-mode)))
-  
+
 #+end_src
 
 ** Lispy Footer

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -407,11 +407,11 @@ Thes values toggle the availability of specific packages. These options are not 
     :group 'mrf-custom-toggles)
 
   ;; Keep as defvar until the frameset save/restore process works better.
-  (defvar enable-frameset-restore t
+  (defcustom enable-frameset-restore t
     "Set to t to enable restoring the last Emacs window size and position
-     upon startup.")
-    ;; :type 'boolean
-    ;; :group 'mrf-custom-toggles)
+     upon startup."
+    :type 'boolean
+    :group 'mrf-custom-toggles)
 
 #+end_src
 

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -2,7 +2,7 @@
 #+author: Mitch Fisher
 #+date: 2024-05-11
 #+OPTIONS: toc:nil h:4
-#+STARTUP: showall
+#+STARTUP: showeverything
 #+PROPERTY: header-args:emacs-lisp :tangle ./init.el :results silent :exports code :mkdirp yes
 
 
@@ -23,6 +23,8 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
   + Ivy, Counsel, Swiper
   + Corfu
 
+- Customized Org mode
+  
 - Undo Handlers
   + =Vundo=
   + Undo-tree
@@ -31,9 +33,9 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
   + DAPE
   + DAP
 
-- Integrated Development Environments
-  + =Elpy=
-  + =Eglot=
+- Integrated Development Environments (IDE)
+  + Elpy
+  + Eglot
   + Stand-alone LSP
   + LSP Bridge (experimental)
   + Anaconda-mode for Python
@@ -58,7 +60,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 
 --------------------------------------------------------------------------------
 
-- This configuration requires Emacs 29.1+
+- This configuration requires Emacs 29.1+. It has been tested with Emacs 29.1 - 29.3 and Emacs 30.0.50
 
 - While this configuration includes support for several languages - and I mean support for syntax highlighting and, to some extent, debugging - this configuration caters to be a Python development environment.
 
@@ -72,9 +74,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 
 - Take a look a the [[Custom enable flags][Custom Variables]] and [[Customization groups][Groups]] section to see what options exist. It's important to note that these variables need to be adhered to. Another thing to note is that the various =enable*= flags are not used as =:if= option in =use-package= statement. Instead, a lisp conditional statement is used so that the package is actually never loaded or installed. This improves overall startup performance.
 
-- Tested with Emacs versions 29.1 - 29.3 and 30.0.50.
-  
-- Shout out to the many people in the Emacs community from which a lot of this configuration took inspiration from.
+- *Shout out to the many people in the Emacs community from which a lot of this configuration took inspiration from.*
   
 --------------------------------------------------------------------------------
 
@@ -517,17 +517,19 @@ This is a curated selection of themes that I personally like. Most of them are d
   ;;; ##########################################################################
   ;;; Theming related
 
-  (defcustom theme-list '("palenight-deeper-blue"
-                         "ef-symbiosis"
-                         "ef-maris-light"
-                         "ef-maris-dark"
-                         "ef-kassio"
-                         "ef-bio"
-                         "sanityinc-tomorrow-bright"
-                         "ef-melissa-dark"
-                         "darktooth-dark"
-                         "material"
-                         "tron-legacy")
+  (defcustom theme-list '( "palenight-deeper-blue"
+                           "ef-symbiosis"
+                           "ef-maris-light"
+                           "ef-maris-dark"
+                           "ef-kassio"
+                           "ef-bio"
+                           "ef-dream"
+                           "ef-deuteranopia-dark"
+                           "sanityinc-tomorrow-bright"
+                           "ef-melissa-dark"
+                           "darktooth-dark"
+                           "material"
+                           "tron-legacy")
 
     "My personal list of themes to cycle through indexed by `theme-selector'.
   If additional themes are added, they must be previously installed."
@@ -766,7 +768,7 @@ These are global variables that effect the behavior of Emacs in general.
     visible-bell t             ;; Set up the visible bell
     truncate-lines 1           ;; long lines of text do not wrap
     sentence-end-double-space nil
-    fill-column 80             ;; Default line limit for fills
+    fill-column 79             ;; Default line limit for fills
     ;; Triggers project for directories with any of the following files:
     project-vc-extra-root-markers '(".dir-locals.el"
                                    "requirements.txt"
@@ -859,14 +861,14 @@ These functions will save and restore Emacs framework. These are normally called
         ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
         (desktop-save-mode 0)
         (if (file-exists-p file)
-  	(progn
-  	  (load file)
-  	  (desktop-restore-frameset)
-  	  (when (featurep 'spacious-padding)
+        (progn
+          (load file)
+          (desktop-restore-frameset)
+          (when (featurep 'spacious-padding)
               (when spacious-padding-mode
                 (spacious-padding-mode 0)
                 (spacious-padding-mode 1))))
-  	(use-medium-display-font t)))))
+        (use-medium-display-font t)))))
 
 #+end_src
 
@@ -877,6 +879,8 @@ These are just some common registers that I have just so I can bookmark files an
 
   (setq register-preview-delay 0) ;; Show registers ASAP
   (set-register ?O (cons 'file (concat emacs-config-directory "emacs-config.org")))
+
+  (set-register ?G '(file . "~/Developer/game-dev/GB_asm"))
 
 #+end_src
 
@@ -944,6 +948,15 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
       (run-with-timer 1.0 nil 'mifi/set-diminsh)))
 
 
+#+end_src
+
+** Dumb Jump
+#+begin_src emacs-lisp
+
+  (use-package dumb-jump
+    :config
+    (add-hook 'xref-backend-functions #'dumb-jump-xref-activate))
+  
 #+end_src
 
 ** Which Key
@@ -1269,8 +1282,8 @@ Window numbers for Emacs: Navigate your windows and frames using numbers. This i
   (use-package winum
     ;; :vc syntax below works, just for testing. Elpaca handles it for now.
     ;; :vc ( :url "https://github.com/deb0ch/emacs-winum"
-    ;; 	:branch "master"
-    ;; 	:main-file "winum.el")
+    ;;  :branch "master"
+    ;;  :main-file "winum.el")
     :config (winum-mode))
 
 #+end_src
@@ -1329,6 +1342,23 @@ Jinx requires the library ~libenchant~ or ~enchant~ installed. This can be done 
     (dolist (hook '(text-mode-hook prog-mode-hook org-mode-hook))
       (add-hook hook #'jinx-mode)))
 
+
+#+end_src
+
+** JSON-RPC
+
+The JSON-RPC protocol is used to communicate with many different types of server. This is required for the DAPE and DAP Debug Adapters as well as Eglot.
+
+#+begin_src emacs-lisp
+  ;;; ------------------------------------------------------------------------
+  (use-package jsonrpc
+    :config
+    ;; For some odd reason, it is possible that jsonrpc will try to load a
+    ;; theme. (jsonrpc/lisp/custom.el:1362). If our theme hasn't been loaded
+    ;; yet, go ahead and try. This could prevent a startup without the theme
+    ;; properly loaded.
+    (unless theme-did-load
+      (mifi/load-theme-from-selector)))
 
 #+end_src
 
@@ -2511,7 +2541,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
 *** Color Theming
 
-<<<Color Theming>>> as a curated list of theming packages.
+Color Theming (or just <<<theming>>>) is a curated list of theming packages.
 *Note:* If new themes are added in the ~theme-list~ custom variable then they must be included here along with any customizations.
 
 #+begin_src emacs-lisp
@@ -2861,8 +2891,8 @@ Apply saved font/window-size early in the startup process.
     (add-hook 'elpaca-after-init-hook
       (lambda ()
         (progn
-  	(mifi/update-face-attribute)
-  	(unless (daemonp)
+        (mifi/update-face-attribute)
+        (unless (daemonp)
             (unless enable-frameset-restore (mifi/frame-recenter))))
         )))
 #+end_src
@@ -2898,7 +2928,7 @@ This package provides a global minor mode to increase the spacing/padding of Ema
 * Productivity
 ** Org Mode
 
-Org Mode is one of the hallmark features of Emacs.  It is a rich document editor, project planner, task and time tracker, blogging engine, and literate coding utility all wrapped up in one package [[https://orgmode.org/][Orgmode]].
+<<<Org Mode>>> is one of the hallmark features of Emacs.  It is a rich document editor, project planner, task and time tracker, blogging engine, and literate coding utility all wrapped up in one package [[https://orgmode.org/][Orgmode]].
 
 The =mifi/org-font-setup= function configures various text faces to tweak the sizes of headings and use variable width fonts in most cases so that it looks more like we're editing a document in =org-mode=.  We switch back to fixed width (monospace) fonts for code blocks and tables so that they display correctly.
 
@@ -3010,10 +3040,6 @@ This section contains the basic configuration for =org-mode= plus the configurat
     ;; (use-package org-habit)
     ;; (add-to-list 'org-modules 'org-habit)
     ;; (setq org-habit-graph-column 60)
-    (setq org-todo-keywords
-      '((sequence "TODO(t)" "NEXT(n)" "|" "DONE(d!)")
-         (sequence "BACKLOG(b)" "PLAN(p)" "READY(r)" "ACTIVE(a)"
-           "REVIEW(v)" "WAIT(w@/!)" "HOLD(h)" "|" "COMPLETED(c)" "CANC(k@)")))
     (setq org-refile-targets
       '(("Archive.org" :maxlevel . 1)
          ("Tasks.org" :maxlevel . 1))))
@@ -3118,18 +3144,23 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+begin_src emacs-lisp
 
   (defun mifi/org-setup-todos ()
-    (setq org-todo-keywords '((type
-                                "TODO(t)" "WAITING(h)" "INPROG-TODO(i)" "WORK(w)"
-                                "STUDY(s)" "SOMEDAY" "READ(r)" "PROJ(p)"
-                                "CONTACT(c)" "|" "DONE(d)" "CANCELLED(C@)")))
+    "Setup the org TODO keywords and colors."
+    (setq org-todo-keywords
+      '((type
+          "TODO(t)" "WAITING(w)" "IN-PROGRESS(i)"
+          "RESEARCH(r)" "SOMEDAY(-)" "READING(e)"
+          "CONTACT(c)" "|" "DONE(d)" "CANCELLED(C@)")))
 
     (setq org-todo-keyword-faces
-      '(("TODO"  :inherit (region org-todo) :foreground "DarkOrange1" :weight bold)
-         ("WORK"  :inherit (org-todo region) :foreground "DarkOrange1" :weight bold)
-         ("READ"  :inherit (org-todo region) :foreground "MediumPurple2" :weight bold)
-         ("PROJ"  :inherit (org-todo region) :foreground "orange3" :weight bold)
-         ("STUDY" :inherit (region org-todo) :foreground "plum3"   :weight bold)
-         ("DONE" . "SeaGreen4"))))
+      '(("TODO" :inherit (region org-todo) :foreground "gray70" :weight bold)
+         ("WAITING" :inherit (org-todo region) :foreground "red1" :weight bold)
+         ("IN-PROGRESS" :inherit (org-todo region) :foreground "gold1" :weight bold)
+         ("RESEARCH" :inherit (org-todo region) :foreground "OliveDrab3" :weight bold)
+         ("SOMEDAY" :inherit (org-todo region) :foreground "MediumPurple2" :weight bold)
+         ("READING" :inherit (org-todo region) :foreground "DeepSkyBlue1" :weight bold)
+         ("CONTACT" :inherit (org-todo region) :foreground "orange1" :weight bold)
+         ("DONE" :inherit (region org-todo) :foreground "green1"   :weight bold)
+         ("CANCELLED" :inherit (region org-todo) :foreground "green4"   :weight bold))))
 
 #+end_src
 
@@ -3153,6 +3184,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
    '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
 
 #+end_src
+
 
 *** The main 'Org' package
 #+begin_src emacs-lisp
@@ -3203,8 +3235,6 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
-#+RESULTS:
-: #s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8125 data (:use-package (26172 1876 296393 0) :use-package-secs (0 0 907 0) :preface (26171 64968 44297 0) :init (26171 64968 44286 0) :init-secs (0 0 28 0) :preface-secs (0 0 265 0) :config (26171 64988 735976 0) :config-secs (0 0 361702 0)))
 
 *** Better Bullets
 [[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
@@ -3320,37 +3350,38 @@ Note that org-modern is a full replacement for both org-superstar and org-bullet
     :hook (org-mode . org-modern-mode)
     :config
     ;; Add frame borders and window dividers
-    ;; (modify-all-frames-parameters
-    ;;   '((right-divider-width . 40)
-    ;;      (internal-border-width . 40)))
-    ;; (dolist (face '(window-divider
-    ;; 		   window-divider-first-pixel
-    ;; 		   window-divider-last-pixel))
-    ;;   (face-spec-reset-face face)
-    ;;   (set-face-foreground face (face-attribute 'default :background nil)))
-    ;; (set-face-background 'fringe (face-attribute 'default :background nil))
-    ;; (setq
-    ;;   ;; Edit settings
-    ;;   org-auto-align-tags nil
-    ;;   org-tags-column 0
-    ;;   org-catch-invisible-edits 'show-and-error
-    ;;   org-special-ctrl-a/e t
-    ;;   org-insert-heading-respect-content t
+    (modify-all-frames-parameters
+      '((right-divider-width . 40)
+         (internal-border-width . 40)))
+    (dolist (face '(window-divider
+                   window-divider-first-pixel
+                   window-divider-last-pixel))
+      (face-spec-reset-face face)
+      (set-face-foreground face (face-attribute 'default :background nil)))
+    (set-face-background 'fringe (face-attribute 'default :background nil))
+    (setq
+      ;;   ;; Edit settings
+      ;;   org-auto-align-tags nil
+      ;;   org-tags-column 0
+      org-catch-invisible-edits 'show-and-error
+      org-special-ctrl-a/e t
+      org-insert-heading-respect-content t
 
-    ;;   ;; Org styling, hide markup etc.
-    ;;   org-hide-emphasis-markers nil
-    ;;   org-pretty-entities t
-    ;;   org-ellipsis "…"
+      ;;   ;; Org styling, hide markup etc.
+      org-hide-emphasis-markers nil
+      org-pretty-entities t
+      org-ellipsis "…"
 
-    ;;   ;; Agenda styling
-    ;;   org-agenda-tags-column 0
-    ;;   org-agenda-block-separator ?─
-    ;;   org-agenda-time-grid
-    ;;   '((daily today require-timed)
-    ;;      (800 1000 1200 1400 1600 1800 2000)
-    ;;      " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
-    ;;   org-agenda-current-time-string
-    ;;   "◀── now ─────────────────────────────────────────────────")
+      ;;   ;; Agenda styling
+      ;;   org-agenda-tags-column 0
+      ;;   org-agenda-block-separator ?─
+      ;;   org-agenda-time-grid
+      ;;   '((daily today require-timed)
+      ;;      (800 1000 1200 1400 1600 1800 2000)
+      ;;      " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
+      ;;   org-agenda-current-time-string
+      ;;   "◀── now ─────────────────────────────────────────────────"
+      )
     (global-org-modern-mode))
 
 #+end_src
@@ -3370,6 +3401,7 @@ Org Roam solves these problems by making it easy to create topic-focused Org Fil
 
 #+begin_src emacs-lisp :tangle no
   ;;; ##########################################################################
+
   (use-package emacsql :demand t :ensure t :after org)
   (use-package emacsql-sqlite :demand t :ensure t :after org)
    
@@ -3597,6 +3629,7 @@ Org-transclusion lets you insert a copy of text content via a file link or ID li
 
 #+end_src
 
+
 ** Denote
 
 Denote aims to be a simple-to-use, focused-in-scope, and effective note-taking and file-naming tool for Emacs.
@@ -3753,16 +3786,15 @@ This is the default built-in project system. For those not needing the full-feat
 
 * Integrated Development Environments
 
-The following are configured for Python development and provide an IDE type experience.  It's worth noting that Eglot/LSP can be configured for other languages. The others are Python specific. Use the =configure= system to select which one is used (=Mrf Custom Selection=).
+The following are configured for Python development and provide an <<<IDE>>> type experience.  It's worth noting that Eglot/LSP can be configured for other languages. The others are Python specific. Use the =configure= system to select which one is used (=Mrf Custom Selection=).
 
-:Features:
 - context-sensitive code completion
 - jump to definitions
 - find references
 - view documentation
 - virtual environment
 - eldoc mode
-:END:
+
 
 ** EGlot
 
@@ -3789,23 +3821,6 @@ The following are configured for Python development and provide an IDE type expe
 
 #+end_src
 
-*** JSON-RPC
-
-The JSON-RPC protocol is used to communicate with many different types of server. This is required for the DAPE and DAP Debug Adapters as well as Eglot.
-
-#+begin_src emacs-lisp
-  ;;; ------------------------------------------------------------------------
-  (use-package jsonrpc
-    :config
-    ;; For some odd reason, it is possible that jsonrpc will try to load a
-    ;; theme. (jsonrpc/lisp/custom.el:1362). If our theme hasn't been loaded
-    ;; yet, go ahead and try. This could prevent a startup without the theme
-    ;; properly loaded.
-    (unless theme-did-load
-      (mifi/load-theme-from-selector)))
-
-#+end_src
-
 *** Eglot Setup
 
 #+begin_src emacs-lisp
@@ -3826,7 +3841,7 @@ The JSON-RPC protocol is used to communicate with many different types of server
     (lisp-mode . eglot-ensure)
     (python-mode . eglot-ensure)
     (go-mode . eglot-ensure)
-    (rust-mode . eglot-ensure)
+    (rustic-mode . eglot-ensure)
     ;; (c-mode . eglot-ensure)
     ;; (c++-mode . eglot-ensure)
     ;; (prog-mode . eglot-ensure)
@@ -4206,7 +4221,7 @@ Magit]] is the one of the best Git interface implementations .  Common Git opera
 
 #+end_src
 
-** Python :Python:
+** Python
 
 <<<Python>>> is an interpreted, interactive, object-oriented programming language. It incorporates modules, exceptions, dynamic typing, very high level dynamic data types, and classes. It supports multiple programming paradigms beyond object-oriented programming, such as procedural and functional programming. Python combines remarkable power with very clear syntax. It has interfaces to many system calls and libraries, as well as to various window systems, and is extensible in C or C++. It is also usable as an extension language for applications that need a programmable interface. Finally, Python is portable: it runs on many Unix variants including Linux and macOS, and on Windows.
 
@@ -4528,6 +4543,31 @@ RGBDS is a compiler that has been around quite a long time (since 1997). It supp
 
 Rust is blazingly fast and memory-efficient: with no runtime or garbage collector, it can power performance-critical services, run on embedded devices, and easily integrate with other languages.
 
+Much of this configuration was taken from the [[https://robert.kra.hn/posts/rust-emacs-setup/][Robert Krahn]] web site.
+
+*** Prerequisites
+
+1. Install Rust and Cargo
+   
+   #+begin_src shell
+               
+     curl https://sh.rustup.rs -sSf | sh
+
+   #+end_src
+
+
+2. Install the Rust analyzer 
+   
+#+begin_src shell
+  #!/bin/bash
+
+  git clone https://github.com/rust-analyzer/rust-analyzer.git -b release
+  cd rust-analyzer
+  cargo xtask install --server # will install rust-analyzer into $HOME/.cargo/bin
+
+#+end_src
+
+
 *** Rustic package configuration
 
 #+begin_src emacs-lisp
@@ -4544,6 +4584,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
             ("C-c C-c q" . lsp-workspace-restart)
             ("C-c C-c Q" . lsp-workspace-shutdown)
             ("C-c C-c s" . lsp-rust-analyzer-status))
+    :hook (rustic-mode . rk/rustic-mode-hook)
     :config
     ;; uncomment for less flashiness
     ;; (setq lsp-eldoc-hook nil)
@@ -4551,8 +4592,8 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
     ;; (setq lsp-signature-auto-activate nil)
 
     ;; comment to disable rustfmt on save
-    (setq rustic-format-on-save t)
-    (add-hook 'rustic-mode-hook 'rk/rustic-mode-hook))
+    (setq rustic-format-on-save t))
+
 
   (defun rk/rustic-mode-hook ()
     ;; so that run C-c C-c C-r works without having to confirm, but don't try to
@@ -4562,7 +4603,18 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
     (when buffer-file-name
       (setq-local buffer-save-without-query t))
     (add-hook 'before-save-hook 'lsp-format-buffer nil t))
-  
+
+#+end_src
+
+*** Cargo and Cargo.toml packages
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+  ;; for Cargo.toml and other config files
+
+  (use-package toml-mode :ensure)
+
+
 #+end_src
 
 *** Rust-mode configuration
@@ -4572,6 +4624,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 
   ;; (use-package graphql-mode)
   (use-package rust-mode
+    :disabled ;;; Older than rustic so don't use but 
     :defer t
     :init (setq rust-mode-treesitter-derive t)
     :hook
@@ -5500,10 +5553,6 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
         (bind-keys :map map
           ("M-RET $" . jinx-correct)
           ("M-RET ?" . eldoc-box-help-at-point)
-          ("M-RET R 1" . eshell)
-          ("M-RET R 2" . eshell)
-          ("M-RET R 3" . eshell)
-          ("M-RET R 4" . eshell)
           ("M-RET S e" . eshell)
           ("M-RET S i" . ielm)
           ("M-RET S v" . vterm-other-window)
@@ -5520,6 +5569,9 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
           ("M-RET C-g" . keyboard-quit))
         map)
       "mmm-keys-minor-mode keymap.")
+
+    (which-key-add-key-based-replacements "M-RET |" "display-fill-column")    
+    (which-key-add-key-based-replacements "M-RET ?" "help-at-point")
 
     (define-minor-mode mmm-keys-minor-mode
       "A minor mode so that my key settings override annoying major modes."
@@ -5544,23 +5596,28 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
     (when winframe
       (let ((map mmm-keys-minor-mode-map))
         (when enable-thesaurus
-  	(bind-keys :map map
+        (bind-keys :map map
             ("M-RET m t" . mw-thesaurus-lookup-dwim)))
         (cond
-  	((equal major-mode 'org-mode)
+        ((equal major-mode 'org-mode)
             (bind-keys :map map
               ("M-RET M-RET" . org-insert-heading)
               ("M-RET o f" . mifi/set-org-fill-column-interactively)
               ("M-RET o l" . org-toggle-link-display)))
-  	((equal major-mode 'python-mode)
+        ((equal major-mode 'python-mode)
             (bind-keys :map map
               ("M-RET P" . 'pydoc-at-point)))
-  	(t   ;; Default 
+        (t   ;; Default 
             (unbind-key "M-RET o f" map)
             (unbind-key "M-RET o l" map)
             (unbind-key "M-RET P ?" map)
-            (unbind-key "M-RET M-RET" map))))))
-  
+            (unbind-key "M-RET M-RET" map)))))
+
+    ;; Override default menu text with better things
+    (which-key-add-key-based-replacements "M-RET m t" "thesaurus-at-point")
+    (which-key-add-key-based-replacements "M-RET o" "org-menu")
+    (which-key-add-key-based-replacements "M-RET o f" "set-org-fill-column"))
+
 #+end_src
 
 *** Key Description Overrides
@@ -5578,7 +5635,6 @@ What's also important with this function is that it calls the ~mifi/mmm-handle-c
     (which-key-add-key-based-replacements "M-RET S" "shells")
     (which-key-add-key-based-replacements "M-RET T" "theme-keys")
     (which-key-add-key-based-replacements "M-RET P" "python-menu")
-    (which-key-add-key-based-replacements "M-RET o" "org-menu")
     (which-key-add-key-based-replacements "M-RET e" "treemacs-toggle")
     (which-key-add-key-based-replacements "M-RET m" "Thesaurus")
     (which-key-add-key-based-replacements "M-RET f" "set-fill-column")

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -2438,18 +2438,27 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
   (defun mifi/load-theme-from-selector (&optional step)
     "Load the theme in `theme-list' indexed by `theme-selector'."
     (interactive)
-    (setq theme-cycle-step nil)
-    (cond
-      ((or (eq step nil) (eq step 0)) (setq theme-cycle-step 0))
-      ((> step 0) (setq theme-cycle-step 1))
-      ((< step 0) (setq theme-cycle-step -1)))
-    (when loaded-theme
-      (disable-theme (intern loaded-theme)))
-    (setq loaded-theme (nth theme-selector theme-list))
-    (setq theme-did-load (load-theme (intern loaded-theme) t))
-    (when (featurep 'org)
-      (mifi/org-font-setup))
-    (set-face-foreground 'line-number "SkyBlue4"))
+    ;; Save value of spacious-padding-mode
+    (let ((spm? (featurep 'spacious-padding)))
+      (if spm?
+        (setq mifi/spm-on-off (default-value 'spacious-padding-mode))
+        (setq mifi/spm-on-off nil))
+      (setq theme-cycle-step nil)
+      (cond
+        ((or (eq step nil) (eq step 0)) (setq theme-cycle-step 0))
+        ((> step 0) (setq theme-cycle-step 1))
+        ((< step 0) (setq theme-cycle-step -1)))
+      (when loaded-theme
+        (when spm?
+  	(spacious-padding-mode 0))
+        (disable-theme (intern loaded-theme)))
+      (setq loaded-theme (nth theme-selector theme-list))
+      (setq theme-did-load (load-theme (intern loaded-theme) t))
+      (when (featurep 'org)
+        (mifi/org-font-setup))
+      (when spm?
+        (spacious-padding-mode mifi/spm-on-off))
+      (set-face-foreground 'line-number "SkyBlue4")))
 
 #+end_src
 

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -80,6 +80,29 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 
 
 * early-init.el
+
+This is where all of the settings/setup goes for the ~early-init.el~ file.
+
+*NOTE:* that each source header line has =:tangle "early-init.el"= . This is required for anything going to the early-init.el file. If it's not present, the code will be tangled to the default location of init.el.
+
+** Lispy Header for early-init.el
+
+Standard fare and good practice.
+
+#+begin_src emacs-lisp :tangle "early-init.el"
+  ;;; early-init.el -*- flycheck-disabled-checkers: (emacs-lisp); lexical-binding: nil -*-
+  ;;;
+  ;;; Commentary:
+
+  ;; Settings/Packages that need to be used early in the initialization process
+  ;; of the Emacs startup. This file is executed before init.el.
+  ;;
+  ;; DO NOT MODIFY this file directly as changes will be overwritten.
+
+  ;;; Code:
+
+#+end_src
+
 ** Package archives
 
 #+begin_src emacs-lisp :tangle "early-init.el" 
@@ -192,6 +215,7 @@ Because in macOS, Emacs could be started outside of a shell (like an application
 #+end_src
 
 ** Lispy end of early-init.el
+
 Standard fare and good practice.
 
 #+begin_src emacs-lisp :tangle "early-init.el" 
@@ -1305,15 +1329,16 @@ Window numbers for Emacs: Navigate your windows and frames using numbers. This i
 
   (use-package dashboard
     :custom
-    (dashboard-items '(   (recents . 15)
-                        (bookmarks . 10)
-                        (projects . 10)))
+    (dashboard-items '( (recents   . 12)
+                        (bookmarks . 5)
+                        (projects  . 5)
+                        (agenda    . 5)))
     (dashboard-center-content t)
     (dashboard-set-heading-icons t)
     (dashboard-set-file-icons t)
     (dashboard-footer-messages '("Greetings Program!"))
     (dashboard-banner-logo-title "Welcome to Emacs!")
-    (dashboard-startup-banner 'logo)
+    (dashboard-startup-banner (expand-file-name "Emacs-modern-is-sexy-v1.png" user-emacs-directory))
     :bind ("C-c d" . dashboard-open)
     :config
     ;; (setq initial-buffer-choice (lambda () (get-buffer-create dashboard-buffer-name)))
@@ -3080,6 +3105,9 @@ This section contains the basic configuration for =org-mode= plus the configurat
   ;;; ##########################################################################
 
   (defun mifi/org-setup-agenda ()
+    "Function to setup basic org-agenda settings."
+    (bind-key "C-c a" 'org-agenda org-mode-map)
+    
     (setq org-agenda-custom-commands
       '(("d" "Dashboard"
           ((agenda "" ((org-deadline-warning-days 7)))

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -79,7 +79,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 ** Package archives
 
 #+begin_src emacs-lisp :tangle "early-init.el" 
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Adjust garbage collection threshold for early startup (see use of gcmh below)
   (setq gc-cons-threshold (* 100 1024 1024))
@@ -161,7 +161,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 Because in macOS, Emacs could be started outside of a shell (like an application on the Dock), this code is used to migrate the <current user's shell path to Emacs ~exec-path~.
 
 #+begin_src emacs-lisp :tangle "early-init.el"
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   (defconst *is-a-mac* (eq system-type 'darwin))
 
   (defun mifi/setup-exec-path ()
@@ -233,7 +233,7 @@ Elpaca:
 :END:
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (defvar elpaca-installer-version 0.7)
   (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
@@ -296,35 +296,35 @@ Other variables are also defined here that define other emacs behaviors and defa
 These are the groups used by this Emacs config for customization.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Define my customization groups
 
-  (defgroup mrf-custom nil
+  (defgroup mifi-custom nil
     "M.R. Fisher's configuration section."
     :group 'Local)
 
-  (defgroup mrf-custom-toggles nil
+  (defgroup mifi-custom-toggles nil
     "A set of toggles that enable or disable  specific packages."
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
-  (defgroup mrf-custom-features nil
+  (defgroup mifi-custom-features nil
     "Customization from a selection of specific features and handlers."
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
-  (defgroup mrf-custom-fonts nil
+  (defgroup mifi-custom-fonts nil
     "Customization of fonts and sizes."
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
-  (defgroup mrf-custom-theming nil
+  (defgroup mifi-custom-theming nil
     "Custom theming values."
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
 #+end_src
 
 ** File Locations and Variables
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defcustom dashboard-landing-screen t
     "If set to t, the `dashboard' package will be displayed once emacs has
@@ -334,84 +334,84 @@ These are the groups used by this Emacs config for customization.
   The Dashboard will be in the *dashboard* buffer and can also be opened using
   \"C-c d\" or \"M-RET d\" from anywhere even if this value is nil."
     :type 'boolean
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
   (defcustom custom-docs-dir "~/Documents/Emacs-Related"
     "A directory used to store documents and customized data."
     :type 'string
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
   (defcustom working-files-directory
     (expand-file-name "emacs-working-files" custom-docs-dir)
     "The directory where to store Emacs working files."
     :type 'string
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
   (defcustom custom-org-fill-column 120
     "The fill column width for Org mode text.
       Note that the text is also centered on the screen so that should
       be taken into consideration when providing a width."
     :type 'natnum
-    :group 'mrf-custom)
+    :group 'mifi-custom)
 
 #+end_src
 
 ** Custom Package Toggles
 
-Thes values toggle the availability of specific packages. These options are not grouped together as can be done with the =mrf-custom-features= group so are all separate values.
+Thes values toggle the availability of specific packages. These options are not grouped together as can be done with the =mifi-custom-features= group so are all separate values.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Feature Toggles
 
   (defcustom enable-gb-dev nil
     "If set to t, the z80-mode and other GameBoy related packages
       will be enabled."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-ts nil
     "Set to t to enable TypeScript handling."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-centaur-tabs nil
     "Set to t to enable `centaur-tabs' which uses tabs to represent open buffer."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-neotree nil
     "Set to t to enable the `neotree' package."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-golden-ratio nil
     "Set to t to enable `golden-ratio-mode' which resizes the active buffer
      window to the dimensions of a golden-rectangle"
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-org-fill-column-centering nil
     "Set to t to center the visual-fill column of the Org display."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-embark nil
     "Set to t to enable the Embark package."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   (defcustom enable-thesaurus t
     "When set to t, enables the Merriam-Webster Thesaurus."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
   ;; Keep as defvar until the frameset save/restore process works better.
   (defcustom enable-frameset-restore t
     "Set to t to enable restoring the last Emacs window size and position
      upon startup."
     :type 'boolean
-    :group 'mrf-custom-toggles)
+    :group 'mifi-custom-toggles)
 
 #+end_src
 
@@ -420,7 +420,7 @@ Thes values toggle the availability of specific packages. These options are not 
 These are features that basically have multiple-choice options instead of being a typical binary t or nil.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defcustom undo-handler 'undo-handler-vundo
     "Select the undo handler to use.
@@ -436,7 +436,7 @@ These are features that basically have multiple-choice options instead of being 
            (const :tag "Vundo (default)" undo-handler-vundo)
            (const :tag "Undo-tree" undo-handler-undo-tree)
            (const :tag "Built-in" undo-handler-built-in))
-    :group 'mrf-custom-features)
+    :group 'mifi-custom-features)
 
   (defcustom completion-handler 'comphand-vertico
     "Select the default minibuffer completion handler.
@@ -455,7 +455,7 @@ These are features that basically have multiple-choice options instead of being 
            (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
            (const :tag "Cofu completion systems" comphand-corfu)
            (const :tag "Built-in Ido" comphand-built-in))
-    :group 'mrf-custom-features)
+    :group 'mifi-custom-features)
 
   (defcustom debug-adapter 'debug-adapter-dape
     "Select the debug adapter to use for debugging applications.  dap-mode is an
@@ -470,7 +470,7 @@ These are features that basically have multiple-choice options instead of being 
     :type '(radio
            (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
            (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
-    :group 'mrf-custom-features)
+    :group 'mifi-custom-features)
 
   (defcustom custom-ide 'custom-ide-eglot
     "Select which IDE will be used for Python development.
@@ -494,13 +494,13 @@ These are features that basically have multiple-choice options instead of being 
            (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
            (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
            (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
-    :group 'mrf-custom-features)
+    :group 'mifi-custom-features)
 
   (defcustom custom-project-handler 'custom-project-project
     "Select which project handler to use."
     :type '(radio (const :tag "Projectile" custom-project-projectile)
              (const :tag "Built-in project" custom-project-project))
-    :group 'mrf-custom-features)
+    :group 'mifi-custom-features)
 
 #+end_src
 
@@ -509,7 +509,7 @@ These are features that basically have multiple-choice options instead of being 
 This is a curated selection of themes that I personally like. Most of them are dark mode but there are a few light versions. New themes can be added here or done via the =customize= interface. If a new theme is added to this list, it's important to ensure that the theme is actually included (see [[Color Theming][Color Theming]] section)
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Theming related
 
   (defcustom theme-list '("palenight-deeper-blue"
@@ -526,81 +526,81 @@ This is a curated selection of themes that I personally like. Most of them are d
 
     "My personal list of themes to cycle through indexed by `theme-selector'.
   If additional themes are added, they must be previously installed."
-    :group 'mrf-custom-theming
+    :group 'mifi-custom-theming
     :type '(repeat string))
 
   (defcustom default-terminal-theme "sanityinc-tomorrow-bright"
     "The default theme used for a terminal invocation of Emacs."
-    :group 'mrf-custom-theming
+    :group 'mifi-custom-theming
     :type 'string)
 
   (defcustom theme-selector 0
     "The index into the list of custom themes."
-    :group 'mrf-custom-theming
+    :group 'mifi-custom-theming
     :type 'natnum)
 
   ;;; Font related
   (defcustom default-font-family "Fira Code Retina"
     "The font family used as the default font."
     :type 'string
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom mono-spaced-font-family "Fira Code Retina"
     "The font family used as the mono-spaced font."
     :type 'string
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom variable-pitch-font-family "Helvetica Neue"
     "The font family used as the default proportional font."
     :type 'string
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom small-mono-font-size 150
     "The small font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom medium-mono-font-size 170
     "The medium font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom large-mono-font-size 190
     "The large font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom x-large-mono-font-size 220
     "The extra-large font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom small-variable-font-size 170
     "The small font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom medium-variable-font-size 190
     "The small font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom large-variable-font-size 210
     "The small font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom x-large-variable-font-size 240
     "The small font size in pixels."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defcustom custom-default-font-size 170
     "A place to store the most current (face-attribute 'default :height).  This
   is specifically for the mono-spaced and default font. The variable type-face
   font size is computed + 20 of this value."
     :type 'natnum
-    :group 'mrf-custom-fonts)
+    :group 'mifi-custom-fonts)
 
   (defvar custom-default-mono-font-size 170
     "Storage for the current mono-spaced font height.")
@@ -612,7 +612,7 @@ This is a curated selection of themes that I personally like. Most of them are d
 Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (defun mifi/validate-variable-pitch-font ()
     (let* ((variable-pitch-font
@@ -641,7 +641,7 @@ Look for a proportional font that is available on the OS. If the actual default 
 Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (defun mifi/validate-monospace-font ()
     (let* ((monospace-font
@@ -673,7 +673,7 @@ Setup initial paths, global values and settings, and Emacs working directories.
 By default, the =user-emacs-directory= points to the .emacs.d* directory from which the =init.el= is used when Emacs starts. What this means is that any package that writes to this directory will be writing files to this initialization directory. Since we want to keep this directory clean, we set this directory to something external. A new variable, =emacs-config-directory= is set to now point to the starting Emacs condfiguration directory.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Set a variable that represents the actual emacs configuration directory.
   ;;; This is being done so that the user-emacs-directory which normally points
   ;;; to the .emacs.d directory can be re-assigned so that customized files don't
@@ -709,7 +709,7 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (add-to-list 'load-path (expand-file-name "lisp" emacs-config-directory))
   (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
@@ -722,7 +722,7 @@ These are global variables that effect the behavior of Emacs in general.
 
 #+begin_src emacs-lisp
 
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (setq-default
     window-resize-pixelwise t ;; enable smooth resizing
@@ -755,7 +755,7 @@ These are global variables that effect the behavior of Emacs in general.
 Keeps a persistent history file across Emacs restarts. It's also saved into the ~user-emacs-directory~ so it's not tied to a specific Emacs installation.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
   (savehist-mode t)
   (setq history-length t)
@@ -773,7 +773,7 @@ Keeps a persistent history file across Emacs restarts. It's also saved into the 
 Calls to mode functions that effect various Emacs behavior.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; (global-display-line-numbers-mode 1) ;; Line numbers appear everywhere
   ;; A cool mode to revert a window configuration
   (winner-mode 1)
@@ -792,7 +792,7 @@ Calls to mode functions that effect various Emacs behavior.
 *** Configure 'paren' mode
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Used to highlight matching delimiters '( { [ ] } )
   (use-package paren
@@ -813,7 +813,7 @@ Calls to mode functions that effect various Emacs behavior.
 These functions will save and restore Emacs framework. These are normally called when starting and exiting Emacs.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/save-desktop-frameset ()
     (unless (daemonp)
@@ -823,22 +823,25 @@ These functions will save and restore Emacs framework. These are normally called
         (insert (format
                   "(setq desktop-saved-frameset %S)"
                   desktop-saved-frameset)))))
-
+  
   (add-hook 'kill-emacs-hook 'mifi/save-desktop-frameset)
 
-  ;;; --------------------------------------------------------------------------
-   
+  ;;; ##########################################################################
+
   (defun mifi/restore-desktop-frameset ()
     (unless (and (daemonp) (not enable-frameset-<restore))
       (let
         ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
         (desktop-save-mode 0)
-        (when (file-exists-p  file) (load file)
-        (desktop-restore-frameset)
-        (when (featurep 'spacious-padding)
-            (when spacious-padding-mode
-              (spacious-padding-mode 0)
-              (spacious-padding-mode 1)))))))
+        (if (file-exists-p file)
+  	(progn
+  	  (load file)
+  	  (desktop-restore-frameset)
+  	  (when (featurep 'spacious-padding)
+              (when spacious-padding-mode
+                (spacious-padding-mode 0)
+                (spacious-padding-mode 1))))
+  	(use-medium-display-font t)))))
 
 #+end_src
 
@@ -848,7 +851,7 @@ These are just some common registers that I have just so I can bookmark files an
 #+begin_src emacs-lisp
 
   (setq register-preview-delay 0) ;; Show registers ASAP
-  (set-register ?C (cons 'file (concat emacs-config-directory "emacs-config.org")))
+  (set-register ?O (cons 'file (concat emacs-config-directory "emacs-config.org")))
 
 #+end_src
 
@@ -856,7 +859,7 @@ These are just some common registers that I have just so I can bookmark files an
 Handle the case of starting the Emacs server when Emacs is started as a foreground or background daemon.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Allow access from emacsclient
   (add-hook 'elpaca-after-init-hook
     (lambda ()
@@ -873,7 +876,7 @@ Handle the case of starting the Emacs server when Emacs is started as a foregrou
 * Universal Packages
 
 These are the common packages that I pretty much use universally in my normal Emacs workflow.
-It excludes packages that can be customized through my =mrf-custom= variables as they are generally in their own section
+It excludes packages that can be customized through my =mifi-custom= variables as they are generally in their own section
 
 ** Hydra
 
@@ -882,7 +885,7 @@ This is a package for GNU Emacs that can be used to tie related commands into a 
 The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, arrives. Note that Hercules, besides vanquishing the Hydra, will still serve his original purpose, calling his proper command. This makes the Hydra very seamless, it's like a minor mode that disables itself auto-magically.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package hydra
     :ensure (:repo "abo-abo/hydra" :fetcher github
@@ -893,7 +896,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 
 ** Diminish
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/set-diminish ()
     (when (equal custom-project-handler 'custom-project-projectile)
@@ -922,7 +925,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 [[https://github.com/justbur/emacs-which-key][which-key]] is a useful UI panel that appears when you start pressing any key binding in Emacs to offer you all possible completions for the prefix.  For example, if you press =C-c= (hold control and press the letter =c=), a panel will appear at the bottom of the frame displaying all of the bindings under that prefix and which command they run.  This is very useful for learning the possible key bindings in the mode of your current buffer.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package which-key
     :diminish which-key-mode
@@ -942,7 +945,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 Multiple cursors for Emacs. This is some pretty crazy functionality, so yes, there are kinks. Don't be afraid though.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package multiple-cursors
     :bind (("C-S-c C-S-c" . mc/edit-lines)
@@ -956,7 +959,7 @@ Multiple cursors for Emacs. This is some pretty crazy functionality, so yes, the
 anzu.el is an Emacs port of anzu.vim. anzu.el provides a minor mode which displays current match and total matches information in the mode-line in various search modes.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package anzu
     :custom
@@ -981,7 +984,7 @@ anzu.el is an Emacs port of anzu.vim. anzu.el provides a minor mode which displa
 We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]] to center =org-mode= buffers for a more pleasing writing experience as it centers the contents of the buffer horizontally to seem more like you are editing a document.  This is really a matter of personal preference so you can remove the block below if you don't like the behavior.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package visual-fill-column :after org)
 
@@ -990,7 +993,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 ** Default Text Scale
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package default-text-scale
     :hook (elpaca-after-init . default-text-scale-mode))
@@ -1000,7 +1003,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 ** Mac Specific
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Macintosh specific configurations.
   (when *is-a-mac*
@@ -1008,16 +1011,14 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
           mac-option-modifier         nil
           mac-control-modifier       'control
           mac-right-command-modifier 'super
-          mac-right-control-modifier 'hyper)
-
-    (global-set-key (kbd "<escape>") 'keyboard-escape-quit))
+          mac-right-control-modifier 'hyper))
 
 #+end_src
 
 ** Prompt Indicator / minibuffer
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Prompt indicator/Minibuffer
 
@@ -1046,7 +1047,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 
 ** Global key-binding
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (bind-key "C-c ]" 'indent-region prog-mode-map)
   (bind-key "C-c }" 'indent-region prog-mode-map)
@@ -1081,7 +1082,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 This package displays ElDoc documentations in a childframe. The childframe is selectable and scrollable with mouse, even though the cursor is hidden.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; prevent (emacs) eldoc loaded before Elpaca activation warning.
   ;; (Warning only displayed during first Elpaca installation)
@@ -1115,7 +1116,7 @@ The auto-package-update package helps us keep our Emacs packages up to date!  It
 You can also use =M-x auto-package-update-now= to update right now!
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Automatic Package Updates
 
   (use-package auto-package-update
@@ -1136,7 +1137,7 @@ You can also use =M-x auto-package-update-now= to update right now!
 These are useful snippets of code that are commonly used in various languages. You can even create your own.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; YASnippets
 
   (use-package yasnippet
@@ -1162,7 +1163,7 @@ These are useful snippets of code that are commonly used in various languages. Y
 Collections of more yasnippet snippets for various languages.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package yasnippet-snippets
     :after yasnippet)
@@ -1177,7 +1178,7 @@ would normal text.  This enables things such as better scaling of and anti
 aliasing of the icons.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package all-the-icons
     :when (display-graphic-p))
@@ -1194,7 +1195,7 @@ Features:
 - Extensibility
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Auto Complete
 
   (use-package auto-complete)
@@ -1226,7 +1227,7 @@ Features:
 [[https://github.com/abo-abo/ace-window][ace-window]] is a package for selecting a window to switch to. Like =other-window= but better!
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package ace-window
     ;;:ensure (:repo "abo-abo/ace-window" :fetcher github)
@@ -1237,7 +1238,7 @@ Features:
 ** Winum
 Window numbers for Emacs: Navigate your windows and frames using numbers. This is not only handy but used by Treemacs.
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Window Number
 
   (use-package winum
@@ -1254,7 +1255,7 @@ Jinx is a fast just-in-time spell-checker for Emacs. Jinx highlights misspelled 
 Jinx requires the library ~libenchant~ or ~enchant~ installed. This can be done via the [[https://github.com/AbiWord/enchant][enchant github]] site, through ~brew~ on macOS or the package management system of the OS.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   (use-package jinx
     :ensure (:host github :repo "minad/jinx")
     ;;:hook (emacs-startup . global-jinx-mode)
@@ -1272,7 +1273,7 @@ Jinx requires the library ~libenchant~ or ~enchant~ installed. This can be done 
 These are packages located in the ~"lisp"~ directory within the emacs-config-directory.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
 #+end_src
 
@@ -1284,7 +1285,7 @@ These are packages located in the ~"lisp"~ directory within the emacs-config-dir
 Vundo displays the undo history as a tree and lets you move in the tree to go back to previous buffer states. To use vundo, type M-x vundo RET in the buffer you want to undo. An undo tree buffer should pop up.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package vundo
     ;;:ensure ( :host github :repo "casouri/vundo")
@@ -1303,7 +1304,7 @@ Vundo displays the undo history as a tree and lets you move in the tree to go ba
 Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode treats undo history as a branching tree of changes, similar to the way Vim handles it. This makes it substantially easier to undo and redo any change, while preserving the entire history of past states. The undo-tree visualizer is particularly helpful in complex cases. An added side bonus is that undo history can in some cases be stored more efficiently, allowing more changes to accumulate before Emacs starts discarding history. Undo history can be saved persistently across sessions with Emacs 24.3 and later. It also sports various other nifty features: storing and restoring past buffer states in registers, a diff view of the changes that will be made by undoing, and probably more besides.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/undo-tree-hook ()
     (set-frame-width (selected-frame) 20))
@@ -1314,7 +1315,7 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
          (split-width-threshold 0))
       (apply original-function args)))
 
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;;
   ;; Sometimes, when behind a firewall, the undo-tree package triggers elpaca
@@ -1359,7 +1360,7 @@ As compared to other packages which accomplish similar tasks, including IDO, Ivy
 TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package prescient)
 
@@ -1370,7 +1371,7 @@ TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
 This package provides an orderless completion style that divides the pattern into space-separated components, and matches candidates that match all of the components in any order. Each component can match in any one of several ways: literally, as a regexp, as an initialism, in the flex style, or as multiple word prefixes. By default, regexp and literal matches are enabled.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package orderless
     :when (or (equal completion-handler 'comphand-vertico)
@@ -1386,7 +1387,7 @@ This package provides an orderless completion style that divides the pattern int
 <<<Ivy>>> is an excellent completion framework for Emacs.  It provides a minimal yet powerful selection menu that appears when you open files, switch buffers, and for many other tasks in Emacs.  Counsel is a customized set of commands to replace `find-file` with `counsel-find-file`, etc which provide useful commands for each of the default completion commands.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Swiper and IVY mode
 
   (use-package ivy
@@ -1421,7 +1422,7 @@ Ivy-rich provides rich transformers for commands from ivy and counsel.
 Ivy-yasnippet lets you preview yasnippet snippets with ivy.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package ivy-rich
     :when (equal completion-handler 'comphand-ivy-counsel)
@@ -1442,7 +1443,7 @@ Ivy-yasnippet lets you preview yasnippet snippets with ivy.
 Swiper is an alternative to isearch that uses Ivy to show an overview of all matches.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package swiper
     :when (equal completion-handler 'comphand-ivy-counsel)
@@ -1456,7 +1457,7 @@ Swiper is an alternative to isearch that uses Ivy to show an overview of all mat
 Counsel takes this further, providing versions of common Emacs commands that are customised to make the best use of Ivy. For example, ~counsel-find-file~ has some additional keybindings. Pressing =DEL= will move you to the parent directory.
 
 #+begin_src emacs-lisp :results output silent
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package counsel
     :when (equal completion-handler 'comphand-ivy-counsel)
@@ -1478,7 +1479,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 ~prescient.el~ is a library which sorts and filters lists of candidates, such as appear when you use a package like =Ivy= or =Company=.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package ivy-prescient
     :when (equal completion-handler 'comphand-ivy-counsel)
@@ -1495,7 +1496,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 <<<Corfu>>> enhances in-buffer completion with a small completion popup. The current candidates are shown in a popup below or above the point. The candidates can be selected by moving up and down. Corfu is the minimalistic in-buffer completion counterpart of the Vertico minibuffer UI.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;;;; Code Completion
   (use-package corfu
@@ -1535,7 +1536,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 **** Cape Configuration
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Add extensions
   (use-package cape
     :when (equal completion-handler 'comphand-corfu)
@@ -1583,7 +1584,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 **** Corfu-prescient
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package corfu-prescient
     :when (equal completion-handler 'comphand-corfu)
@@ -1596,7 +1597,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 <<<Vertico>>> provides a performant and minimalistic vertical completion UI based on the default completion system. The focus of Vertico is to provide a UI which behaves correctly under all circumstances. By reusing the built-in facilities system, Vertico achieves full compatibility with built-in Emacs completion commands and completion tables.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package vertico
     :when (equal completion-handler 'comphand-vertico)
@@ -1623,7 +1624,7 @@ Counsel takes this further, providing versions of common Emacs commands that are
 Marginalia are marks or annotations placed at the margin of the page of a book or in this case helpful colorful annotations placed at the margin of the  minibuffer for your completion candidates. Marginalia can only add annotations  to the completion candidates. It cannot modify the appearance of the candidates  themselves, which are shown unaltered as supplied by the original command.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package marginalia
     ;; :when (equal completion-handler 'comphand-vertico)
@@ -1640,7 +1641,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
 **** Icons for Marginalia
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package all-the-icons-completion
     :after (marginalia all-the-icons)
@@ -1653,7 +1654,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
 Consult provides search and navigation commands based on the Emacs completion function completing-read. Completion allows you to quickly select an item from a list of candidates. Consult offers asynchronous and interactive consult-grep and  consult-ripgrep commands, and the line-based search command consult-line. Furthermore Consult provides an advanced buffer switching command consult-buffer to switch between buffers, recently opened files, bookmarks and buffer-like candidates from other sources. Some of the Consult commands are enhanced versions of built-in Emacs commands.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package consult
     :when (equal completion-handler 'comphand-vertico)
@@ -1708,7 +1709,7 @@ Consult provides search and navigation commands based on the Emacs completion fu
 **** Vertico support packages
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package vertico-prescient
     :when (equal completion-handler 'comphand-vertico)
@@ -1719,7 +1720,7 @@ Consult provides search and navigation commands based on the Emacs completion fu
 vertico-posframe is an vertico extension, which lets vertico use posframe to show its candidate menu.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package vertico-posframe
     :when (equal completion-handler 'comphand-vertico)
@@ -1747,7 +1748,7 @@ vertico-posframe is an vertico extension, which lets vertico use posframe to sho
 Enable the IDO handler everywhere.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; This has to be evaluated at the end of the init since it's possible that the
   ;; completion-handler variable will not yet be defined at this point in the
@@ -1764,7 +1765,7 @@ Enable the IDO handler everywhere.
 Embark makes it easy to choose a command to run based on what is near point, both during a minibuffer completion session (in a way familiar to Helm or Counsel users) and in normal buffers. Bind the command  embark-act to a key and it acts like prefix-key for a keymap of actions (commands) relevant to the target around point. With point on an URL in a buffer you can open the URL in a browser or eww or download the file it points to. If while switching buffers you spot an old one, you can kill it right there and continue to select another. Embark comes preconfigured with over a hundred actions for common types of targets such as files, buffers, identifiers, s-expressions, sentences; and it is easy to add more actions and more target types. Embark can also collect all the candidates in a minibuffer to an occur-like buffer or export them to a buffer in a major-mode specific to the type of candidates, such as dired for a set of files, ibuffer for a set of buffers, or customize for a set of variables.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package embark
     :when enable-embark
@@ -1812,7 +1813,7 @@ Embark makes it easy to choose a command to run based on what is near point, bot
 We also use [[https://github.com/sebastiencs/company-box][company-box]] to further enhance the look of the completions with icons and better overall presentation.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
   ;; features. They actually collide.
@@ -1829,7 +1830,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
   ;; features. They actually collide.
@@ -1860,7 +1861,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 **** Company Packages
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package company-box
     :after company
@@ -1904,7 +1905,7 @@ Run a terminal with =M-x term!=
 - If you have =evil-collection= installed, =term-mode= will enter char mode when you use Evil's Insert mode
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package term+
     ;;:ensure (:repo "tarao/term-plus-el" :fetcher github)
@@ -1923,7 +1924,7 @@ Run a terminal with =M-x term!=
 The =eterm-256color= package enhances the output of =term-mode= to enable handling of a wider range of color codes so that many popular terminal applications look as you would expect them to.  Keep in mind that this package requires =ncurses= to be installed on your machine so that it has access to the =tic= program.  Most Linux distributions come with this program installed already so you may not have to do anything extra to use it.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package eterm-256color
     :hook (term-mode . eterm-256color-mode))
@@ -1937,7 +1938,7 @@ The =eterm-256color= package enhances the output of =term-mode= to enable handli
 Make sure that you have the [[https://github.com/akermu/emacs-libvterm/#requirements][necessary dependencies]] installed before trying to use =vterm= because there is a module that will need to be compiled before you can use it successfully.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package vterm
     ;;:ensure (:fetcher github :repo "akermu/emacs-libvterm")
@@ -1981,7 +1982,7 @@ For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
 - https://ambrevar.xyz/emacs-eshell-versus-shell/index.html
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/configure-eshell ()
     ;; Save command history when commands are entered
@@ -2067,7 +2068,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 **** Configuration
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
     ;; Prefer g-prefixed coreutils version of standard utilities when available
   (let ((gls (executable-find "gls")))
@@ -2098,7 +2099,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 Dired, by default, opens up multiple windows - one for each directory. It would be nice to be able to limit =dired= to use just a single window. [[https://codeberg.org/amano.kenji/dired-single][dired-single]] does just that. We configure =dired-single= to open up a directory while in dired with the =C-<return>=  key combination. This will then open up the directory in the buffer named =*dired*=. Whenever a directory is opened with the =C-<return>= key sequence, that directory will then replace what's currently in the =*dired*= buffer.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Single Window dired - don't continually open new buffers
 
   (defun mifi/dired-single-keymap-init ()
@@ -2124,7 +2125,7 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
 This bit of code contains a list of themes that I like personally and then allows them to be switched between themselves. The index of ~theme-selector~ is what is set in order to access a theme via the ~mifi/load-theme-from-selector()~ function.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;;
   ;; 1. The function `mifi/load-theme-from-selector' is called from the
@@ -2152,7 +2153,7 @@ This bit of code contains a list of themes that I like personally and then allow
 This is the main function that allows cycling (up or down) through the list of themes defined in the ~theme-list~.  This function is normally called by the ~disable-theme-functions~ hook. Before calling this function, set the variable ~theme-cycle-step~ to either a 1 or -1 depending upon which direction in the ~theme-list~ array to select the next element from. The resulting index will cycle to the end or the beginning of the list if the computed index goes beyond element 0 or the length of ~theme-list~. The parameter theme is passed to this function when a theme becomes disabled (via the ~disable-theme~ function) and represents the theme that has become disabled.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/cycle-theme-selector (&rest theme)
     "Cycle the `theme-selector' by 1, resetting to 0 if beyond array bounds."
@@ -2179,7 +2180,7 @@ This is the main function that allows cycling (up or down) through the list of t
 This function simply loads the theme from the theme-list indexed by the ~theme-selector~ variable. Note the advice for ~load-theme~ that deactivates the current theme before activating the new theme. This is done to reset all the colors, a clean slate, before the new theme is activated.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defvar theme-did-load nil
     "Set to true if the last Theme was loaded.")
@@ -2205,7 +2206,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 *** Theme selection helper functions.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (defun mifi/print-custom-theme-name ()
     "Print the current loaded theme from the `theme-list' on the modeline."
@@ -2239,7 +2240,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 *** Theme Override Values
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-theme-override-values ()
     (defface org-block-begin-line
@@ -2258,7 +2259,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
       '((t (:strike-through "green" :weight bold)))
       "Face used for the Horizontal like (-----)"))
 
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/customize-modus-theme ()
     (when (featurep 'org)
@@ -2291,7 +2292,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 *Note:* If new themes are added in the ~theme-list~ custom variable then they must be included here along with any customizations.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
 
@@ -2312,7 +2313,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 This includes the theme to use in both graphical and non-graphical.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; (add-hook 'emacs-startup-hook #'(mifi/load-theme-from-selector))
   ;; (mifi/load-theme-from-selector)
   ;; For terminal mode we choose Material theme
@@ -2345,7 +2346,7 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
 *** Define the various font size constants
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Frame (view) setup including fonts.
   ;; You will most likely need to adjust this font size for your system!
@@ -2382,7 +2383,7 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
 A better version of variable-pitch mode. This keeps certain faces (defined in mixed-pitch-fixed-pitch-faces) fixed-pitch.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package mixed-pitch
     :defer t
@@ -2398,7 +2399,7 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
 *** Functions to set the frame size
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Functions to set the frame size
 
   (defun mifi/frame-recenter (&optional frame)
@@ -2452,7 +2453,7 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
 *** Default fonts and sizes
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Default fonts
 
@@ -2495,7 +2496,7 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
 The functions in the list =after-setting-font-hook= are called whenever the frame's font changes. In order to save this value, we capture it and store it in the =custom-default-font-size= custom variable. This variable is saved whenver Emacs exists. Then, when Emacs is started again, the default and fixed-pitch font height values are set to =custom-default-font-size=. The variable pitch font is computed as ~(+ custom-default-font-size 20)~
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/default-font-height-change ()
     (setq-default custom-default-font-size (face-attribute 'default :height))
@@ -2511,7 +2512,7 @@ The functions in the list =after-setting-font-hook= are called whenever the fram
 This little function toggles between a larger font size and the default font size.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Frame font selection
 
   (defvar mifi/font-size-slot 1)
@@ -2549,7 +2550,7 @@ This little function toggles between a larger font size and the default font siz
 Some key kindings to switch to different screen resolutions.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Some alternate keys below....
 
   (bind-keys ("C-c 1". use-small-display-font)
@@ -2573,7 +2574,7 @@ Some key kindings to switch to different screen resolutions.
 These functions are used to configure the main frame font size. Based upon a monitor's size, it may be necessary to make the font larger or smaller.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Frame support functions
 
   (defun mifi/set-frame-font (slot)
@@ -2587,7 +2588,7 @@ These functions are used to configure the main frame font size. Based upon a mon
       ;;else
       (unless enable-frameset-restore (mifi/frame-recenter))))
 
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun use-small-display-font (&optional force-recenter)
     (interactive)
@@ -2631,7 +2632,7 @@ These functions are used to configure the main frame font size. Based upon a mon
 This package provides a global minor mode to increase the spacing/padding of Emacs windows and frames. The idea is to make editing and reading feel more comfortable.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package spacious-padding
     :custom
@@ -2668,7 +2669,7 @@ The =mifi/org-font-setup= function configures various text faces to tweak the si
 This function sets up the fonts faces that are used within org-mode.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package faces :ensure nil)
   (defun mifi/org-font-setup ()
@@ -2747,7 +2748,7 @@ This function sets up the fonts faces that are used within org-mode.
 This section contains the basic configuration for =org-mode= plus the configuration for Org agendas and capture templates.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-mode-visual-fill ()
     (interactive)
@@ -2782,7 +2783,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 ***** Function to setup the agenda
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-setup-agenda ()
     (setq org-agenda-custom-commands
@@ -2838,7 +2839,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 ***** The capture-templates function
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-setup-capture-templates ()
     (setq org-capture-templates
@@ -2915,7 +2916,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 *** The main 'Org' package
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package org
     :pin gnu-elpa
@@ -2969,7 +2970,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 [[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
 
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
+    ;;; ##########################################################################
 
     (use-package org-superstar
       :after org
@@ -3008,7 +3009,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 To execute or export code in =org-mode= code blocks, you'll need to set up =org-babel-load-languages= for each language you'd like to use.  [[https://orgmode.org/worg/org-contrib/babel/languages.html][Babel]] documents all of the languages that you can use with =org-babel=.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (with-eval-after-load 'org
     (org-babel-do-load-languages
@@ -3044,7 +3045,7 @@ Org Mode's structure templates feature enables you to quickly insert code blocks
 This snippet adds a hook to =org-mode= buffers so that =mifi/org-babel-tangle-config= gets executed each time such a buffer gets saved.  This function checks to see if the file being saved is the Emacs.org file you're looking at right now, and if so, automatically exports the configuration here to the associated output files.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (with-eval-after-load 'org
     ;; This is needed as of Org 9.2
@@ -3058,7 +3059,7 @@ This snippet adds a hook to =org-mode= buffers so that =mifi/org-babel-tangle-co
 While there is standard markdown support built into =org-mode=, this additional markdown package can also be used.
 *Disabled for now. Plus there is a large starup time.*
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package ox-gfm
     :after org)
@@ -3078,7 +3079,7 @@ Org Roam solves these problems by making it easy to create topic-focused Org Fil
 **** Some required pacakages 
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   (use-package emacsql :demand t :ensure t :after org)
   (use-package emacsql-sqlite :demand t :ensure t :after org)
    
@@ -3092,7 +3093,7 @@ Typically you won’t want to pull in all of your Org Roam notes, so we’ll onl
 Here is a snippet that will find all the notes with a specific tag and then set your org-agenda-list with the corresponding note files.
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; The buffer you put this code in must have lexical-binding set to t!
   ;; See the final configuration at the end for more details.
 
@@ -3123,7 +3124,7 @@ One added benefit is that we can override the set of capture templates that get 
 This means that we can automatically create a new note with our project capture template if the note doesn’t already exist!
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-roam-project-finalize-hook ()
     "Adds the captured project file to `org-agenda-files' if the
@@ -3160,7 +3161,7 @@ If you want to quickly capture new notes and tasks with a single keybinding into
 
 Even though this file won’t have the timestamped filename, it will still be treated as a node in your Org Roam notes.
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-roam-capture-inbox ()
     (interactive)
@@ -3173,7 +3174,7 @@ Even though this file won’t have the timestamped filename, it will still be tr
 **** Insert a node immediately
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (defun mifi/org-roam-node-insert-immediate (arg &rest args)
     (interactive "P")
@@ -3190,7 +3191,7 @@ If you’ve set up project note files like we mentioned earlier, you can set up 
 Much like the example before, we can either select a project that exists or automatically create a project note when it doesn’t exist yet.
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-roam-capture-task ()
     (interactive)
@@ -3211,7 +3212,7 @@ Much like the example before, we can either select a project that exists or auto
 The following snippet sets up a hook for all Org task state changes and then copies the completed (DONE) entry to today’s note file
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/org-roam-copy-todo-to-today ()
     (interactive)
@@ -3235,7 +3236,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 **** Table-of-contents
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package toc-org
     :after org markdown-mode
@@ -3250,7 +3251,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 **** Main Org-roam Configuration
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package org-roam
     ;; :demand t  ;; Ensure org-roam is loaded by default
@@ -3296,7 +3297,7 @@ Org-transclusion lets you insert a copy of text content via a file link or ID li
 *This is experimental for me and will only enable it when testing.*
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package org-transclusion
     :after org
@@ -3317,7 +3318,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 *** Denote Keymap
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/define-denote-keymap ()
     (interactive)
@@ -3366,7 +3367,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 *** Denote Configuration
 
 #+begin_src  emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package denote
     :custom
@@ -3414,7 +3415,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 [[https://projectile.mx/][Projectile]] is a project management library for Emacs which makes it a lot easier to navigate around code projects for various languages.  Many packages integrate with Projectile so it's a good idea to have it installed even if you don't use its commands directly.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package projectile
     :when (equal custom-project-handler 'custom-project-projectile)
@@ -3442,7 +3443,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 This is the default built-in project system. For those not needing the full-featured ~projectile~, this package is generally enough.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun project-find-go-module (dir)
     (when-let ((root (locate-dominating-file dir "go.mod")))
@@ -3464,7 +3465,7 @@ This is the default built-in project system. For those not needing the full-feat
 <<<Treemacs>>> is a file and project explorer similar to NeoTree or vim’s NerdTree, but largely inspired by the Project Explorer in Eclipse. It shows the file system outlines of your projects in a simple tree layout allowing quick navigation and exploration, while also possessing basic file management utilities.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Treemacs
 
   (use-package treemacs
@@ -3558,7 +3559,7 @@ This is the default built-in project system. For those not needing the full-feat
 ** Treemacs Projectile
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package treemacs-projectile
     :when (equal custom-project-handler 'custom-project-projectile)
@@ -3568,7 +3569,7 @@ This is the default built-in project system. For those not needing the full-feat
 
 ** Treemacs dired
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package treemacs-icons-dired
     :after treemacs
@@ -3578,7 +3579,7 @@ This is the default built-in project system. For those not needing the full-feat
 
 ** Treemacs Persp
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; (use-package treemacs-perspective
   ;;    :disabled
@@ -3595,7 +3596,7 @@ This is the default built-in project system. For those not needing the full-feat
 ** Treemacs tab-bar
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
     :after treemacs
@@ -3606,7 +3607,7 @@ This is the default built-in project system. For those not needing the full-feat
 ** Treemacs all-the-icons
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package treemacs-all-the-icons
     :after treemacs
@@ -3629,7 +3630,7 @@ This is the default built-in project system. For those not needing the full-feat
 
 ** Dashboard Setup
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package dashboard
     :custom
@@ -3671,7 +3672,7 @@ The following are configured for Python development and provide an IDE type expe
 <<<Eglot>>> is the Emacs client for the Language Server Protocol (LSP). Eglot provides infrastructure and a set of commands for enriching the source code editing capabilities of Emacs via LSP. Eglot itself is completely language-agnostic, but it can support any programming language for which there is a language server and an Emacs major mode.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Emacs Polyglot is the Emacs LSP client that stays out of your way:
 
   (defvar mifi/clangd-path (executable-find "clangd")
@@ -3711,7 +3712,7 @@ The JSON-RPC protocol is used to communicate with many different types of server
 *** Eglot Setup
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package eglot
     :when (equal custom-ide 'custom-ide-eglot)
@@ -3762,7 +3763,7 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
 ⚙ Easy to configure - works out of the box and automatically upgrades if additional packages are present.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Language Server Protocol
 
   ;; (when (equal custom-ide 'custom-ide-lsp)
@@ -3788,7 +3789,7 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
 This package contains all the higher level UI modules of lsp-mode, like flycheck support and code lenses. By default, lsp-mode automatically activates lsp-ui unless lsp-auto-configure is set to nil. You only have to put (use-package lsp-ui) in your config and the package will work out of the box.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package lsp-ui
     :when (equal custom-ide 'custom-ide-lsp)
@@ -3819,7 +3820,7 @@ This package contains all the higher level UI modules of lsp-mode, like flycheck
 Integration between lsp-mode and treemacs and implementation of treeview controls using treemacs as a tree renderer.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; To enable bidirectional synchronization of lsp workspace folders and
   ;;; treemacs projects set lsp-treemacs-sync-mode to 1.
 
@@ -3842,7 +3843,7 @@ Integration between lsp-mode and treemacs and implementation of treeview control
 This function is called from the lsp-mode-hook when enering or leaving LSP mode.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; LSP mode setup hook
 
   (defun mifi/lsp-mode-setup ()
@@ -3858,7 +3859,7 @@ This function is called from the lsp-mode-hook when enering or leaving LSP mode.
 *** LSP configuration for Rust
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (defun mifi/define-rust-lsp-values ()
     (setq-default lsp-rust-analyzer-cargo-watch-command "clippy")
@@ -3896,7 +3897,7 @@ Advantages of lsp-bridge:
 + Flexible Customization: Customizing LSP server options is as simple as using a JSON file, allowing different projects to have different JSON configurations with just a few lines of rules
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package lsp-bridge
     :when (equal custom-ide 'custom-ide-lsp-bridge)
@@ -3912,7 +3913,7 @@ Advantages of lsp-bridge:
 
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package markdown-mode
     :when (equal custom-ide 'custom-ide-lsp-bridge))
@@ -3931,7 +3932,7 @@ Anaconda-mode provides Code navigation, documentation lookup and completion for 
 #+end_src
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package anaconda-mode
     :when (equal custom-ide 'custom-ide-anaconda)
@@ -3963,7 +3964,7 @@ C-c C-z switches between your script and the interactive shell.
 C-c C-d displays documentation for the thing under cursor. The documentation will pop in a different buffer, that can be closed with q.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package elpy
     :when (equal custom-ide 'custom-ide-elpy)
@@ -4005,7 +4006,7 @@ C-c C-d displays documentation for the thing under cursor. The documentation wil
 This is more support for a language rather than a langage itself
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package flycheck
     :unless (equal custom-ide 'custom-ide-elpy)
@@ -4035,7 +4036,7 @@ Tree-sitter is a parser generator tool and an incremental parsing library. It ca
 Some functions that are used during the initialization of tree-sitter.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/tree-sitter-setup ()
     (tree-sitter-hl-mode t))
@@ -4049,7 +4050,7 @@ Some functions that are used during the initialization of tree-sitter.
 **** The main Tree-sitter setup
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package tree-sitter
     :defer t
@@ -4079,7 +4080,7 @@ Some functions that are used during the initialization of tree-sitter.
 If a tree-sitter grammer is available and installed, use it instead of the corresponding default mode.  Conversely, when a tree-sitter grammar is not available and a fallback major mode is available/specified, use it instead.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package treesit-auto
     :demand t
@@ -4093,7 +4094,7 @@ If a tree-sitter grammer is available and installed, use it instead of the corre
 Magit]] is the one of the best Git interface implementations .  Common Git operations are easy to execute quickly using Magit's command panel system.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package transient :defer t)
   (use-package git-commit :after transient :defer t)
@@ -4138,7 +4139,7 @@ message
 The following are keymaps that are used by by the custom-ide and for python-mode
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/set-custom-ide-python-keymaps ()
     (cond
@@ -4179,7 +4180,7 @@ The following are keymaps that are used by by the custom-ide and for python-mode
 These functions are used during python intialization or file loading. This is where Python IDE functionality, linting and debugging setup begins.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/load-python-file-hook ()
     (python-mode)
@@ -4233,7 +4234,7 @@ These functions are used during python intialization or file loading. This is wh
 This is the primary Python setup that is triggered by the first load of the Python mode and then any time a file is loaded.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (add-to-list 'auto-mode-alist '("\\.py\\'" . mifi/load-python-file-hook))
 
@@ -4252,7 +4253,7 @@ This is the primary Python setup that is triggered by the first load of the Pyth
 autopep8 automatically formats Python code to conform to the `PEP 8` style guide.  It uses the pycodestyle_ utility to determine what parts of the code needs to be formatted.  autopep8 is capable of fixing most of the formatting issues_ that can be reported by pycodestyle. Refer to the [[IMPORTANT][IMPORTANT]] section above for possible issues when autopep8 is installed.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package py-autopep8
     :after python
@@ -4263,7 +4264,7 @@ autopep8 automatically formats Python code to conform to the `PEP 8` style guide
 *** Python Keybinding
 **** Helpful Macros
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; This is a helpful macro that is used to put double quotes around a word.
   (defalias 'quote-word
@@ -4284,7 +4285,7 @@ autopep8 automatically formats Python code to conform to the `PEP 8` style guide
 We use Pyvenv-auto is a package that automatically changes to the Python virtual environment based upon the project's directory.  pyvenv-auto looks at the root director of the project for a =.venv= or =venv= (and a few others)
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package pyvenv-auto
     :after python
@@ -4295,7 +4296,7 @@ We use Pyvenv-auto is a package that automatically changes to the Python virtual
 *** Pydoc
 #Pydoc, the Python documentation navigation package
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package pydoc
     ;;:ensure (:host github :repo "statmobile/pydoc")
@@ -4311,7 +4312,7 @@ We use Pyvenv-auto is a package that automatically changes to the Python virtual
 This is a basic configuration for the TypeScript language so that =.ts= files activate =typescript-ts-mode= when opened.  We're also adding a hook to =typescript-mode-hook= to call =lsp-deferred= so that we activate =lsp-mode= to get LSP features every time we edit TypeScript code.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package typescript-mode
     :defer t
@@ -4335,7 +4336,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 *** NodeJS
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/load-js-file-hook ()
     (js2-mode)
@@ -4362,7 +4363,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 
 *** JS2-Mode
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package js2-mode
     :hook (js-mode . js2-minor-mode)
@@ -4380,7 +4381,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 
 ** C/C++
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/load-c-file-hook ()
     (c-mode)
@@ -4409,7 +4410,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 RGBDS is a compiler that has been around quite a long time (since 1997). It supports Z80 and the LR35902 assembler syntaxes that are used in the development of Game Boy and Game Boy color games.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package z80-mode
     :when enable-gb-dev
@@ -4433,7 +4434,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 *** Rustic package configuration
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package rustic
     :ensure t
@@ -4470,7 +4471,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 *** Rust-mode configuration
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; (use-package graphql-mode)
   (use-package rust-mode
@@ -4491,7 +4492,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 *** Cargo-mode configuration
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package cargo-mode
     :defer t
@@ -4522,7 +4523,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
 *** Main go-mode config
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun eglot-format-buffer-on-save ()
     (add-hook 'before-save-hook #'eglot-format-buffer -10 t))
@@ -4552,7 +4553,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
 for variable, functions and current argument position of function.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package go-eldoc
     :after go-mode
@@ -4570,7 +4571,7 @@ for variable, functions and current argument position of function.
 Integration of the Go 'guru' analysis tool into Emacs.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package go-guru
     :after go-mode
@@ -4586,7 +4587,7 @@ Lesser used or lesser known languages.
 Lisp support is handled by SLIME which is the “Superior Lisp Interaction Mode for Emacs”. SLIME extends Emacs with support for interactive programming in Common Lisp. The features are centered around slime-mode, an Emacs minor-mode that complements the standard lisp-mode. While lisp-mode supports editing Lisp source files, slime-mode adds support for interacting with a running Common Lisp process for compilation, debugging, documentation lookup, and so on. Extensive documentation can be found [[https://slime.common-lisp.dev/doc/html/][at this link]].
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package slime
     :defer t
@@ -4599,7 +4600,7 @@ Lisp support is handled by SLIME which is the “Superior Lisp Interaction Mode 
 *** Swift / Swift Playground
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package swift-mode
     :defer t
@@ -4706,7 +4707,7 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
 **** DAPE for TypeScript
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (setq mifi/vscode-js-debug-dir (file-name-concat user-emacs-directory "dape/vscode-js-debug"))
 
@@ -4727,7 +4728,7 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
 This is meant to be evaluated and run once. Calling this function will clone the vscode-js-debug framework. This is a DAP-based JavaScript debugger. It debugs Node.js, Chrome, Edge, WebView2, VS Code extensions, and more. It has been the default JavaScript debugger in Visual Studio Code since 1.46, and is gradually rolling out in Visual Studio proper.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; (mifi/install-vscode-js-debug)
 
@@ -4766,7 +4767,7 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
 ***** DAPE Hydra Debug Functions
 
 #+begin_src emacs-lisp :output silent
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/dape-end-debug-session ()
     "End the debug session."
@@ -4784,7 +4785,7 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
 ***** DAPE Hydra Definition
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun define-dape-hydra ()
     (defhydra dape-hydra (:color pink :hint nil :foreign-keys run)
@@ -4839,7 +4840,7 @@ The idea behind the Debug Adapter Protocol (DAP) is to abstract the way how the 
 The Debug Adapter Protocol makes it possible to implement a generic debugger for a development tool that can communicate with different debuggers via Debug Adapters. And Debug Adapters can be re-used across multiple development tools which significantly reduces the effort to support a new debugger in different tools.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; Debug Adapter Protocol
   (use-package dap-mode
     :when (equal debug-adapter 'debug-adapter-dap-mode)
@@ -4864,7 +4865,7 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
 **** DAP Package for Python :Python:
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; DAP for Python
 
   (use-package dap-python
@@ -4882,7 +4883,7 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
 Something that is needed for Rust and Go debugging.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package dap-lldb
     :when (equal debug-adapter 'debug-adapter-dap-mode)
@@ -4921,7 +4922,7 @@ Something that is needed for Rust and Go debugging.
 
 **** DAP Template for NodeJS
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;;; DAP for NodeJS
 
   (defun mifi/setup-dap-node ()
@@ -4952,7 +4953,7 @@ Something that is needed for Rust and Go debugging.
 **** DAP Templates For Various Languages :Python:Rust:
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (with-eval-after-load 'dap-lldb
     (dap-register-debug-template
@@ -4989,7 +4990,7 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 
 ***** DAP Hydra Debug Functions :Python:
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/dap-end-debug-session ()
     "End the debug session and delete project Python buffers."
@@ -5015,7 +5016,7 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 
 ***** DAP Hydra Definition Function
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun define-dap-hydra ()
     (defhydra dap-hydra (:color pink :hint nil :foreign-keys run)
@@ -5081,7 +5082,7 @@ The following packages are some additional quality of life features.
 
 ** IRC Client
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (add-hook 'rcirc-mode-hook #'rcirc-track-minor-mode)
   (add-hook 'rcirc-mode-hook #'rcirc-omit-mode)
@@ -5093,7 +5094,7 @@ The following packages are some additional quality of life features.
 [[https://github.com/Wilfred/helpful][Helpful]] adds a lot of very helpful (get it?) information to Emacs' =describe-= command buffers.  For example, if you use =describe-function=, you will not only get the documentation about the function, you will also see the source code of the function and where it gets used in other places in the Emacs configuration.  It is very useful for figuring out how things work in Emacs.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; helpful package
 
   (use-package helpful
@@ -5137,7 +5138,7 @@ The following packages are some additional quality of life features.
 
 ** Solair mode
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package solaire-mode
     :after treemacs
@@ -5152,7 +5153,7 @@ The following packages are some additional quality of life features.
 
 ** Golden Ratio
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Golen Ratio
 
   (use-package golden-ratio
@@ -5185,7 +5186,7 @@ The following packages are some additional quality of life features.
 This file is for lazy people wanting to swap buffers without typing C-x b on each window.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   
   (use-package buffer-move
     :bind (("C-S-<up>"     . buf-move-up)
@@ -5199,7 +5200,7 @@ This file is for lazy people wanting to swap buffers without typing C-x b on eac
 A tree plugin like NerdTree for Vim
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package neotree
     :when enable-neotree
@@ -5213,7 +5214,7 @@ A tree plugin like NerdTree for Vim
 Here are some helpful functions.
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Functions to insert the buffer file name at the current cursor position
   ;;
   (defun mifi/insert-buffer-full-name-at-point ()
@@ -5228,7 +5229,7 @@ Here are some helpful functions.
 
 ** Centaur Tabs
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Enable tabs for each buffer
 
   (use-package centaur-tabs
@@ -5249,7 +5250,7 @@ Here are some helpful functions.
 =diff-hl-mode= highlights uncommitted changes on the left side of the window (area also known as the "gutter"), allows you to jump between and revert them selectively.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package diff-hl
     :config
@@ -5259,7 +5260,7 @@ Here are some helpful functions.
 
 ** Pulsar
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package pulsar
     :config
@@ -5277,7 +5278,7 @@ Here are some helpful functions.
 This minor mode sets background color to strings that match color names, e.g. #0000FF is displayed in white with a blue background.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package rainbow-mode
     :hook (prog-mode . (lambda () (rainbow-mode t))))
@@ -5289,7 +5290,7 @@ This minor mode sets background color to strings that match color names, e.g. #0
 highlight-defined is an Emacs minor mode that highlights defined Emacs Lisp symbols in source code.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package highlight-defined
     :hook (emacs-lisp-mode . highlight-defined-mode))
@@ -5303,7 +5304,7 @@ Popper is a minor-mode to tame the flood of ephemeral windows Emacs produces, wh
 Designate any buffer to “popup” status, and it will stay out of your way. Disimss or summon it easily with one key. Cycle through all your “popups” or just the ones relevant to your current buffer. Group popups automatically so you’re presented with the most relevant ones. Useful for many things, including toggling display of REPLs, documentation, compilation or shell output: any buffer you need instant access to but want kept out of your way!
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package popper
     :bind (("C-`"   . popper-toggle)
@@ -5333,7 +5334,7 @@ Designate any buffer to “popup” status, and it will stay out of your way. Di
 markdown-mode is a major mode for editing Markdown-formatted text. The latest stable version is markdown-mode 2.5, released on Feb 12, 2022. See the release notes for details. markdown-mode is free software, licensed under the GNU GPL, version 3 or later.
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (use-package markdown-mode
     :ensure t
@@ -5347,7 +5348,7 @@ markdown-mode is a major mode for editing Markdown-formatted text. The latest st
 Instant Github-flavored Markdown/Org preview using Grip (GitHub Readme Instant Preview).
 
 #+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;; Use keybindings
   (use-package grip-mode
@@ -5368,16 +5369,16 @@ Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It work
 
 *** Mitch's Minor Mode Functions
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/set-fill-column-interactively (num)
     "Asks for the fill column."
-    (interactive "fill-column: ")
+    (interactive "nfill-column: ")
     (set-fill-column num))
 
   (defun mifi/set-org-fill-column-interactively (num)
     "Asks for the fill column for Org mode."
-    (interactive "org-fill-column: ")
+    (interactive "norg-fill-column: ")
     (setq custom-org-fill-column num)
     (mifi/org-mode-visual-fill)
     (redraw-display))
@@ -5394,13 +5395,13 @@ Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It work
 This is a set of keymaps that do the same things as the popup menu. Both are here for convenience. *Note* that the ~mmm-menu~ is called with either a ="C-c RET RET"= or simply a ="C-c C-<return>"=.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/define-mmm-minor-mode-map ()
     (defvar mmm-keys-minor-mode-map
       (let ((map (make-sparse-keymap)))
         (bind-keys :map map
-        ("M-RET $" . jinx-correct)
+          ("M-RET $" . jinx-correct)
           ("M-RET ?" . eldoc-box-help-at-point)
           ("M-RET S e" . eshell)
           ("M-RET S i" . ielm)
@@ -5413,8 +5414,9 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
           ("M-RET f" . mifi/set-fill-column-interactively)
           ("M-RET p" . pulsar-pulse-line)
           ("M-RET r" . repeat-mode)
-        ("M-RET j" . mifi/jump-to-register)
-          ("M-RET |" . global-display-fill-column-indicator-mode))
+          ("M-RET j" . mifi/jump-to-register)
+          ("M-RET |" . global-display-fill-column-indicator-mode)
+          ("M-RET C-g" . keyboard-quit))
         map)
       "mmm-keys-minor-mode keymap.")
 
@@ -5434,31 +5436,33 @@ For those menus that would normally show up as either =prefix= or =lambda=, give
 shown. Plus, some keys are mode specific and will only appear when that major mode is active.
 
 #+begin_src emacs-lisp :results output silent
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
-  (defun mifi/mmm-handle-context-keys ()
+  (defun mifi/mmm-handle-context-keys (&optional winframe)
     "Enable or Disable keys based upon featurep context."
+    (when winframe
     (let ((map mmm-keys-minor-mode-map))
-      (unbind-key "M-RET o f" map)
-      (unbind-key "M-RET o l" map)
-      (unbind-key "M-RET P ?" map)
-      (unbind-key "M-RET M-RET" map)
       (when enable-thesaurus
         (bind-keys :map map
-        ("M-RET m t" . mw-thesaurus-lookup-dwim)))
+          ("M-RET m t" . mw-thesaurus-lookup-dwim)))
       (cond
         ((equal major-mode 'org-mode)
-        (bind-keys :map map
-          ("M-RET M-RET" . org-insert-heading)
-          ("M-RET o f" . mifi/set-org-fill-column-interactively)
-          ("M-RET o l" . org-toggle-link-display)))
+          (bind-keys :map map
+            ("M-RET M-RET" . org-insert-heading)
+            ("M-RET o f" . mifi/set-org-fill-column-interactively)
+            ("M-RET o l" . org-toggle-link-display)))
         ((equal major-mode 'python-mode)
-        (bind-keys :map map
-          ("M-RET P" . 'pydoc-at-point))))))
+          (bind-keys :map map
+            ("M-RET P" . 'pydoc-at-point)))
+        (t   ;; Default 
+          (unbind-key "M-RET o f" map)
+          (unbind-key "M-RET o l" map)
+          (unbind-key "M-RET P ?" map)
+          (unbind-key "M-RET M-RET" map))))))
 
-  (defun mifi/mmm-update-menu ()
+  (defun mifi/mmm-update-menu (&optional winframe)
     (interactive)
-    (mifi/mmm-handle-context-keys)
+    (mifi/mmm-handle-context-keys nil)
     (which-key-add-key-based-replacements "M-RET S" "shells")
     (which-key-add-key-based-replacements "M-RET T" "theme-keys")
     (which-key-add-key-based-replacements "M-RET P" "python-menu")
@@ -5469,14 +5473,22 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
     (which-key-add-key-based-replacements "M-RET j" "jump-to-register")
     (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
+
+  ;; Check the keys when:
+  ;; - the whick-key menu is displayed
   (add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)
+  ;; - the user updates/changes the buffer - like loading a file
+  ;;   (but not switching to a new buffer)
+  (add-hook 'window-buffer-change-functions 'mifi/mmm-handle-context-keys)
+  ;; - the user switches windows
+  (add-hook 'window-selection-change-functions 'mifi/mmm-handle-context-keys)
 
 #+end_src
 
 ** Initial *scratch* buffer message
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (add-hook 'elpaca-after-init-hook
     (lambda ()
@@ -5501,7 +5513,7 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
 ** Exiting and Cleanup
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   (defun mifi/cleanup-when-exiting ()
     (let ((backdir (format "%s/config-backup" working-files-directory)))
@@ -5526,7 +5538,7 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
 The following is a list of major mode-hooks variables that are set so that they don't follow the normal global line number mode. If there is any mode that doesn't appear here, more than likely it will have line numbers added. Just add the hook name here to make it so that major mode not have line numbers. This doesn't effect minor modes.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Ignore Line Numbers for the following modes:
 
   ;; Line #'s appear everywhere if global-display-line-numbers-mode is set
@@ -5549,7 +5561,7 @@ The following is a list of major mode-hooks variables that are set so that they 
 ** Supress common warnings
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
   ;; Supress common annoying warning.
   ;; These can still be found in the  *Warnings* buffer
   (setq warning-suppress-types '((package reinitialization)
@@ -5564,7 +5576,7 @@ The following is a list of major mode-hooks variables that are set so that they 
 The standard =lisp= footer that should appear at the end of every =lisp= source file.
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+  ;;; ##########################################################################
 
   ;;; init.el ends here.
 

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -2,7 +2,7 @@
 #+author: Mitch Fisher
 #+date: 2024-05-11
 #+OPTIONS: toc:nil h:4
-#+STARTUP: showeverything
+#+STARTUP: showall
 #+PROPERTY: header-args:emacs-lisp :tangle ./init.el :results silent :exports code :mkdirp yes
 
 * Welcome!
@@ -11,7 +11,7 @@ This ORG file will configure the  ~init.el~  file based upon all of the =emacs-l
 
 The goal of this Emacs configuration is to make an Emacs configuration that has a good collection of popular options. So far, the following collections of options are included here:
 
-
+:feature-overview:
 - Landing Screen Options ::
   + Dashboard
   + IELM (Integrated Emacs Lisp Mode)
@@ -50,6 +50,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
   + Golden Ratio
   + Embark
   + Customizable Menu (MmM)
+:END:
 
 
 * README:
@@ -124,6 +125,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
     use-package-always-ensure nil
     use-package-always-demand nil
     use-package-always-defer nil)
+  
 #+end_src
 
 ** Calculate startup time
@@ -154,6 +156,40 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
       (setq gc-cons-percentage 0.1))) ;; Default value for `gc-cons-percentage'
 
 #+end_src
+
+** Establish PATH
+
+Because in macOS, Emacs could be started outside of a shell (like an application on the Dock), this code is used to migrate the <current user's shell path to Emacs ~exec-path~.
+
+#+begin_src emacs-lisp :tangle "early-init.el"
+  ;;; --------------------------------------------------------------------------
+  (defconst *is-a-mac* (eq system-type 'darwin))
+
+  (defun mifi/setup-exec-path ()
+       ;;; Set up Emacs' `exec-path' and PATH environment variable to match"
+       ;;; that used by the user's shell.
+       ;;; This is particularly useful under Mac OS X and macOS, where GUI
+       ;;; apps are not started from a shell."
+    (interactive)
+    (setq exec-path '( "/Users/strider/.cargo/bin"
+                     "/Users/strider/.local/bin"
+                     "/opt/homebrew/bin" "/opt/homebrew/sbin"
+                     "/usr/bin" "/bin" "/usr/sbin" "/sbin"
+                     "/usr/local/bin" "/opt/local/bin"
+                     "/Library/Frameworks/Python.framework/Versions/Current/bin"))
+
+    (let ((path-from-exec-path (string-join exec-path path-separator)))
+      (setenv "PATH" path-from-exec-path)))
+
+  (setq browse-url-firefox-program
+    "/Applications/Firefox.app/Contents/MacOS/firefox")
+  (setq browse-url-chrome-program
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+
+  (add-hook 'before-init-hook #'mifi/setup-exec-path)
+
+#+end_src
+
 
 #+begin_src emacs-lisp :tangle "early-init.el" 
   ;;; early-init.el ends here.
@@ -187,6 +223,7 @@ This is the standard format of a =lisp= header that should appear for all =lisp=
 
 Elpaca is an elisp package manager. It allows users to find, install, update, and remove third-party packages for Emacs. It is a replacement for the built-in Emacs package manager, package.el.
 
+:Elpaca-Features:
 Elpaca:
 
 - Installs packages asynchronously, in parallel for fast, non-blocking installations.
@@ -194,9 +231,11 @@ Elpaca:
 - Downloads packages from their sources for convenient elisp development.
 - Supports thousands of elisp packages out of the box (MELPA, NonGNU/GNU ELPA, Org/org-contrib).
 - Makes it easy for users to create their own ELPAs.
+:END:
 
 #+begin_src emacs-lisp
-
+  ;;; --------------------------------------------------------------------------
+  
   (defvar elpaca-installer-version 0.7)
   (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
   (defvar elpaca-builds-directory (expand-file-name "builds/" elpaca-directory))
@@ -246,7 +285,7 @@ Elpaca:
 #+end_src
 
 
-* Custom Groups and Variables
+* Customizable Variables
 
 Set various variables to =t= to turn on a specific feature or =nil= to disable it. Changing any of these values will require a restart of ~emacs~ since these values are inspected only during startup.
 
@@ -286,7 +325,7 @@ These are the groups used by this Emacs config for customization.
 ** File Locations and Variables
 
 #+begin_src emacs-lisp
-      ;;; --------------------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
 
   (defcustom dashboard-landing-screen t
     "If set to t, the `dashboard' package will be displayed once emacs has
@@ -462,6 +501,7 @@ These are features that basically have multiple-choice options instead of being 
 #+end_src
 
 ** Theme Specific Values
+
 This is a curated selection of themes that I personally like. Most of them are dark mode but there are a few light versions. New themes can be added here or done via the =customize= interface. If a new theme is added to this list, it's important to ensure that the theme is actually included (see [[Color Theming][Color Theming]] section)
 
 #+begin_src emacs-lisp
@@ -568,15 +608,16 @@ This is a curated selection of themes that I personally like. Most of them are d
 Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
 
 #+begin_src emacs-lisp
-
-  (defun mrf/validate-variable-pitch-font ()
+  ;;; --------------------------------------------------------------------------
+  
+  (defun mifi/validate-variable-pitch-font ()
     (let* ((variable-pitch-font
              (cond
-  	     ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
-  	     ((x-list-fonts "SF Pro")           "SF Pro")
-  	     ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
-  	     ((x-list-fonts "Ubuntu")           "Ubuntu")
-  	     ((x-list-fonts "Helvetica")        "Helvetica")
+             ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
+             ((x-list-fonts "SF Pro")           "SF Pro")
+             ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
+             ((x-list-fonts "Ubuntu")           "Ubuntu")
+             ((x-list-fonts "Helvetica")        "Helvetica")
                ((x-list-fonts "Source Sans Pro")  "Source Sans Pro")
                ((x-list-fonts "Lucida Grande")    "Lucida Grande")
                ((x-list-fonts "Verdana")          "Verdana")
@@ -584,7 +625,7 @@ Look for a proportional font that is available on the OS. If the actual default 
                (nil (warn "Cannot find a Sans Serif Font.  Install Source Sans Pro.")))))
       (if variable-pitch-font
         (when (not (equal variable-pitch-font variable-pitch-font-family))
-  	(setq variable-pitch-font-family variable-pitch-font))
+        (setq variable-pitch-font-family variable-pitch-font))
         (message "---- Can't find a variable-pitch font to use.")))
 
     (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
@@ -596,60 +637,32 @@ Look for a proportional font that is available on the OS. If the actual default 
 Look for a proportional font that is available on the OS. If the actual default font isn't available, find another that will work instead.
 
 #+begin_src emacs-lisp
-
-  (defun mrf/validate-monospace-font ()
+  ;;; --------------------------------------------------------------------------
+  
+  (defun mifi/validate-monospace-font ()
     (let* ((monospace-font
              (cond
-  	     ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
-  	     ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
-  	     ((x-list-fonts "Fira Code")         "Fira Code")
-  	     ((x-list-fonts "Source Code Pro")   "Source Code Pro")
-  	     ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
+             ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
+             ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
+             ((x-list-fonts "Fira Code")         "Fira Code")
+             ((x-list-fonts "Source Code Pro")   "Source Code Pro")
+             ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
                ((x-family-fonts "Monospaced")      "Monospaced")
                (nil (warn "Cannot find a monospaced Font.  Install Source Code Pro.")))))
       (if monospace-font
         (when (not (equal monospace-font variable-pitch-font-family))
-  	(setq mono-spaced-font-family monospace-font)
-  	(setq default-font-family monospace-font))
+        (setq mono-spaced-font-family monospace-font)
+        (setq default-font-family monospace-font))
         (message "---- Can't find a monospace font to use.")))
 
     (message (format ">>> monospace font is %s" mono-spaced-font-family)))
-  
+
 #+end_src
 
 
-* Global Configuration
+* General Configuration
 
 Setup initial paths, global values and settings, and Emacs working directories.
-
-** Use Shell Path
-Because in macOS, Emacs could be started outside of a shell (like an application on the Dock), this code is used to migrate the <current user's shell path to Emacs ~exec-path~.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  ;; Use shell path
-
-  (defun set-exec-path-from-shell-PATH ()
-     ;;; Set up Emacs' `exec-path' and PATH environment variable to match"
-     ;;; that used by the user's shell.
-     ;;; This is particularly useful under Mac OS X and macOS, where GUI
-     ;;; apps are not started from a shell."
-    (interactive)
-    (let ((path-from-shell (replace-regexp-in-string "[ \t\n]*$" ""
-                             (shell-command-to-string "$SHELL --login -c 'echo $PATH'"))))
-      (setenv "PATH" path-from-shell)
-      (setq exec-path (split-string path-from-shell path-separator))
-      (add-to-list 'exec-path "/opt/homebrew/bin")
-      (add-to-list 'exec-path "/usr/local/bin")
-      (add-to-list 'exec-path "/opt/homebrew/opt/openjdk/bin")
-      (add-to-list 'exec-path "/opt/homebrew/opt/node@20/bin/node")
-      (setq-default insert-directory-program "gls"
-        dired-use-ls-dired t
-        ;; Needed to fix an issue on Mac which causes dired to fail
-        dired-listing-switches "-al --group-directories-first")))
-
-#+end_src
 
 ** Emacs/User Config Directory
 
@@ -683,8 +696,8 @@ By default, the =user-emacs-directory= points to the .emacs.d* directory from wh
 
   ;; ensure that the loaded font values are supported by this OS. If not, try
   ;; to correct them.
-  (mrf/validate-variable-pitch-font)
-  (mrf/validate-monospace-font)
+  (mifi/validate-variable-pitch-font)
+  (mifi/validate-monospace-font)
 
 #+end_src
 
@@ -701,7 +714,9 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
 #+end_src
 
-** Global default variables
+** Better Defaults
+
+These are global variables that effect the behavior of Emacs in general.
 
 #+begin_src emacs-lisp
 
@@ -723,6 +738,7 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
     lisp-indent-offset '2     ;; emacs lisp tab size
     visible-bell t             ;; Set up the visible bell
     truncate-lines 1           ;; long lines of text do not wrap
+    sentence-end-double-space nil
     fill-column 80             ;; Default line limit for fills
     ;; Triggers project for directories with any of the following files:
     project-vc-extra-root-markers '(".dir-locals.el"
@@ -730,13 +746,12 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
                                    "Gemfile"
                                    "package.json"))
 
-  (defconst *is-a-mac* (eq system-type 'darwin))
-
-
 #+end_src
 
-** Globally enabled/disabled modes
-*** Save History
+** Save History
+
+Keeps a persistent history file across Emacs restarts. It's also saved into the ~user-emacs-directory~ so it's not tied to a specific Emacs installation.
+
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
@@ -751,12 +766,19 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
 #+end_src
 
+** Better Modes
+
+Calls to mode functions that effect various Emacs behavior.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; (global-display-line-numbers-mode 1) ;; Line numbers appear everywhere
+  ;; A cool mode to revert a window configuration
+  (winner-mode 1)
+
+  ;; Change "yes" or "no" responses to just require "y" or "n"
+  (fset 'yes-or-no-p 'y-or-n-p)
   (save-place-mode 1)                  ;; Remember where we were last editing a file.
-  (show-paren-mode 1)
   (column-number-mode 1)
   (tool-bar-mode -1)                   ;; Hide the toolbar
   (global-prettify-symbols-mode 1)     ;; Display pretty symbols (i.e. λ = lambda)
@@ -765,26 +787,56 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
 #+end_src
 
-*** Save / Restore Frameset
+*** Configure 'paren' mode
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  ;; Used to highlight matching delimiters '( { [ ] } )
+  (use-package paren
+    :ensure nil    ;; built-in
+    :custom
+    show-paren-delay 0.1
+    show-paren-highlight-openparen t
+    show-paren-when-point-inside-paren t
+    show-paren-when-point-in-periphery t
+    show-paren-context-when-offscreen t
+    :config
+    (show-paren-mode 1))
+
+#+end_src
+
+
+** Save / Restore Frameset
+** Some Common Registers
+
+#+begin_src emacs-lisp
+
+  (setq register-preview-delay 0) ;; Show registers ASAP
+  (set-register ?C (cons 'file (concat emacs-config-directory "/emacs-config.org")))
+
+#+end_src
+
 
 These functions will save and restore Emacs framework. These are normally called when starting and exiting Emacs.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/save-desktop-frameset ()
+  (defun mifi/save-desktop-frameset ()
     (unless (daemonp)
       (desktop-save-mode 0)
       (desktop-save-frameset)
       (with-temp-file (expand-file-name "saved-frameset.el" user-emacs-directory)
-        (insert
-        (format "(setq desktop-saved-frameset %S)" desktop-saved-frameset)))))
+        (insert (format
+                  "(setq desktop-saved-frameset %S)"
+                  desktop-saved-frameset)))))
 
-  (add-hook 'kill-emacs-hook 'mrf/save-desktop-frameset)
+  (add-hook 'kill-emacs-hook 'mifi/save-desktop-frameset)
 
   ;;; --------------------------------------------------------------------------
    
-  (defun mrf/restore-desktop-frameset ()
+  (defun mifi/restore-desktop-frameset ()
     (unless (and (daemonp) (not enable-frameset-restore))
       (let
         ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
@@ -802,7 +854,7 @@ These functions will save and restore Emacs framework. These are normally called
 ** Emacs in server mode
 
 #+begin_src emacs-lisp
-
+  ;;; --------------------------------------------------------------------------
   ;; Allow access from emacsclient
   (add-hook 'elpaca-after-init-hook
     (lambda ()
@@ -859,7 +911,7 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/set-diminish ()
+  (defun mifi/set-diminish ()
     (when (equal custom-project-handler 'custom-project-projectile)
       (diminish 'projectile-mode "PrM"))
     (diminish 'anaconda-mode)
@@ -876,8 +928,8 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
     :config
     (if (not elpaca-after-init-time)
       (add-hook 'elpaca-after-init-hook
-        (lambda () (run-with-timer 0.5 nil 'mrf/set-diminish)))
-      (run-with-timer 1.0 nil 'mrf/set-diminsh)))
+        (lambda () (run-with-timer 0.5 nil 'mifi/set-diminish)))
+      (run-with-timer 1.0 nil 'mifi/set-diminsh)))
 
 
 #+end_src
@@ -890,10 +942,15 @@ The Hydra is vanquished once Hercules, any binding that isn't the Hydra's head, 
 
   (use-package which-key
     :diminish which-key-mode
-    :custom (which-key-idle-delay 1)
+    :custom
+    (which-key-idle-delay 1)
+    (which-key-prefix-prefix "◉ ")
+    (which-key-sort-order 'which-key-key-order-alpha)
+    (which-key-min-display-lines 3)
+    (which-key-max-display-columns nil)
     :config
     (which-key-mode)
-    (which-key-setup-side-window-right))
+    (which-key-setup-minibuffer))
 
 #+end_src
 
@@ -964,13 +1021,14 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
   ;;; --------------------------------------------------------------------------
 
   ;; Macintosh specific configurations.
+  (when *is-a-mac*
+    (setq mac-command-modifier       'meta
+          mac-option-modifier         nil
+          mac-control-modifier       'control
+          mac-right-command-modifier 'super
+          mac-right-control-modifier 'hyper)
 
-  (defconst *is-a-mac* (eq system-type 'darwin))
-  (when (eq system-type 'darwin)
-    (setq mac-option-key-is-meta nil
-      mac-command-key-is-meta t
-      mac-command-modifier 'meta
-      mac-option-modifier 'super))
+    (global-set-key (kbd "<escape>") 'keyboard-escape-quit))
 
 #+end_src
 
@@ -1041,7 +1099,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 This package displays ElDoc documentations in a childframe. The childframe is selectable and scrollable with mouse, even though the cursor is hidden.
 
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
 
   ;; prevent (emacs) eldoc loaded before Elpaca activation warning.
   ;; (Warning only displayed during first Elpaca installation)
@@ -1058,7 +1116,7 @@ This package displays ElDoc documentations in a childframe. The childframe is se
     ;; So, to get our themes loading properly, load it here if not already
     ;; loaded.
     (unless theme-did-load
-      (mrf/load-theme-from-selector)))
+      (mifi/load-theme-from-selector)))
 
   (use-package eldoc-box
     :after eldoc
@@ -1214,7 +1272,7 @@ Jinx is a fast just-in-time spell-checker for Emacs. Jinx highlights misspelled 
 Jinx requires the library ~libenchant~ or ~enchant~ installed. This can be done via the [[https://github.com/AbiWord/enchant][enchant github]] site, through ~brew~ on macOS or the package management system of the OS.
 
 #+begin_src emacs-lisp
-
+  ;;; --------------------------------------------------------------------------
   (use-package jinx
     :ensure (:host github :repo "minad/jinx")
     ;;:hook (emacs-startup . global-jinx-mode)
@@ -1232,7 +1290,8 @@ Jinx requires the library ~libenchant~ or ~enchant~ installed. This can be done 
 These are packages located in the ~"lisp"~ directory within the emacs-config-directory.
 
 #+begin_src emacs-lisp
-
+  ;;; --------------------------------------------------------------------------
+  
 #+end_src
 
 
@@ -1266,7 +1325,7 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/undo-tree-hook ()
+  (defun mifi/undo-tree-hook ()
     (set-frame-width (selected-frame) 20))
 
   (defun undo-tree-split-side-by-side (original-function &rest args)
@@ -1311,15 +1370,16 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
 
 
 
-* Theme List and Selection
+* Visuals
+** Theme List and Selection
 
-This bit of code contains a list of themes that I like personally and then allows them to be switched between themselves. The index of ~theme-selector~ is what is set in order to access a theme via the ~mrf/load-theme-from-selector()~ function.
+This bit of code contains a list of themes that I like personally and then allows them to be switched between themselves. The index of ~theme-selector~ is what is set in order to access a theme via the ~mifi/load-theme-from-selector()~ function.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;;
-  ;; 1. The function `mrf/load-theme-from-selector' is called from the
+  ;; 1. The function `mifi/load-theme-from-selector' is called from the
   ;;    "C-= =" Keybinding (just search for it).
   ;;
   ;; 2. Once the new theme is loaded via the `theme-selector', the previous
@@ -1327,7 +1387,7 @@ This bit of code contains a list of themes that I like personally and then allow
   ;;    `disable-theme-functions' hook are called (defined in the load-theme.el
   ;;    package).
   ;;
-  ;; 3. The function `mrf/cycle-theme-selector' is called by the hook. This
+  ;; 3. The function `mifi/cycle-theme-selector' is called by the hook. This
   ;;    function increments the theme-selector by 1, cycling the value to 0
   ;;    if beyond the `theme-list' bounds.
   ;;
@@ -1339,14 +1399,14 @@ This bit of code contains a list of themes that I like personally and then allow
 
 #+end_src
 
-** Cycle Theme Function
+*** Cycle Theme Function
 
 This is the main function that allows cycling (up or down) through the list of themes defined in the ~theme-list~.  This function is normally called by the ~disable-theme-functions~ hook. Before calling this function, set the variable ~theme-cycle-step~ to either a 1 or -1 depending upon which direction in the ~theme-list~ array to select the next element from. The resulting index will cycle to the end or the beginning of the list if the computed index goes beyond element 0 or the length of ~theme-list~. The parameter theme is passed to this function when a theme becomes disabled (via the ~disable-theme~ function) and represents the theme that has become disabled.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/cycle-theme-selector (&rest theme)
+  (defun mifi/cycle-theme-selector (&rest theme)
     "Cycle the `theme-selector' by 1, resetting to 0 if beyond array bounds."
     (interactive)
     (when (not (eq theme-cycle-step nil))
@@ -1361,12 +1421,12 @@ This is the main function that allows cycling (up or down) through the list of t
 
   ;; This is used to trigger the cycling of the theme-selector
   ;; It is called when a theme is disabled. The theme is disabled from the
-  ;; `mrf/load-theme-from-selector' function.
-  (add-hook 'disable-theme-functions #'mrf/cycle-theme-selector)
+  ;; `mifi/load-theme-from-selector' function.
+  (add-hook 'disable-theme-functions #'mifi/cycle-theme-selector)
 
 #+end_src
 
-** Load Theme Function
+*** Load Theme Function
 
 This function simply loads the theme from the theme-list indexed by the ~theme-selector~ variable. Note the advice for ~load-theme~ that deactivates the current theme before activating the new theme. This is done to reset all the colors, a clean slate, before the new theme is activated.
 
@@ -1376,7 +1436,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
   (defvar theme-did-load nil
     "Set to true if the last Theme was loaded.")
 
-  (defun mrf/load-theme-from-selector (&optional step)
+  (defun mifi/load-theme-from-selector (&optional step)
     "Load the theme in `theme-list' indexed by `theme-selector'."
     (interactive)
     (setq theme-cycle-step nil)
@@ -1389,16 +1449,17 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
     (setq loaded-theme (nth theme-selector theme-list))
     (setq theme-did-load (load-theme (intern loaded-theme) t))
     (when (featurep 'org)
-      (mrf/org-font-setup))
+      (mifi/org-font-setup))
     (set-face-foreground 'line-number "SkyBlue4"))
 
 #+end_src
 
-** Theme selection helper functions.
+*** Theme selection helper functions.
 
 #+begin_src emacs-lisp
-
-  (defun mrf/print-custom-theme-name ()
+  ;;; --------------------------------------------------------------------------
+  
+  (defun mifi/print-custom-theme-name ()
     "Print the current loaded theme from the `theme-list' on the modeline."
     (interactive)
     (message (format "Custom theme is %S" loaded-theme)))
@@ -1407,17 +1468,17 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
   (defun next-theme ()
     "Go to the next theme in the list."
     (interactive)
-    (mrf/load-theme-from-selector 1))
+    (mifi/load-theme-from-selector 1))
 
   (defun previous-theme ()
     "Go to the next theme in the list."
     (interactive)
-    (mrf/load-theme-from-selector -1))
+    (mifi/load-theme-from-selector -1))
 
   (defun which-theme ()
     "Go to the next theme in the list."
     (interactive)
-    (mrf/print-custom-theme-name))
+    (mifi/print-custom-theme-name))
 
   ;; Go to NEXT theme
   (global-set-key (kbd "C-c C-=") 'next-theme)
@@ -1427,12 +1488,12 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
   (global-set-key (kbd "C-c C-?") 'which-theme)
 #+end_src
 
-** Theme Override Values
+*** Theme Override Values
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-theme-override-values ()
+  (defun mifi/org-theme-override-values ()
     (defface org-block-begin-line
       '((t (:underline "#1D2C39" :foreground "SlateGray" :background "#1D2C39")))
       "Face used for the line delimiting the begin of source blocks.")
@@ -1451,32 +1512,32 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/customize-modus-theme ()
+  (defun mifi/customize-modus-theme ()
     (when (featurep 'org)
-      (mrf/org-font-setup))
+      (mifi/org-font-setup))
     (setq modus-themes-common-palette-overrides
       '((bg-mode-line-active bg-blue-intense)
          (fg-mode-line-active fg-main)
          (border-mode-line-active blue-intense))))
 
-  (add-hook 'elpaca-after-init-hook 'mrf/customize-modus-theme)
+  (add-hook 'elpaca-after-init-hook 'mifi/customize-modus-theme)
 
-  (defun mrf/customize-ef-theme ()
+  (defun mifi/customize-ef-theme ()
     (defface ef-themes-fixed-pitch
       '((t (:background "#242635" :extend t :font "Courier New")))
       "Face used for the source block background.")
     (when (featurep 'org)
-      (mrf/org-font-setup))
+      (mifi/org-font-setup))
     (setq ef-themes-common-palette-override
       '( (bg-mode-line bg-blue-intense)
          (fg-mode-line fg-main)
          (border-mode-line-active blue-intense))))
-  ;;(add-hook 'org-load-hook 'mrf/customize-ef-theme)
-  (add-hook 'elpaca-after-init-hook 'mrf/customize-ef-theme)
+  ;;(add-hook 'org-load-hook 'mifi/customize-ef-theme)
+  (add-hook 'elpaca-after-init-hook 'mifi/customize-ef-theme)
 
 #+end_src
 
-** Color Theming
+*** Color Theming
 
 <<<Color Theming>>> as a curated list of theming packages.
 *Note:* If new themes are added in the ~theme-list~ custom variable then they must be included here along with any customizations.
@@ -1486,10 +1547,10 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
   (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
 
-  (mrf/org-theme-override-values)
+  (mifi/org-theme-override-values)
   (use-package tron-legacy-theme :defer t)
-  (use-package ef-themes :init (mrf/customize-ef-theme) :defer t)
-  (use-package modus-themes :init (mrf/customize-modus-theme) :defer t)
+  (use-package ef-themes :init (mifi/customize-ef-theme) :defer t)
+  (use-package modus-themes :init (mifi/customize-modus-theme) :defer t)
   (use-package material-theme :defer t)
   (use-package color-theme-modern :defer t)
   (use-package color-theme-sanityinc-tomorrow :defer t)
@@ -1499,42 +1560,41 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
 
 #+end_src
 
-** Selected theme
+*** Selected theme
 This includes the theme to use in both graphical and non-graphical.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
-  ;; (add-hook 'emacs-startup-hook #'(mrf/load-theme-from-selector))
-  ;; (mrf/load-theme-from-selector)
+  ;; (add-hook 'emacs-startup-hook #'(mifi/load-theme-from-selector))
+  ;; (mifi/load-theme-from-selector)
   ;; For terminal mode we choose Material theme
 
-  (defun mrf/load-terminal-theme ()
+  (defun mifi/load-terminal-theme ()
     (load-theme (intern default-terminal-theme) t))
 
   (if (not (display-graphic-p))
-    (add-hook 'elpaca-after-init-hook 'mrf/load-terminal-theme)
+    (add-hook 'elpaca-after-init-hook 'mifi/load-terminal-theme)
     ;;else
     (progn
       (if (not elpaca-after-init-time)
         (add-hook 'elpaca-after-init-hook
         (lambda ()
           (unless theme-did-load
-            (mrf/load-theme-from-selector))))
+            (mifi/load-theme-from-selector))))
         ;; else
         (add-hook 'window-setup-hook
         (lambda ()
           (unless theme-did-load
-            (mrf/load-theme-from-selector))))
+            (mifi/load-theme-from-selector))))
         )))
 
 #+end_src
 
-
-* Frame and Font Setup
+** Frame and Font Setup
 
 It's nice to know that Emacs is somewhat working. To help this along, we set the Frame (window size fonts) early in the loading process.
 
-** Define the various font size constants
+*** Define the various font size constants
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -1542,40 +1602,58 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
   ;; Frame (view) setup including fonts.
   ;; You will most likely need to adjust this font size for your system!
 
-  (setq-default mrf/small-font-size 150)
-  (setq-default mrf/small-mono-font-size 150)
-  (setq-default mrf/small-variable-font-size 170)
+  (setq-default mifi/small-font-size 150)
+  (setq-default mifi/small-mono-font-size 150)
+  (setq-default mifi/small-variable-font-size 170)
 
-  (setq-default mrf/medium-font-size 170)
-  (setq-default mrf/medium-mono-font-size 170)
-  (setq-default mrf/medium-variable-font-size 190)
+  (setq-default mifi/medium-font-size 170)
+  (setq-default mifi/medium-mono-font-size 170)
+  (setq-default mifi/medium-variable-font-size 190)
 
-  (setq-default mrf/large-font-size 190)
-  (setq-default mrf/large-mono-font-size 190)
-  (setq-default mrf/large-variable-font-size 210)
+  (setq-default mifi/large-font-size 190)
+  (setq-default mifi/large-mono-font-size 190)
+  (setq-default mifi/large-variable-font-size 210)
 
-  (setq-default mrf/x-large-font-size 220)
-  (setq-default mrf/x-large-mono-font-size 220)
-  (setq-default mrf/x-large-variable-font-size 240)
+  (setq-default mifi/x-large-font-size 220)
+  (setq-default mifi/x-large-mono-font-size 220)
+  (setq-default mifi/x-large-variable-font-size 240)
 
-  ;; (setq-default custom-default-font-size mrf/medium-font-size)
-  (setq-default mrf/default-variable-font-size (+ custom-default-font-size 20))
-  ;; (setq-default mrf/set-frame-maximized t)  ;; or f
+  ;; (setq-default custom-default-font-size mifi/medium-font-size)
+  (setq-default mifi/default-variable-font-size (+ custom-default-font-size 20))
+  ;; (setq-default mifi/set-frame-maximized t)  ;; or f
 
   ;; Make frame transparency overridable
-  ;; (setq-default mrf/frame-transparency '(90 . 90))
+  ;; (setq-default mifi/frame-transparency '(90 . 90))
 
   (setq frame-resize-pixelwise t)
 
 #+end_src
 
-** Functions to set the frame size
+*** mixed-pitch
+
+A better version of variable-pitch mode. This keeps certain faces (defined in mixed-pitch-fixed-pitch-faces) fixed-pitch.
+
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
+  (use-package mixed-pitch
+    :defer t
+    :custom
+    (mixed-pitch-set-height t)
+    :config
+    (dolist (face '(org-date org-priority org-special-keyword org-tag))
+      (add-to-list 'mixed-pitch-fixed-pitch-faces face)))
+    
+#+end_src
+
+
+*** Functions to set the frame size
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
   ;; Functions to set the frame size
 
-  (defun mrf/frame-recenter (&optional frame)
+  (defun mifi/frame-recenter (&optional frame)
     "Center FRAME on the screen.  FRAME can be a frame name, a terminal name,
     or a frame.  If FRAME is omitted or nil, use currently selected frame."
     (interactive)
@@ -1584,59 +1662,53 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
       (progn
         (let ((width (nth 3 (assq 'geometry (car (display-monitor-attributes-list)))))
                (height (nth 4 (assq 'geometry (car (display-monitor-attributes-list))))))
-          (cond (( > width 3000) (mrf/update-large-display))
-            (( > width 2000) (mrf/update-built-in-display))
-            (t (mrf/set-frame-alpha-maximized)))
-          ))
-      ))
+          (cond (( > width 3000) (mifi/update-large-display))
+            (( > width 2000) (mifi/update-built-in-display))
+            (t (mifi/set-frame-alpha-maximized)))))))
 
-  (defun mrf/update-large-display ()
+  (defun mifi/update-large-display ()
     (modify-frame-parameters
       frame '((user-position . t)
                (top . 0.0)
                (left . 0.70)
                (width . (text-pixels . 2800))
-               (height . (text-pixels . 1650))) ;; 1800
-      ))
+               (height . (text-pixels . 1650))))) ;; 1800
 
-  (defun mrf/update-built-in-display ()
+  (defun mifi/update-built-in-display ()
     (modify-frame-parameters
       frame '((user-position . t)
                (top . 0.0)
                (left . 0.90)
                (width . (text-pixels . 1800))
-               (height . (text-pixels . 1170)));; 1329
-      ))
-
+               (height . (text-pixels . 1170))))) ;; 1329
 
   ;; Set frame transparency
-  (defun mrf/set-frame-alpha-maximized ()
+  (defun mifi/set-frame-alpha-maximized ()
     "Function to set the alpha and also maximize the frame."
-    ;; (set-frame-parameter (selected-frame) 'alpha mrf/frame-transparency)
+    ;; (set-frame-parameter (selected-frame) 'alpha mifi/frame-transparency)
     (set-frame-parameter (selected-frame) 'fullscreen 'maximized)
     (add-to-list 'default-frame-alist '(fullscreen . maximized)))
 
   ;; default window width and height
-  (defun mrf/custom-set-frame-size ()
+  (defun mifi/custom-set-frame-size ()
     "Simple function to set the default frame width/height."
-    ;; (set-frame-parameter (selected-frame) 'alpha mrf/frame-transparency)
+    ;; (set-frame-parameter (selected-frame) 'alpha mifi/frame-transparency)
     (setq swidth (nth 3 (assq 'geometry (car (display-monitor-attributes-list)))))
     (setq sheight (nth 4 (assq 'geometry (car (display-monitor-attributes-list)))))
 
     (add-to-list 'default-frame-alist '(fullscreen . maximized))
-    (unless enable-frameset-restore (mrf/frame-recenter))
-    )
+    (unless enable-frameset-restore (mifi/frame-recenter)))
 
 #+end_src
 
-** Default fonts and sizes
+*** Default fonts and sizes
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;; Default fonts
 
-  (defun mrf/update-face-attribute ()
+  (defun mifi/update-face-attribute ()
     "Set the font faces."
     ;; ====================================
     (set-face-attribute 'default nil
@@ -1661,71 +1733,71 @@ It's nice to know that Emacs is somewhat working. To help this along, we set the
   (add-hook 'emacs-startup-hook
     (lambda ()
       (when (display-graphic-p)
-        (mrf/update-face-attribute)
+        (mifi/update-face-attribute)
         (unless (daemonp)
-  	(if enable-frameset-restore
-            (mrf/restore-desktop-frameset)
-  	  (mrf/frame-recenter)))
+        (if enable-frameset-restore
+            (mifi/restore-desktop-frameset)
+          (mifi/frame-recenter)))
         )))
 
 #+end_src
 
-** Track Slected Front Size
+*** Track Slected Front Size
 
 The functions in the list =after-setting-font-hook= are called whenever the frame's font changes. In order to save this value, we capture it and store it in the =custom-default-font-size= custom variable. This variable is saved whenver Emacs exists. Then, when Emacs is started again, the default and fixed-pitch font height values are set to =custom-default-font-size=. The variable pitch font is computed as ~(+ custom-default-font-size 20)~
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/default-font-height-change ()
+  (defun mifi/default-font-height-change ()
     (setq-default custom-default-font-size (face-attribute 'default :height))
-    (mrf/update-face-attribute)
-    (unless enable-frameset-restore (mrf/frame-recenter)))
+    (mifi/update-face-attribute)
+    (unless enable-frameset-restore (mifi/frame-recenter)))
 
-  (add-hook 'after-setting-font-hook 'mrf/default-font-height-change)
+  (add-hook 'after-setting-font-hook 'mifi/default-font-height-change)
 
 #+end_src
 
-** Helper to up the font size for a higher-res monitor.
-*** Frame font selection
+*** Helper to up the font size for a higher-res monitor.
+**** Frame font selection
 This little function toggles between a larger font size and the default font size.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Frame font selection
 
-  (defvar mrf/font-size-slot 1)
+  (defvar mifi/font-size-slot 1)
 
-  (defun mrf/update-font-size ()
+  (defun mifi/update-font-size ()
     (cond
-      ((equal mrf/font-size-slot 3)
-        (setq custom-default-font-size mrf/x-large-font-size
-              custom-default-mono-font-size mrf/x-large-mono-font-size
-              mrf/default-variable-font-size (+ custom-default-font-size 20)
-              mrf/font-size-slot 2)
-        (mrf/update-face-attribute))
-      ((equal mrf/font-size-slot 2)
-        (setq custom-default-font-size mrf/large-font-size
-              custom-default-mono-font-size mrf/large-mono-font-size
-              mrf/default-variable-font-size (+ custom-default-font-size 20)
-              mrf/font-size-slot 1)
-        (mrf/update-face-attribute))
-      ((equal mrf/font-size-slot 1)
-        (setq custom-default-font-size mrf/medium-font-size
-              custom-default-mono-font-size mrf/medium-mono-font-size
-              mrf/default-variable-font-size (+ custom-default-font-size 20)
-              mrf/font-size-slot 0)
-        (mrf/update-face-attribute))
-      ((equal mrf/font-size-slot 0)
-        (setq custom-default-font-size mrf/small-font-size
-              custom-default-mono-font-size mrf/small-mono-font-size
-              mrf/default-variable-font-size (+ custom-default-font-size 20)
-              mrf/font-size-slot 3)
-        (mrf/update-face-attribute))))
+      ((equal mifi/font-size-slot 3)
+        (setq custom-default-font-size mifi/x-large-font-size
+              custom-default-mono-font-size mifi/x-large-mono-font-size
+              mifi/default-variable-font-size (+ custom-default-font-size 20)
+              mifi/font-size-slot 2)
+        (mifi/update-face-attribute))
+      ((equal mifi/font-size-slot 2)
+        (setq custom-default-font-size mifi/large-font-size
+              custom-default-mono-font-size mifi/large-mono-font-size
+              mifi/default-variable-font-size (+ custom-default-font-size 20)
+              mifi/font-size-slot 1)
+        (mifi/update-face-attribute))
+      ((equal mifi/font-size-slot 1)
+        (setq custom-default-font-size mifi/medium-font-size
+              custom-default-mono-font-size mifi/medium-mono-font-size
+              mifi/default-variable-font-size (+ custom-default-font-size 20)
+              mifi/font-size-slot 0)
+        (mifi/update-face-attribute))
+      ((equal mifi/font-size-slot 0)
+        (setq custom-default-font-size mifi/small-font-size
+              custom-default-mono-font-size mifi/small-mono-font-size
+              mifi/default-variable-font-size (+ custom-default-font-size 20)
+              mifi/font-size-slot 3)
+        (mifi/update-face-attribute))))
 
 #+end_src
 
-**** Resolution Key Bindings
+***** Resolution Key Bindings
 Some key kindings to switch to different screen resolutions.
 
 #+begin_src emacs-lisp
@@ -1749,48 +1821,48 @@ Some key kindings to switch to different screen resolutions.
 
 #+end_src
 
-**** Frame support functions
+***** Frame support functions
 These functions are used to configure the main frame font size. Based upon a monitor's size, it may be necessary to make the font larger or smaller.
 
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
   ;; Frame support functions
 
-  (defun mrf/set-frame-font (slot)
-    (setq mrf/font-size-slot slot)
-    (mrf/update-font-size)
-    (unless enable-frameset-restore (mrf/frame-recenter)))
+  (defun mifi/set-frame-font (slot)
+    (setq mifi/font-size-slot slot)
+    (mifi/update-font-size)
+    (unless enable-frameset-restore (mifi/frame-recenter)))
 
-  (defun mrf/should-recenter (&optional force-recenter)
+  (defun mifi/should-recenter (&optional force-recenter)
     (if force-recenter
-      (mrf/frame-recenter)
+      (mifi/frame-recenter)
       ;;else
-      (unless enable-frameset-restore (mrf/frame-recenter))))
+      (unless enable-frameset-restore (mifi/frame-recenter))))
 
   ;;; --------------------------------------------------------------------------
 
   (defun use-small-display-font (&optional force-recenter)
     (interactive)
-    (mrf/set-frame-font 0)
-    (mrf/should-recenter force-recenter))
+    (mifi/set-frame-font 0)
+    (mifi/should-recenter force-recenter))
 
 
   (defun use-medium-display-font (&optional force-recenter)
     (interactive)
-    (mrf/set-frame-font 1)
-    (mrf/should-recenter force-recenter))
+    (mifi/set-frame-font 1)
+    (mifi/should-recenter force-recenter))
 
 
   (defun use-large-display-font (&optional force-recenter)
     (interactive)
-    (mrf/set-frame-font 2)
-    (mrf/should-recenter force-recenter))
+    (mifi/set-frame-font 2)
+    (mifi/should-recenter force-recenter))
 
 
   (defun use-x-large-display-font (&optional force-recenter)
     (interactive)
-    (mrf/set-frame-font 3)
-    (mrf/should-recenter force-recenter))
+    (mifi/set-frame-font 3)
+    (mifi/should-recenter force-recenter))
 
 
   ;; This is done so that the Emacs window is sized early in the init phase along with the default font size.
@@ -1799,14 +1871,14 @@ These functions are used to configure the main frame font size. Based upon a mon
     (add-hook 'elpaca-after-init-hook
       (lambda ()
         (progn
-        (mrf/update-face-attribute)
+        (mifi/update-face-attribute)
         (unless (daemonp)
-          (unless enable-frameset-restore (mrf/frame-recenter))))
+          (unless enable-frameset-restore (mifi/frame-recenter))))
         )))
 
 #+end_src
 
-** Window, mode-line, +more padding
+*** Window, mode-line, +more padding
 
 This package provides a global minor mode to increase the spacing/padding of Emacs windows and frames. The idea is to make editing and reading feel more comfortable.
 
@@ -1838,7 +1910,7 @@ This package provides a global minor mode to increase the spacing/padding of Ema
 
 Org Mode is one of the hallmark features of Emacs.  It is a rich document editor, project planner, task and time tracker, blogging engine, and literate coding utility all wrapped up in one package [[https://orgmode.org/][Orgmode]].
 
-The =mrf/org-font-setup= function configures various text faces to tweak the sizes of headings and use variable width fonts in most cases so that it looks more like we're editing a document in =org-mode=.  We switch back to fixed width (monospace) fonts for code blocks and tables so that they display correctly.
+The =mifi/org-font-setup= function configures various text faces to tweak the sizes of headings and use variable width fonts in most cases so that it looks more like we're editing a document in =org-mode=.  We switch back to fixed width (monospace) fonts for code blocks and tables so that they display correctly.
 
 *NOTE:* Most of the code below has been taken from the [[https://systemcrafters.net][System Crafters]] site run by David Wilson. Please visit that site for lots of great stuff!
 
@@ -1850,7 +1922,7 @@ This function sets up the fonts faces that are used within org-mode.
   ;;; --------------------------------------------------------------------------
 
   (use-package faces :ensure nil)
-  (defun mrf/org-font-setup ()
+  (defun mifi/org-font-setup ()
     "Setup org mode fonts."
 
     (font-lock-add-keywords
@@ -1926,19 +1998,19 @@ This function sets up the fonts faces that are used within org-mode.
 This section contains the basic configuration for =org-mode= plus the configuration for Org agendas and capture templates.
 
 #+begin_src emacs-lisp
-  ;; -----------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-mode-visual-fill ()
+  (defun mifi/org-mode-visual-fill ()
     (interactive)
     (setq visual-fill-column-width custom-org-fill-column
       visual-fill-column-center-text enable-org-fill-column-centering)
     (visual-fill-column-mode 1))
 
-  (defun mrf/org-mode-setup ()
+  (defun mifi/org-mode-setup ()
     (org-indent-mode)
     (variable-pitch-mode 1)
     (visual-line-mode 1)
-    (mrf/org-mode-visual-fill)
+    (mifi/org-mode-visual-fill)
     (font-lock-add-keywords nil
       '(("^_\\{5,\\}"    0 '(:foreground "green" :weight bold))))
     (setq org-ellipsis " ▾")
@@ -1963,7 +2035,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-setup-agenda ()
+  (defun mifi/org-setup-agenda ()
     (setq org-agenda-custom-commands
       '(("d" "Dashboard"
           ((agenda "" ((org-deadline-warning-days 7)))
@@ -2010,7 +2082,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
              (todo "CANC"
                ((org-agenda-overriding-header "Cancelled Projects")
                  (org-agenda-files org-agenda-files)))))))
-    ) ;; mrf/org-setup-agenda
+    ) ;; mifi/org-setup-agenda
 
 #+end_src
 
@@ -2019,7 +2091,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-setup-capture-templates ()
+  (defun mifi/org-setup-capture-templates ()
     (setq org-capture-templates
       `(("t" "Tasks / Projects")
          ("tt" "Task" entry (file+olp "~/Projects/Code/emacs-from-scratch/OrgFiles/Tasks.org" "Inbox")
@@ -2051,16 +2123,37 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
+**** Todos
+
+#+begin_src emacs-lisp
+
+  (defun mifi/org-setup-todos ()
+    (setq org-todo-keywords '((type
+                                "TODO(t)" "WAITING(h)" "INPROG-TODO(i)" "WORK(w)"
+                                "STUDY(s)" "SOMEDAY" "READ(r)" "PROJ(p)"
+                                "CONTACT(c)" "|" "DONE(d)" "CANCELLED(C@)")))
+
+    (setq org-todo-keyword-faces
+      '(("TODO"  :inherit (region org-todo) :foreground "DarkOrange1" :weight bold)
+         ("WORK"  :inherit (org-todo region) :foreground "DarkOrange1" :weight bold)
+         ("READ"  :inherit (org-todo region) :foreground "MediumPurple2" :weight bold)
+         ("PROJ"  :inherit (org-todo region) :foreground "orange3" :weight bold)
+         ("STUDY" :inherit (region org-todo) :foreground "plum3"   :weight bold)
+         ("DONE" . "SeaGreen4"))))
+
+#+end_src
+
 ** The main 'Org' package
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   (use-package org
+    :pin gnu-elpa
     :preface
-    (mrf/org-theme-override-values)
+    (mifi/org-theme-override-values)
     :commands (org-capture org-agenda)
     :defer t
-    :hook (org-mode . mrf/org-mode-setup)
+    :hook (org-mode . mifi/org-mode-setup)
     :custom
     (org-startup-indented t)
     (org-pretty-entities t)
@@ -2089,9 +2182,10 @@ This section contains the basic configuration for =org-mode= plus the configurat
          ("note" . ?n)
          ("idea" . ?i)))
     ;; Configure custom agenda views
-    (mrf/org-setup-agenda)
-    (mrf/org-setup-capture-templates)
-    (mrf/org-font-setup)
+    (mifi/org-setup-agenda)
+    (mifi/org-setup-capture-templates)
+    (mifi/org-font-setup)
+    (mifi/org-setup-todos)
     (yas-global-mode t)
     (define-key global-map (kbd "C-c j")
       (lambda () (interactive) (org-capture nil "jj"))))
@@ -2101,63 +2195,42 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+RESULTS:
 : #s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8125 data (:use-package (26172 1876 296393 0) :use-package-secs (0 0 907 0) :preface (26171 64968 44297 0) :init (26171 64968 44286 0) :init-secs (0 0 28 0) :preface-secs (0 0 265 0) :config (26171 64988 735976 0) :config-secs (0 0 361702 0)))
 
-** Org Modern
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package org-modern
-    :when (display-graphic-p)
-    :after org
-    :hook (org-mode . org-modern-mode)
-    :config
-    ;; Add frame borders and window dividers
-    (modify-all-frames-parameters
-      '((right-divider-width . 40)
-         (internal-border-width . 40)))
-    (dolist (face '(window-divider
-                     window-divider-first-pixel
-                     window-divider-last-pixel))
-      (face-spec-reset-face face)
-      (set-face-foreground face (face-attribute 'default :background nil)))
-    (set-face-background 'fringe (face-attribute 'default :background nil))
-    (setq
-      ;; Edit settings
-      org-auto-align-tags nil
-      org-tags-column 0
-      org-catch-invisible-edits 'show-and-error
-      org-special-ctrl-a/e t
-      org-insert-heading-respect-content t
-
-      ;; Org styling, hide markup etc.
-      org-hide-emphasis-markers nil
-      org-pretty-entities t
-      org-ellipsis "…"
-
-      ;; Agenda styling
-      org-agenda-tags-column 0
-      org-agenda-block-separator ?─
-      org-agenda-time-grid
-      '((daily today require-timed)
-         (800 1000 1200 1400 1600 1800 2000)
-         " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
-      org-agenda-current-time-string
-      "◀── now ─────────────────────────────────────────────────")
-    (global-org-modern-mode))
-
-#+end_src
-
 ** Better Bullets
 [[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
 
 #+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
+    ;;; --------------------------------------------------------------------------
 
-  (use-package org-superstar
-    :after org
-    :custom
-    (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
-    :hook (org-mode . org-superstar-mode))
+    (use-package org-superstar
+      :after org
+      :custom
+      (org-superstar-leading-bullet " ")
+      (org-superstar-special-todo-items t)
+      (org-superstar-todo-bullet-alist '( ("TODO" . 9744)
+                                      ("INPROG-TODO" . 9744)
+                                      ("HW" . 9744)
+                                      ("STUDY" . 9744)
+                                      ("SOMEDAY" . 9744)
+                                      ("READ" . 9744)
+                                      ("PROJ" . 9744)
+                                      ("CONTACT" . 9744)
+                                      ("DONE" . 9745)))
+      ;; (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
+      :hook (org-mode . org-superstar-mode))
+
+    (use-package org-appear
+      :init
+      (setq org-hide-emphasis-markers t)
+      (setq org-appear-autoemphasis t) ;; Enable org-appear on emphasis
+      (setq org-appear-autolinks t) ;; Enable on links
+      (setq org-appear-autosubmarkers t) ;; Enable on sub and superscript
+      :commands (org-appear-mode)
+      :hook (or-mode . org-appear-mode))
+
+  ;; Automatically change bullet type when indenting
+  ;; Ex: indenting a + makes the bullet a *.
+  (setq org-list-demote-modify-bullet
+  '(("+" ・ "*"）（"*" ・ "-"）（"-" . "+")))
 
 #+end_src
 
@@ -2172,25 +2245,25 @@ To execute or export code in =org-mode= code blocks, you'll need to set up =org-
       'org-babel-load-languages
       (seq-filter
         (lambda (pair)
-  	(locate-library (concat "ob-" (symbol-name (car pair)))))
+        (locate-library (concat "ob-" (symbol-name (car pair)))))
         '((emacs-lisp . t)
-  	 (ditaa . t)
-  	 (dot . t)
-  	 (emacs-lisp . t)
-  	 (gnuplot . t)
-  	 (haskell . nil)
-  	 (latex . t)
-  	 (ledger . t)
-  	 (ocaml . nil)
-  	 (octave . t)
-  	 (plantuml . t)
-  	 (python . t)
-  	 (ruby . t)
-  	 (screen . nil)
-  	 (sh . t) ;; obsolete
-  	 (shell . t)
-  	 (sql . t)
-  	 (sqlite . t))))
+         (ditaa . t)
+         (dot . t)
+         (emacs-lisp . t)
+         (gnuplot . t)
+         (haskell . nil)
+         (latex . t)
+         (ledger . t)
+         (ocaml . nil)
+         (octave . t)
+         (plantuml . t)
+         (python . t)
+         (ruby . t)
+         (screen . nil)
+         (sh . t) ;; obsolete
+         (shell . t)
+         (sql . t)
+         (sqlite . t))))
     (push '("conf-unix" . conf-unix) org-src-lang-modes))
   
 #+end_src
@@ -2198,7 +2271,7 @@ To execute or export code in =org-mode= code blocks, you'll need to set up =org-
 ** Structure Templates
 Org Mode's structure templates feature enables you to quickly insert code blocks into your Org files in combination with =org-tempo= by typing =<= followed by the template name like =el= or =py= and then press =TAB=.  For example, to insert an empty =emacs-lisp= block below, you can type =<el= and press =TAB= to expand into such a block.  You can add more =src= block templates below by copying one of the lines and changing the two strings at the end, the first to be the template name and the second to contain the name of the language as it is known by Org Babel.
 
-This snippet adds a hook to =org-mode= buffers so that =mrf/org-babel-tangle-config= gets executed each time such a buffer gets saved.  This function checks to see if the file being saved is the Emacs.org file you're looking at right now, and if so, automatically exports the configuration here to the associated output files.
+This snippet adds a hook to =org-mode= buffers so that =mifi/org-babel-tangle-config= gets executed each time such a buffer gets saved.  This function checks to see if the file being saved is the Emacs.org file you're looking at right now, and if so, automatically exports the configuration here to the associated output files.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -2234,7 +2307,7 @@ Org Roam solves these problems by making it easy to create topic-focused Org Fil
 
 *** Some required pacakages 
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
   (use-package emacsql :demand t :ensure t :after org)
   (use-package emacsql-sqlite :demand t :ensure t :after org)
@@ -2248,24 +2321,24 @@ Typically you won’t want to pull in all of your Org Roam notes, so we’ll onl
 
 Here is a snippet that will find all the notes with a specific tag and then set your org-agenda-list with the corresponding note files.
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
   ;; The buffer you put this code in must have lexical-binding set to t!
   ;; See the final configuration at the end for more details.
 
-  (defun mrf/org-roam-filter-by-tag (tag-name)
+  (defun mifi/org-roam-filter-by-tag (tag-name)
     (lambda (node)
       (member tag-name (org-roam-node-tags node))))
 
-  (defun mrf/org-roam-list-notes-by-tag (tag-name)
+  (defun mifi/org-roam-list-notes-by-tag (tag-name)
     (mapcar #'org-roam-node-file
       (seq-filter
-        (mrf/org-roam-filter-by-tag tag-name)
+        (mifi/org-roam-filter-by-tag tag-name)
         (org-roam-node-list))))
 
-  (defun mrf/org-roam-refresh-agenda-list ()
+  (defun mifi/org-roam-refresh-agenda-list ()
     (interactive)
-    (setq org-agenda-files (mrf/org-roam-list-notes-by-tag "Project")))
+    (setq org-agenda-files (mifi/org-roam-list-notes-by-tag "Project")))
 
   ;; Build the agenda list the first time for the session
 #+end_src
@@ -2279,36 +2352,36 @@ One added benefit is that we can override the set of capture templates that get 
 
 This means that we can automatically create a new note with our project capture template if the note doesn’t already exist!
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-roam-project-finalize-hook ()
+  (defun mifi/org-roam-project-finalize-hook ()
     "Adds the captured project file to `org-agenda-files' if the
   capture was not aborted."
     ;; Remove the hook since it was added temporarily
-    (remove-hook 'org-capture-after-finalize-hook #'mrf/org-roam-project-finalize-hook)
+    (remove-hook 'org-capture-after-finalize-hook #'mifi/org-roam-project-finalize-hook)
 
     ;; Add project file to the agenda list if the capture was confirmed
     (unless org-note-abort
       (with-current-buffer (org-capture-get :buffer)
         (add-to-list 'org-agenda-files (buffer-file-name)))))
 
-  (defun mrf/org-roam-find-project ()
+  (defun mifi/org-roam-find-project ()
     (interactive)
     ;; Add the project file to the agenda after capture is finished
-    (add-hook 'org-capture-after-finalize-hook #'mrf/org-roam-project-finalize-hook)
+    (add-hook 'org-capture-after-finalize-hook #'mifi/org-roam-project-finalize-hook)
 
     ;; Select a project file to open, creating it if necessary
     (org-roam-node-find
       nil
       nil
-      (mrf/org-roam-filter-by-tag "Project")
+      (mifi/org-roam-filter-by-tag "Project")
       :templates
       '(("p" "project" plain "* Goals\n\n%?\n\n* Tasks\n\n** TODO Add initial tasks\n\n* Dates\n\n"
         :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" "#+title: ${title}\n#+category: ${title}\n#+filetags: Project")
         :unnarrowed t))))
 
-  ;; (global-set-key (kbd "C-c n p") #'mrf/org-roam-find-project)
+  ;; (global-set-key (kbd "C-c n p") #'mifi/org-roam-find-project)
   
 #+end_src
 
@@ -2316,10 +2389,10 @@ This means that we can automatically create a new note with our project capture 
 If you want to quickly capture new notes and tasks with a single keybinding into a place that you can review later, we can use org-roam-capture- to capture to a single-specific file like Inbox.org!
 
 Even though this file won’t have the timestamped filename, it will still be treated as a node in your Org Roam notes.
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-roam-capture-inbox ()
+  (defun mifi/org-roam-capture-inbox ()
     (interactive)
     (org-roam-capture- :node (org-roam-node-create)
       :templates '(("i" "inbox" plain "* %?"
@@ -2329,9 +2402,10 @@ Even though this file won’t have the timestamped filename, it will still be tr
 
 *** Insert a node immediately
 
-#+begin_src emacs-lisp
-
-  (defun mrf/org-roam-node-insert-immediate (arg &rest args)
+#+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
+  
+  (defun mifi/org-roam-node-insert-immediate (arg &rest args)
     (interactive "P")
     (let ((args (push arg args))
          (org-roam-capture-templates
@@ -2345,17 +2419,17 @@ If you’ve set up project note files like we mentioned earlier, you can set up 
 
 Much like the example before, we can either select a project that exists or automatically create a project note when it doesn’t exist yet.
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-roam-capture-task ()
+  (defun mifi/org-roam-capture-task ()
     (interactive)
     ;; Add the project file to the agenda after capture is finished
-    (add-hook 'org-capture-after-finalize-hook #'mrf/org-roam-project-finalize-hook)
+    (add-hook 'org-capture-after-finalize-hook #'mifi/org-roam-project-finalize-hook)
 
     ;; Capture the new task, creating the project file if necessary
     (org-roam-capture- :node (org-roam-node-read nil
-                             (mrf/org-roam-filter-by-tag "Project"))
+                             (mifi/org-roam-filter-by-tag "Project"))
       :templates '(("p" "project" plain "** TODO %?"
                    :if-new
                    (file+head+olp "%<%Y%m%d%H%M%S>-${slug}.org"
@@ -2366,10 +2440,10 @@ Much like the example before, we can either select a project that exists or auto
 *** Todo
 The following snippet sets up a hook for all Org task state changes and then copies the completed (DONE) entry to today’s note file
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/org-roam-copy-todo-to-today ()
+  (defun mifi/org-roam-copy-todo-to-today ()
     (interactive)
     (let ((org-refile-keep t) ;; Set this to nil to delete the original!
          (org-roam-dailies-capture-templates
@@ -2390,8 +2464,9 @@ The following snippet sets up a hook for all Org task state changes and then cop
 #+end_src
 
 *** Table-of-contents
-#+begin_src emacs-lisp
-
+#+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
+  
   (use-package toc-org
     :after org markdown-mode
     :hook
@@ -2404,8 +2479,9 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 *** Main Org-roam Configuration
 
-#+begin_src emacs-lisp
-
+#+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
+  
   (use-package org-roam
     ;; :demand t  ;; Ensure org-roam is loaded by default
     :defer t
@@ -2421,10 +2497,10 @@ The following snippet sets up a hook for all Org task state changes and then cop
     :bind ( ("C-c n l" . org-roam-buffer-toggle)
           ("C-c n f" . org-roam-node-find)
           ("C-c n i" . org-roam-node-insert)
-          ("C-c n I" . mrf/org-roam-node-insert-immediate)
-          ("C-c n p" . mrf/org-roam-find-project)
-          ("C-c n t" . mrf/org-roam-capture-task)
-          ("C-c n b" . mrf/org-roam-capture-inbox)
+          ("C-c n I" . mifi/org-roam-node-insert-immediate)
+          ("C-c n p" . mifi/org-roam-find-project)
+          ("C-c n t" . mifi/org-roam-capture-task)
+          ("C-c n b" . mifi/org-roam-capture-inbox)
           :map org-mode-map
           ("C-M-i" . completion-at-point)
           :map org-roam-dailies-map
@@ -2434,11 +2510,11 @@ The following snippet sets up a hook for all Org task state changes and then cop
     ("C-c n d" . org-roam-dailies-map)
     :config
     (require 'org-roam-dailies) ;; Ensure the keymap is available
-    (mrf/org-roam-refresh-agenda-list)
+    (mifi/org-roam-refresh-agenda-list)
     (add-to-list 'org-after-todo-state-change-hook
       (lambda ()
         (when (equal org-state "DONE")
-        (mrf/org-roam-copy-todo-to-today))))
+        (mifi/org-roam-copy-todo-to-today))))
     (org-roam-db-autosync-mode))
 
 #+end_src
@@ -2450,6 +2526,7 @@ Org-transclusion lets you insert a copy of text content via a file link or ID li
 *This is experimental for me and will only enable it when testing.*
 
 #+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
 
   (use-package org-transclusion
     :after org
@@ -2473,7 +2550,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/define-denote-keymap ()
+  (defun mifi/define-denote-keymap ()
     (interactive)
     ;; Denote DOES NOT define any key bindings.  This is for the user to
     ;; decide.
@@ -2512,7 +2589,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
       (define-key map (kbd "C-c C-d C-k") #'denote-dired-rename-marked-files-with-keywords)
       (define-key map (kbd "C-c C-d C-R") #'denote-dired-rename-marked-files-using-front-matter))
 
-    (if (mrf/minor-mode-is-active 'which-key-mode)
+    (if (mifi/minor-mode-is-active 'which-key-mode)
       (which-key-add-key-based-replacements "C-c n f" "denote-find")))
 
 #+end_src
@@ -2546,7 +2623,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
     (add-hook 'dired-mode-hook #'denote-dired-mode-in-directories)
     (denote-rename-buffer-mode 1)
 
-    (mrf/define-denote-keymap) ;; Define the keymap for Denote.
+    (mifi/define-denote-keymap) ;; Define the keymap for Denote.
 
     (with-eval-after-load 'org-capture
       (setq denote-org-capture-specifiers "%l\n%i\n%?")
@@ -2726,12 +2803,14 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 ***** ='official= which displays the official emacs logo
 ***** ='logo= which displays an alternative emacs logo
 ***** =1, 2 or 3= which displays one of the text banners
-***** ~"path/to/your/image.gif"~, ~"path/to/your/image.png"~ or ~"path/to/your/text.txt"~  which displays whatever gif/image/text you would prefer
+***** ~"path/to/your/image.gif"~,
+~"path/to/your/image.png"~ or
+~"path/to/your/text.txt"~  which displays whatever gif/image/text you would prefer
 ***** a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
 
 ** Dashboard Setup
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
 
   (use-package dashboard
     :custom
@@ -2756,7 +2835,9 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 
 * Integrated Development Environments
+
 The following are configured for Python development and provide an IDE type experience.  It's worth noting that Eglot/LSP can be configured for other languages. The others are Python specific. Use the =configure= system to select which one is used (=Mrf Custom Selection=).
+
 *** Features
 - context-sensitive code completion
 - jump to definitions
@@ -2770,13 +2851,13 @@ The following are configured for Python development and provide an IDE type expe
 <<<Eglot>>> is the Emacs client for the Language Server Protocol (LSP). Eglot provides infrastructure and a set of commands for enriching the source code editing capabilities of Emacs via LSP. Eglot itself is completely language-agnostic, but it can support any programming language for which there is a language server and an Emacs major mode.
 
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
-    ;;; Emacs Polyglot is the Emacs LSP client that stays out of your way:
+  ;;; --------------------------------------------------------------------------
+  ;;; Emacs Polyglot is the Emacs LSP client that stays out of your way:
 
-  (defvar mrf/clangd-path (executable-find "clangd")
+  (defvar mifi/clangd-path (executable-find "clangd")
     "Clangd executable path.")
 
-  (defun mrf/projectile-proj-find-function (dir)
+  (defun mifi/projectile-proj-find-function (dir)
     "Find the project `DIR' function for Projectile.
     Thanks @wyuenho on GitHub"
     (let ((root (projectile-project-root dir)))
@@ -2786,7 +2867,7 @@ The following are configured for Python development and provide an IDE type expe
     :defer t
     :config
     (unless theme-did-load
-      (mrf/load-theme-from-selector)))
+      (mifi/load-theme-from-selector)))
 
 #+end_src
 
@@ -2803,14 +2884,15 @@ The JSON-RPC protocol is used to communicate with many different types of server
     ;; yet, go ahead and try. This could prevent a startup without the theme
     ;; properly loaded.
     (unless theme-did-load
-      (mrf/load-theme-from-selector)))
+      (mifi/load-theme-from-selector)))
 
 #+end_src
 
 *** Eglot Setup
 
 #+begin_src emacs-lisp
-
+  ;;; --------------------------------------------------------------------------
+  
   (use-package eglot
     :when (equal custom-ide 'custom-ide-eglot)
     ;; :ensure (:repo "https://github.com/emacs-mirror/emacs" :local-repo "eglot" :branch "master"
@@ -2840,7 +2922,7 @@ The JSON-RPC protocol is used to communicate with many different types of server
     ;; theme loading mechanism. Our theme could fail to load because of this.  So,
     ;; to get our themes loading properly, load it here if not already loaded.
     (unless theme-did-load
-      (mrf/load-theme-from-selector))
+      (mifi/load-theme-from-selector))
     (add-to-list 'eglot-stay-out-of 'flymake)
     (if (featurep 'company) ;; Company should be loaded.
       (bind-keys :map eglot-mode-map
@@ -2869,14 +2951,14 @@ Client for Language Server Protocol (v3.14). lsp-mode aims to provide IDE-like e
   (use-package lsp-mode
     :when (equal custom-ide 'custom-ide-lsp)
     :commands (lsp lsp-deferred)
-    :hook (lsp-mode . mrf/lsp-mode-setup)
+    :hook (lsp-mode . mifi/lsp-mode-setup)
     :init
     (setq lsp-keymap-prefix "C-c l")  ;; Or 'C-l', 's-l'
     :config
     (if (featurep 'company)
       (bind-keys :map lsp-mode-map
         ("<tab>" . company-indent-or-complete-common)))
-    (mrf/define-rust-lsp-values)
+    (mifi/define-rust-lsp-values)
     (lsp-enable-which-key-integration t))
   
 #+end_src
@@ -2943,7 +3025,7 @@ This function is called from the lsp-mode-hook when enering or leaving LSP mode.
   ;;; --------------------------------------------------------------------------
   ;;; LSP mode setup hook
 
-  (defun mrf/lsp-mode-setup ()
+  (defun mifi/lsp-mode-setup ()
     "Custom LSP setup function."
     (add-hook 'lsp-after-open-hook 'lsp-enable-imenu)
     (when (equal custom-ide 'custom-ide-lsp)
@@ -2956,8 +3038,9 @@ This function is called from the lsp-mode-hook when enering or leaving LSP mode.
 *** LSP configuration for Rust
 
 #+begin_src emacs-lisp
-
-  (defun mrf/define-rust-lsp-values ()
+  ;;; --------------------------------------------------------------------------
+  
+  (defun mifi/define-rust-lsp-values ()
     (setq-default lsp-rust-analyzer-cargo-watch-command "clippy")
     (setq-default lsp-eldoc-render-all t)
     (setq-default lsp-idle-delay 0.6)
@@ -2972,7 +3055,7 @@ This function is called from the lsp-mode-hook when enering or leaving LSP mode.
     (setq-default lsp-rust-analyzer-display-closure-return-type-hints t)
     (setq-default lsp-rust-analyzer-display-parameter-hints nil)
     (setq-default lsp-rust-analyzer-display-reborrow-hints nil))
-  
+
 #+end_src
 
 ** LSP Bridge
@@ -3020,6 +3103,13 @@ Advantages of lsp-bridge:
 ** Anaconda-mode
 
 Anaconda-mode provides Code navigation, documentation lookup and completion for Python.
+*Note* To use this package, you need to install =setuptools=
+
+#+begin_src example
+
+  pip3 install setuptools
+  
+#+end_src
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -3043,7 +3133,15 @@ Anaconda-mode provides Code navigation, documentation lookup and completion for 
 #+end_src
 
 ** ELPY
+
 Elpy is an Emacs package to bring powerful Python editing to Emacs.  It combines and configures a number of other packages, both written in Emacs Lisp as well as Python.  Elpy is fully documented at [[https://elpy.readthedocs.io/en/latest/index.html][read the docs]].
+
+Once installed, Elpy will automatically provide code completion, syntax error highlighting and code hinting (in the modeline) for python files. Elpy offers a lot of features, but the following keybindings should be enough to get started:
+
+C-c C-c evaluates the current python script (or region if something is selected) in an interactive python shell. The python shell is automatically displayed aside of your script.
+C-RET evaluates the current statement (current line plus the following nested lines).
+C-c C-z switches between your script and the interactive shell.
+C-c C-d displays documentation for the thing under cursor. The documentation will pop in a different buffer, that can be closed with q.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -3095,9 +3193,10 @@ As compared to other packages which accomplish similar tasks, including IDO, Ivy
 TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
 
 #+begin_src emacs-lisp
-
-  (use-package prescient)
+  ;;; --------------------------------------------------------------------------
   
+  (use-package prescient)
+
 #+end_src
 
 ** Orderless
@@ -3267,10 +3366,59 @@ Counsel takes this further, providing versions of common Emacs commands that are
   
 #+end_src
 
+*** Cape Configuration
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;; Add extensions
+  (use-package cape
+    :when (equal completion-handler 'comphand-corfu)
+    :after corfu
+    ;; Bind dedicated completion commands
+    ;; Alternative prefix keys: C-c p, M-p, M-+, ...
+    :bind ( ("C-c C-p p" . completion-at-point) ;; capf
+            ("C-c C-p t" . complete-tag)        ;; etags
+            ("C-c C-p d" . cape-dabbrev)        ;; or dabbrev-completion
+            ("C-c C-p h" . cape-history)
+            ("C-c C-p f" . cape-file)
+            ("C-c C-p k" . cape-keyword)
+            ("C-c C-p s" . cape-elisp-symbol)
+            ("C-c C-p e" . cape-elisp-block)
+            ("C-c C-p a" . cape-abbrev)
+            ("C-c C-p l" . cape-line)
+            ("C-c C-p w" . cape-dict)
+            ("C-c C-p :" . cape-emoji)
+            ("C-c C-p \\" . cape-tex)
+            ("C-c C-p _" . cape-tex)
+            ("C-c C-p ^" . cape-tex)
+            ("C-c C-p &" . cape-sgml)
+            ("C-c C-p r" . cape-rfc1345))
+    :init
+    ;; Add to the global default value of `completion-at-point-functions' which is
+    ;; used by `completion-at-point'.  The order of the functions matters, the
+    ;; first function returning a result wins.  Note that the list of buffer-local
+    ;; completion functions takes precedence over the global list.
+    (add-hook 'completion-at-point-functions #'cape-dabbrev)
+    (add-hook 'completion-at-point-functions #'cape-file)
+    (add-hook 'completion-at-point-functions #'cape-elisp-block)
+    ;;(add-hook 'completion-at-point-functions #'cape-history)
+    ;;(add-hook 'completion-at-point-functions #'cape-keyword)
+    ;;(add-hook 'completion-at-point-functions #'cape-tex)
+    ;;(add-hook 'completion-at-point-functions #'cape-sgml)
+    ;;(add-hook 'completion-at-point-functions #'cape-rfc1345)
+    ;;(add-hook 'completion-at-point-functions #'cape-abbrev)
+    ;;(add-hook 'completion-at-point-functions #'cape-dict)
+    ;;(add-hook 'completion-at-point-functions #'cape-elisp-symbol)
+    ;;(add-hook 'completion-at-point-functions #'cape-line)
+    )
+
+#+end_src
+
 *** Corfu-prescient
 
 #+begin_src emacs-lisp
-
+  ;;; --------------------------------------------------------------------------
+  
   (use-package corfu-prescient
     :when (equal completion-handler 'comphand-corfu)
     :after (corfu prescient))
@@ -3326,6 +3474,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
 *** Icons for Marginalia
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package all-the-icons-completion
     :after (marginalia all-the-icons)
@@ -3338,6 +3487,7 @@ Marginalia are marks or annotations placed at the margin of the page of a book o
 Consult provides search and navigation commands based on the Emacs completion function completing-read. Completion allows you to quickly select an item from a list of candidates. Consult offers asynchronous and interactive consult-grep and  consult-ripgrep commands, and the line-based search command consult-line. Furthermore Consult provides an advanced buffer switching command consult-buffer to switch between buffers, recently opened files, bookmarks and buffer-like candidates from other sources. Some of the Consult commands are enhanced versions of built-in Emacs commands.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package consult
     :when (equal completion-handler 'comphand-vertico)
@@ -3498,7 +3648,7 @@ Embark makes it easy to choose a command to run based on what is near point, bot
 This is more support for a language rather than a langage itself
 
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
 
   (use-package flycheck
     :unless (equal custom-ide 'custom-ide-elpy)
@@ -3530,7 +3680,7 @@ Some functions that are used during the initialization of tree-sitter.
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/tree-sitter-setup ()
+  (defun mifi/tree-sitter-setup ()
     (tree-sitter-hl-mode t))
 
   (defun lsp-go-install-save-hooks ()
@@ -3556,7 +3706,7 @@ Some functions that are used during the initialization of tree-sitter.
       ((equal custom-ide 'custom-ide-lsp)
         (add-hook 'go-mode-hook 'lsp-deferred)))
     :hook
-    (tree-sitter-after-on . mrf/tree-sitter-setup)
+    (tree-sitter-after-on . mifi/tree-sitter-setup)
     (typescript-mode . lsp-deferred)
     ;; (c-mode . lsp-deferred)
     ;; (c++-mode . lsp-deferred)
@@ -3633,7 +3783,7 @@ The following are keymaps that are used by by the custom-ide and for python-mode
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/set-custom-ide-python-keymaps ()
+  (defun mifi/set-custom-ide-python-keymaps ()
     (cond
       ((equal custom-ide 'custom-ide-lsp)
         (bind-keys :map python-mode-map
@@ -3674,15 +3824,15 @@ These functions are used during python intialization or file loading. This is wh
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/load-python-file-hook ()
+  (defun mifi/load-python-file-hook ()
     (python-mode)
     (when (equal custom-ide 'custom-ide-anaconda)
       (anaconda-mode 1))
-    (message ">>> mrf/load-python-file-hook")
+    (message ">>> mifi/load-python-file-hook")
     (setq highlight-indentation-mode -1)
     (setq display-fill-column-indicator-mode t))
 
-  (defun mrf/before-save ()
+  (defun mifi/before-save ()
     "Force the check of the current python file being saved."
     (when (eq major-mode 'python-mode) ;; Python Only
       (flycheck-mode 0)
@@ -3691,8 +3841,8 @@ These functions are used during python intialization or file loading. This is wh
 
   ;; Enable DAP or DAPE, Eglot or LSP modes
   ;; This function should only be called ONCE during python-mode startup.
-  (defun mrf/enable-python-features ()
-    (message ">>> mrf/enable-python-features")
+  (defun mifi/enable-python-features ()
+    (message ">>> mifi/enable-python-features")
     ;; _____________________________
     ;; check for which debug adapter
     (cond
@@ -3710,13 +3860,13 @@ These functions are used during python intialization or file loading. This is wh
       ((equal custom-ide 'custom-ide-lsp)
         (lsp-deferred))))
 
-  (defun mrf/python-mode-triggered ()
+  (defun mifi/python-mode-triggered ()
     ;; (eldoc-box-hover-at-point-mode t) ;; Using Mitch Key for this
-    (mrf/enable-python-features)
-    (mrf/set-custom-ide-python-keymaps)
+    (mifi/enable-python-features)
+    (mifi/set-custom-ide-python-keymaps)
     (unless (featurep 'yasnippet)
       (yas-global-mode t))
-    (add-hook 'before-save-hook 'mrf/before-save)
+    (add-hook 'before-save-hook 'mifi/before-save)
     (set-fill-column 80))
 
 #+end_src
@@ -3728,10 +3878,10 @@ This is the primary Python setup that is triggered by the first load of the Pyth
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (add-to-list 'auto-mode-alist '("\\.py\\'" . mrf/load-python-file-hook))
+  (add-to-list 'auto-mode-alist '("\\.py\\'" . mifi/load-python-file-hook))
 
   (use-package python-mode
-    :hook (python-mode . mrf/python-mode-triggered))
+    :hook (python-mode . mifi/python-mode-triggered))
 
   (use-package blacken :after python) ;Format Python file upon save.
 
@@ -3830,7 +3980,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/load-js-file-hook ()
+  (defun mifi/load-js-file-hook ()
     (js2-mode)
 
     (when (equal debug-adapter 'debug-adapter-dap-mode)
@@ -3845,11 +3995,11 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 
   (use-package nodejs-repl :defer t)
 
-  (defun mrf/nvm-which ()
+  (defun mifi/nvm-which ()
     (let ((output (shell-command-to-string "source ~/.nvm/nvm.sh; nvm which")))
       (cadr (split-string output "[\n]+" t))))
 
-  (setq nodejs-repl-command #'mrf/nvm-which)
+  (setq nodejs-repl-command #'mifi/nvm-which)
 
 #+end_src
 
@@ -3875,7 +4025,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/load-c-file-hook ()
+  (defun mifi/load-c-file-hook ()
     (c-mode)
     (unless (featurep 'realgud))
     (use-package realgud)
@@ -3895,7 +4045,7 @@ This is a basic configuration for the TypeScript language so that =.ts= files ac
       (compile compile-command)))
 
   (global-set-key [f9] 'code-compile)
-  (add-to-list 'auto-mode-alist '("\\.c\\'" . mrf/load-c-file-hook))
+  (add-to-list 'auto-mode-alist '("\\.c\\'" . mifi/load-c-file-hook))
 #+end_src
 
 *** GameBoy Development
@@ -3926,6 +4076,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 *** Rustic package configuration
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package rustic
     :ensure t
@@ -3983,6 +4134,7 @@ Rust is blazingly fast and memory-efficient: with no runtime or garbage collecto
 *** Cargo-mode configuration
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package cargo-mode
     :defer t
@@ -4013,7 +4165,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
 *** Main go-mode config
 
 #+begin_src emacs-lisp
-    ;;; --------------------------------------------------------------------------
+  ;;; --------------------------------------------------------------------------
 
   (defun eglot-format-buffer-on-save ()
     (add-hook 'before-save-hook #'eglot-format-buffer -10 t))
@@ -4024,7 +4176,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
     :custom
     (compile-command "go build -v && go test -v && go vet")
     :bind (:map go-mode-map
-  	  ("C-c C-c" . 'compile))
+          ("C-c C-c" . 'compile))
     :config
     (eglot-format-buffer-on-save)
     (define-key (current-local-map) "\C-c\C-c" 'compile)
@@ -4043,6 +4195,7 @@ Make sure that =gopls= and =dlv= are installed. gopls is the Go! (or golang)  la
 for variable, functions and current argument position of function.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package go-eldoc
     :after go-mode
@@ -4060,6 +4213,7 @@ for variable, functions and current argument position of function.
 Integration of the Go 'guru' analysis tool into Emacs.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package go-guru
     :after go-mode
@@ -4188,7 +4342,7 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
     (message "prepare-dape end")
     (bind-keys :map prog-mode-map
       ("C-c ." . dape-hydra/body))
-    (mrf/additional-dape-configs))
+    (mifi/additional-dape-configs))
   
 #+end_src
 
@@ -4197,13 +4351,13 @@ Please note that DAP is triggered after loading of various languages (for Emacs 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (setq mrf/vscode-js-debug-dir (file-name-concat user-emacs-directory "dape/vscode-js-debug"))
+  (setq mifi/vscode-js-debug-dir (file-name-concat user-emacs-directory "dape/vscode-js-debug"))
 
-  (defun mrf/install-vscode-js-debug ()
+  (defun mifi/install-vscode-js-debug ()
     "Run installation procedure to install JS debugging support"
     (interactive)
-    (mkdir mrf/vscode-js-debug-dir t)
-    (let ((default-directory (expand-file-name mrf/vscode-js-debug-dir)))
+    (mkdir mifi/vscode-js-debug-dir t)
+    (let ((default-directory (expand-file-name mifi/vscode-js-debug-dir)))
 
       (vc-git-clone "https://github.com/microsoft/vscode-js-debug.git" "." nil)
       (call-process "npm" nil "*snam-install*" t "install")
@@ -4218,7 +4372,7 @@ This is meant to be evaluated and run once. Calling this function will clone the
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  ;; (mrf/install-vscode-js-debug)
+  ;; (mifi/install-vscode-js-debug)
 
 #+end_src
 
@@ -4229,7 +4383,7 @@ This is meant to be evaluated and run once. Calling this function will clone the
 :Golang:
 #+begin_src emacs-lisp
   ;;; ------------------------------------------------------------------------
-  (defun mrf/additional-dape-configs ()
+  (defun mifi/additional-dape-configs ()
     "Additional DAPE configruations for various languages."
 
     (with-eval-after-load
@@ -4257,23 +4411,22 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
 #+begin_src emacs-lisp :output silent
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/dape-end-debug-session ()
+  (defun mifi/dape-end-debug-session ()
     "End the debug session."
     (interactive)
     (dape-quit))
 
-  (defun mrf/dape-delete-all-debug-sessions ()
+  (defun mifi/dape-delete-all-debug-sessions ()
     "End the debug session and delete all breakpoints."
     (interactive)
     (dape-breakpoint-remove-all)
-    (mrf/dape-end-debug-session))
+    (mifi/dape-end-debug-session))
   
 #+end_src
 
 ***** DAPE Hydra Definition
 
 #+begin_src emacs-lisp
-
   ;;; --------------------------------------------------------------------------
 
   (defun define-dape-hydra ()
@@ -4311,12 +4464,12 @@ Below are all the necessary functions and definitions for Hydra use under DAPE.
       ("dd" dape)
       ("dw" dape-watch-dwim)
       ("ee" dape-evaluate-expression)
-      ("dx" mrf/dape-end-debug-session)
-      ("dX" mrf/dape-delete-all-debug-sessions)
+      ("dx" mifi/dape-end-debug-session)
+      ("dX" mifi/dape-delete-all-debug-sessions)
       ("dp" dape-prepare)
       ("x" nil "exit Hydra" :color yellow)
-      ("q" mrf/dape-end-debug-session "quit" :color blue)
-      ("Q" mrf/dape-delete-all-debug-sessions :color red)))
+      ("q" mifi/dape-end-debug-session "quit" :color blue)
+      ("Q" mifi/dape-delete-all-debug-sessions :color red)))
   
 #+end_src
 
@@ -4372,6 +4525,7 @@ The Debug Adapter Protocol makes it possible to implement a generic debugger for
 Something that is needed for Rust and Go debugging.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package dap-lldb
     :when (equal debug-adapter 'debug-adapter-dap-mode)
@@ -4413,7 +4567,7 @@ Something that is needed for Rust and Go debugging.
   ;;; --------------------------------------------------------------------------
   ;;; DAP for NodeJS
 
-  (defun mrf/setup-dap-node ()
+  (defun mifi/setup-dap-node ()
     "Require dap-node feature and run dap-node-setup if VSCode module isn't already installed"
     (require 'dap-node)
     (unless (file-exists-p dap-node-debug-path) (dap-node-setup)))
@@ -4421,8 +4575,8 @@ Something that is needed for Rust and Go debugging.
   (use-package dap-node
     :when (equal debug-adapter 'debug-adapter-dap-mode)
     :disabled
-    :hook ((typescript-mode . mrf/setup-dap-node)
-          (js2-mode . mrf/setup-dap-node))
+    :hook ((typescript-mode . mifi/setup-dap-node)
+          (js2-mode . mifi/setup-dap-node))
     ;;:ensure (:host github :repo "emacs-lsp/dap-mode" :files (:defaults "icons" "dap-mode-pkg.el"))
     :after dap-mode
     :config
@@ -4441,6 +4595,7 @@ Something that is needed for Rust and Go debugging.
 **** DAP Templates For Various Languages :Python:Rust:
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (with-eval-after-load 'dap-lldb
     (dap-register-debug-template
@@ -4479,7 +4634,7 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/dap-end-debug-session ()
+  (defun mifi/dap-end-debug-session ()
     "End the debug session and delete project Python buffers."
     (interactive)
     (kill-matching-buffers "\*Python :: Run file [from|\(buffer]*" nil :NO-ASK)
@@ -4487,13 +4642,13 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
     (kill-matching-buffers "\*dap-ui-*" nil :NO-ASK)
     (dap-disconnect (dap--cur-session)))
 
-  (defun mrf/dap-delete-all-debug-sessions ()
+  (defun mifi/dap-delete-all-debug-sessions ()
     "End the debug session and delete project Python buffers and all breakpoints."
     (interactive)
     (dap-breakpoint-delete-all)
-    (mrf/dap-end-debug-session))
+    (mifi/dap-end-debug-session))
 
-  (defun mrf/dap-begin-debug-session ()
+  (defun mifi/dap-begin-debug-session ()
     "Begin a debug session with several dap windows enabled."
     (interactive)
     (dap-ui-show-many-windows)
@@ -4552,11 +4707,11 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
       ("ea" dap-ui-expressions-add)
       ("er" dap-eval-region)
       ("es" dap-eval-thing-at-point)
-      ("dx" mrf/dap-end-debug-session)
-      ("dX" mrf/dap-delete-all-debug-sessions)
+      ("dx" mifi/dap-end-debug-session)
+      ("dX" mifi/dap-delete-all-debug-sessions)
       ("x" nil "exit Hydra" :color yellow)
-      ("q" mrf/dap-end-debug-session "quit" :color blue)
-      ("Q" mrf/dap-delete-all-debug-sessions :color red)))
+      ("q" mifi/dap-end-debug-session "quit" :color blue)
+      ("Q" mifi/dap-delete-all-debug-sessions :color red)))
 
 #+end_src
 
@@ -4679,6 +4834,7 @@ We also use [[https://github.com/sebastiencs/company-box][company-box]] to furth
 This is the default built-in project system. For those not needing the full-featured ~projectile~, this package is generally enough.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (defun project-find-go-module (dir)
     (when-let ((root (locate-dominating-file dir "go.mod")))
@@ -4794,7 +4950,7 @@ For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (defun mrf/configure-eshell ()
+  (defun mifi/configure-eshell ()
     ;; Save command history when commands are entered
     (add-hook 'eshell-pre-command-hook 'eshell-save-some-history)
     ;; Truncate buffer for performance
@@ -4810,7 +4966,7 @@ For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
   (use-package eshell
     :ensure
     :defer t
-    :hook (eshell-first-time-mode . mrf/configure-eshell)
+    :hook (eshell-first-time-mode . mifi/configure-eshell)
     :config
     (with-eval-after-load 'esh-opt
       (setq eshell-destroy-buffer-when-process-dies t)
@@ -4887,9 +5043,12 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  ;; Prefer g-prefixed coreutils version of standard utilities when available
+    ;; Prefer g-prefixed coreutils version of standard utilities when available
   (let ((gls (executable-find "gls")))
-    (when gls (setq insert-directory-program gls)))
+    (when gls (setq-default insert-directory-program gls
+              dired-use-ls-dired t
+                ;; Needed to fix an issue on Mac which causes dired to fail
+                dired-listing-switches "-al --group-directories-first")))
 
   (use-package all-the-icons-dired
     :after dired
@@ -4909,8 +5068,6 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 
 #+end_src
 
-#+RESULTS:
-: #s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8125 data (:use-package (26178 33358 905208 0) :use-package-secs (0 0 140 0)))
 
 *** Single Window
 Dired, by default, opens up multiple windows - one for each directory. It would be nice to be able to limit =dired= to use just a single window. [[https://codeberg.org/amano.kenji/dired-single][dired-single]] does just that. We configure =dired-single= to open up a directory while in dired with the =C-<return>=  key combination. This will then open up the directory in the buffer named =*dired*=. Whenever a directory is opened with the =C-<return>= key sequence, that directory will then replace what's currently in the =*dired*= buffer.
@@ -4919,7 +5076,7 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
   ;;; --------------------------------------------------------------------------
   ;; Single Window dired - don't continually open new buffers
 
-  (defun mrf/dired-single-keymap-init ()
+  (defun mifi/dired-single-keymap-init ()
     "Bunch of stuff to run for dired, either immediately or when it's
      loaded."
     (define-key dired-mode-map
@@ -4932,7 +5089,7 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
   (use-package dired-single
     :after dired
     :config
-    (mrf/dired-single-keymap-init))
+    (mifi/dired-single-keymap-init))
 #+end_src
 
 
@@ -5055,11 +5212,11 @@ Here are some helpful functions.
   ;;; --------------------------------------------------------------------------
   ;; Functions to insert the buffer file name at the current cursor position
   ;;
-  (defun mrf/insert-buffer-full-name-at-point ()
+  (defun mifi/insert-buffer-full-name-at-point ()
     (interactive)
     (insert buffer-file-name))
 
-  (defun mrf/insert-buffer-name-at-point ()
+  (defun mifi/insert-buffer-name-at-point ()
     (interactive)
     (insert (file-name-nondirectory (buffer-file-name))))
 
@@ -5116,6 +5273,7 @@ Here are some helpful functions.
 This minor mode sets background color to strings that match color names, e.g. #0000FF is displayed in white with a blue background.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package rainbow-mode
     :hook (prog-mode . (lambda () (rainbow-mode t))))
@@ -5127,6 +5285,7 @@ This minor mode sets background color to strings that match color names, e.g. #0
 highlight-defined is an Emacs minor mode that highlights defined Emacs Lisp symbols in source code.
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
   (use-package highlight-defined
     :hook (emacs-lisp-mode . highlight-defined-mode))
@@ -5170,6 +5329,7 @@ Designate any buffer to “popup” status, and it will stay out of your way. Di
 markdown-mode is a major mode for editing Markdown-formatted text. The latest stable version is markdown-mode 2.5, released on Feb 12, 2022. See the release notes for details. markdown-mode is free software, licensed under the GNU GPL, version 3 or later.
 
 #+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
 
   (use-package markdown-mode
     :ensure t
@@ -5183,6 +5343,7 @@ markdown-mode is a major mode for editing Markdown-formatted text. The latest st
 Instant Github-flavored Markdown/Org preview using Grip (GitHub Readme Instant Preview).
 
 #+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
 
   ;; Use keybindings
   (use-package grip-mode
@@ -5203,17 +5364,18 @@ Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It work
 
 *** Mitch's Minor Mode Functions
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
   
-  (defun mrf/set-fill-column-interactively (num)
+  (defun mifi/set-fill-column-interactively (num)
     "Asks for the fill column."
     (interactive "nfill-column: ")
     (set-fill-column num))
 
-  (defun mrf/set-org-fill-column-interactively (num)
+  (defun mifi/set-org-fill-column-interactively (num)
     "Asks for the fill column for Org mode."
     (interactive "norg-fill-column: ")
     (setq custom-org-fill-column num)
-    (mrf/org-mode-visual-fill)
+    (mifi/org-mode-visual-fill)
     (redraw-display))
 
 #+end_src
@@ -5224,15 +5386,16 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
-  (defun mrf/define-mmm-minor-mode-map ()
+
+  (defun mifi/define-mmm-minor-mode-map ()
     (defvar mmm-keys-minor-mode-map
       (let ((map (make-sparse-keymap)))
         (bind-keys :map map
-  	("M-RET $" . jinx-correct)
+        ("M-RET $" . jinx-correct)
           ("M-RET p" . pulsar-pulse-line)
           ("M-RET d" . dashboard-open)
           ("M-RET S e" . eshell)
-          ("M-RET f" . mrf/set-fill-column-interactively)
+          ("M-RET f" . mifi/set-fill-column-interactively)
           ("M-RET r" . repeat-mode)
           ("M-RET S i" . ielm)
           ("M-RET S v" . vterm-other-window)
@@ -5250,7 +5413,7 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
       :init-value t
       :lighter " mmm-keys"))
 
-  (mrf/define-mmm-minor-mode-map)
+  (mifi/define-mmm-minor-mode-map)
   (mmm-keys-minor-mode 1)
 
 #+end_src
@@ -5261,8 +5424,9 @@ For those menus that would normally show up as either =prefix= or =lambda=, give
 shown. Plus, some keys are mode specific and will only appear when that major mode is active.
 
 #+begin_src emacs-lisp :results output silent
+  ;;; --------------------------------------------------------------------------
 
-  (defun mrf/mmm-handle-context-keys ()
+  (defun mifi/mmm-handle-context-keys ()
     "Enable or Disable keys based upon featurep context."
     (let ((map mmm-keys-minor-mode-map))
       (unbind-key "M-RET o f" map)
@@ -5273,15 +5437,15 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
         ((equal major-mode 'org-mode)
         (bind-keys :map map
           ("M-RET M-RET" . org-insert-heading)
-          ("M-RET o f" . mrf/set-org-fill-column-interactively)
+          ("M-RET o f" . mifi/set-org-fill-column-interactively)
           ("M-RET o l" . org-toggle-link-display)))
         ((equal major-mode 'python-mode)
         (bind-keys :map map
           ("M-RET P" . 'pydoc-at-point))))))
 
-  (defun mrf/mmm-update-menu ()
+  (defun mifi/mmm-update-menu ()
     (interactive)
-    (mrf/mmm-handle-context-keys)
+    (mifi/mmm-handle-context-keys)
     (which-key-add-key-based-replacements "M-RET S" "shells")
     (which-key-add-key-based-replacements "M-RET T" "theme-keys")
     (which-key-add-key-based-replacements "M-RET P" "python-menu")
@@ -5290,7 +5454,7 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
     (which-key-add-key-based-replacements "M-RET f" "set-fill-column")
     (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
-  (add-hook 'which-key-inhibit-display-hook 'mrf/mmm-update-menu)
+  (add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)
 
 #+end_src
 
@@ -5308,20 +5472,23 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
       (setq-default initial-scratch-message
         (format
         ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
-        ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))))
+        ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
+      (when dashboard-landing-screen (dashboard-open))))
 
-  (if dashboard-landing-screen
+  (when dashboard-landing-screen
     ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
-    (add-hook 'lisp-interaction-mode-hook 'dashboard-open))
+    (add-hook 'elpaca-after-init-hook
+        (lambda ()
+          (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
 
 #+end_src
-
 
 ** Exiting and Cleanup
 
 #+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
 
-  (defun mrf/cleanup-when-exiting ()
+  (defun mifi/cleanup-when-exiting ()
     (let ((backdir (format "%s/config-backup" working-files-directory)))
       (make-directory backdir t)
       ;; Backup init.el
@@ -5332,7 +5499,7 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
       ;;   (expand-file-name "emacs-config.org" emacs-config-directory)
       ;;   (expand-file-name "emacs-config.org" backdir) t)))
 
-  (add-hook 'kill-emacs-hook #'mrf/cleanup-when-exiting)
+  (add-hook 'kill-emacs-hook #'mifi/cleanup-when-exiting)
 
 #+end_src
 
@@ -5340,31 +5507,42 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
 * Lastly
 
 ** Ignore Line Number Mode
+
 The following is a list of major mode-hooks variables that are set so that they don't follow the normal global line number mode. If there is any mode that doesn't appear here, more than likely it will have line numbers added. Just add the hook name here to make it so that major mode not have line numbers. This doesn't effect minor modes.
 
-#+begin_src emacs-lisp :tangle no
+#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
   ;; Ignore Line Numbers for the following modes:
 
-  ;; Line #'s appear everywhere
+  ;; Line #'s appear everywhere if global-display-line-numbers-mode is set
   ;; ... except for when in these modes
-  (dolist (mode '(dashboard-mode-hook
-                   helpful-mode-hook
-                   eshell-mode-hook
-                   eww-mode-hook
-                   help-mode-hook
-                   org-mode-hook
-                   shell-mode-hook
-                   term-mode-hook
-                   treemacs-mode-hook
-                   vterm-mode-hook))
-    (add-hook mode (lambda () (display-line-numbers-mode 0))))
+  (when (equal global-display-line-numbers-mode t)
+    (dolist (mode '( dashboard-mode-hook
+                     helpful-mode-hook
+                     eshell-mode-hook
+                     eww-mode-hook
+                     help-mode-hook
+                     org-mode-hook
+                     shell-mode-hook
+                     term-mode-hook
+                     treemacs-mode-hook
+                     vterm-mode-hook))
+      (add-hook mode (lambda () (display-line-numbers-mode 0)))))
+  
+#+end_src
 
+** Supress common warnings
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;; Supress common annoying warning.
+  ;; These can still be found in the  *Warnings* buffer
   (setq warning-suppress-types '((package reinitialization)
                                   (package-initialize)
                                   (package)
                                   (use-package)
                                   (python-mode)))
+  
 #+end_src
 
 ** Lispy Footer

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -5,13 +5,14 @@
 #+STARTUP: showall
 #+PROPERTY: header-args:emacs-lisp :tangle ./init.el :results silent :exports code :mkdirp yes
 
+
 * Welcome!
 
 This ORG file will configure the  ~init.el~  file based upon all of the =emacs-lisp= source blocks. The =emacs-lisp= source blocks are defined in an organized order. While these blocks can generally be moved around, there are some order dependencies. So it's generally best that this order be preserved to prevent any compile-time issues.
 
 The goal of this Emacs configuration is to make an Emacs configuration that has a good collection of popular options. So far, the following collections of options are included here:
 
-:feature-overview:
+:Features:
 - Landing Screen Options ::
   + Dashboard
   + IELM (Integrated Emacs Lisp Mode)
@@ -52,6 +53,7 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
   + Customizable Menu (MmM)
 :END:
 
+
 * README:
 
 --------------------------------------------------------------------------------
@@ -69,6 +71,8 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
 - When starting this Configuration for the very first time, set the =use-package-always-ensure= variable to =t=. This will force all packages to be installed even if deferred. Make sure to set this value back to =nil= after everything is loaded otherwise Emacs startup time will be impacted. This can be found in the [[Bootstrap straight][Bootstrap straight]] section.
 
 - Take a look a the [[Custom enable flags][Custom Variables]] and [[Customization groups][Groups]] section to see what options exist. It's important to note that these variables need to be adhered to. Another thing to note is that the various =enable*= flags are not used as =:if= option in =use-package= statement. Instead, a lisp conditional statement is used so that the package is actually never loaded or installed. This improves overall startup performance.
+
+- Tested with Emacs versions 29.1 - 29.3 and 30.0.50.
   
 - Shout out to the many people in the Emacs community from which a lot of this configuration took inspiration from.
   
@@ -165,10 +169,9 @@ Because in macOS, Emacs could be started outside of a shell (like an application
   (defconst *is-a-mac* (eq system-type 'darwin))
 
   (defun mifi/setup-exec-path ()
-       ;;; Set up Emacs' `exec-path' and PATH environment variable to match"
-       ;;; that used by the user's shell.
-       ;;; This is particularly useful under Mac OS X and macOS, where GUI
-       ;;; apps are not started from a shell."
+    ;; A list of customized executable paths. This is just something I (mifi)
+    ;; do personally rather than have another package do it for me. For the
+    ;; most part, the paths are typical on a Mac and with homebrew installed.
     (interactive)
     (setq exec-path '( "/Users/strider/.cargo/bin"
                      "/Users/strider/.local/bin"
@@ -189,6 +192,8 @@ Because in macOS, Emacs could be started outside of a shell (like an application
 
 #+end_src
 
+** Lispy end of early-init.el
+Standard fare and good practice.
 
 #+begin_src emacs-lisp :tangle "early-init.el" 
   ;;; early-init.el ends here.
@@ -540,12 +545,12 @@ This is a curated selection of themes that I personally like. Most of them are d
     :type 'natnum)
 
   ;;; Font related
-  (defcustom default-font-family "Fira Code Retina"
+  (defcustom default-font-family "Menlo"
     "The font family used as the default font."
     :type 'string
     :group 'mifi-custom-fonts)
 
-  (defcustom mono-spaced-font-family "Fira Code Retina"
+  (defcustom mono-spaced-font-family "Andale Mono"
     "The font family used as the mono-spaced font."
     :type 'string
     :group 'mifi-custom-fonts)
@@ -713,6 +718,26 @@ This directory is expected to be in the ~emacs-config-direcory~ dir. This can be
 
   (add-to-list 'load-path (expand-file-name "lisp" emacs-config-directory))
   (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
+
+#+end_src
+
+*** Add site-lisp entries to load-path
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  ;; Add both site-lisp and its immediate subdirs to `load-path'
+  (let ((site-lisp-dir (expand-file-name "site-lisp/" emacs-config-directory)))
+    (when (file-directory-p site-lisp-dir)
+      (push site-lisp-dir load-path)
+      ;; Add every non-hidden subdir of PARENT-DIR to `load-path'.
+      (let ((default-directory site-lisp-dir))
+        (setq load-path
+            (append
+             (cl-remove-if-not
+              #'file-directory-p
+               (directory-files (expand-file-name site-lisp-dir) t "^[^\\.]"))
+              load-path)))))
 
 #+end_src
 
@@ -1242,8 +1267,47 @@ Window numbers for Emacs: Navigate your windows and frames using numbers. This i
   ;;; Window Number
 
   (use-package winum
-    ;;:ensure (:host github :repo "deb0ch/emacs-winum")
+    ;; :vc syntax below works, just for testing. Elpaca handles it for now.
+    ;; :vc ( :url "https://github.com/deb0ch/emacs-winum"
+    ;; 	:branch "master"
+    ;; 	:main-file "winum.el")
     :config (winum-mode))
+
+#+end_src
+
+** Dashboard
+<<<Dashboard>>> is an extensible Emacs startup screen showing you what’s most important.
+*** Value of dashboard-startup-banner can be:
+**** =nil= to display no banner
+**** ='official= which displays the official emacs logo
+**** ='logo= which displays an alternative emacs logo
+**** =1, 2 or 3= which displays one of the text banners
+**** ~"path/to/your/image.gif"~,
+~"path/to/your/image.png"~ or
+~"path/to/your/text.txt"~  which displays whatever gif/image/text you would prefer
+**** a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
+
+*** Dashboard Setup
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  (use-package dashboard
+    :custom
+    (dashboard-items '(   (recents . 15)
+                        (bookmarks . 10)
+                        (projects . 10)))
+    (dashboard-center-content t)
+    (dashboard-set-heading-icons t)
+    (dashboard-set-file-icons t)
+    (dashboard-footer-messages '("Greetings Program!"))
+    (dashboard-banner-logo-title "Welcome to Emacs!")
+    (dashboard-startup-banner 'logo)
+    :bind ("C-c d" . dashboard-open)
+    :config
+    ;; (setq initial-buffer-choice (lambda () (get-buffer-create dashboard-buffer-name)))
+    (add-hook 'elpaca-after-init-hook #'dashboard-insert-startupify-lists)
+    (add-hook 'elpaca-after-init-hook #'dashboard-initialize)
+    (dashboard-setup-startup-hook))
 
 #+end_src
 
@@ -1274,11 +1338,16 @@ These are packages located in the ~"lisp"~ directory within the emacs-config-dir
 
 #+begin_src emacs-lisp
   ;;; ##########################################################################
+  ;; These are packages located in the site-lisp or lisp directories in the
+  ;; 'emacs-config-directory'
   
+
 #+end_src
 
 
 * Operational Systems
+These are major systems that control major operational features of Emacs like Search, File handling, Undo/Redo.
+
 ** Undo Handlers
 *** Vundo (visual undo)
 
@@ -2118,6 +2187,160 @@ Dired, by default, opens up multiple windows - one for each directory. It would 
     (mifi/dired-single-keymap-init))
 #+end_src
 
+*** Treemacs
+<<<Treemacs>>> is a file and project explorer similar to NeoTree or vim’s NerdTree, but largely inspired by the Project Explorer in Eclipse. It shows the file system outlines of your projects in a simple tree layout allowing quick navigation and exploration, while also possessing basic file management utilities.
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+  ;;; Treemacs
+
+  (use-package treemacs
+    :after (:all winum ace-window)
+    :bind (:map global-map
+            ("M-0"         . treemacs-select-window)
+            ("C-x t 1"   . treemacs-delete-other-windows)
+            ("C-x t t"   . treemacs)
+            ("C-x t d"   . treemacs-select-directory)
+            ("C-x t B"   . treemacs-bookmark)
+            ("C-x t C-t" . treemacs-find-file)
+            ("C-x t M-t" . treemacs-find-tag))
+    :config
+    (setq treemacs-collapse-dirs                  (if treemacs-python-executable 3 0)
+      treemacs-deferred-git-apply-delay  0.5
+      treemacs-directory-name-transformer        #'identity
+      treemacs-display-in-side-window            t
+      treemacs-eldoc-display                     'simple
+      treemacs-file-event-delay          2000
+      treemacs-file-extension-regex              treemacs-last-period-regex-value
+      treemacs-file-follow-delay                 0.2
+      treemacs-file-name-transformer             #'identity
+      treemacs-follow-after-init                 t
+      treemacs-expand-after-init                 t
+      treemacs-find-workspace-method             'find-for-file-or-pick-first
+      treemacs-git-command-pipe          ""
+      treemacs-goto-tag-strategy                 'refetch-index
+      treemacs-header-scroll-indicators  '(nil . "^^^^^^")
+      treemacs-hide-dot-git-directory            t
+      treemacs-indentation                       2
+      treemacs-indentation-string                " "
+      treemacs-is-never-other-window             nil
+      treemacs-max-git-entries           5000
+      treemacs-missing-project-action            'ask
+      treemacs-move-forward-on-expand            nil
+      treemacs-no-png-images                     nil
+      treemacs-no-delete-other-windows   t
+      treemacs-project-follow-cleanup            nil
+      treemacs-persist-file                      (expand-file-name
+                                                     ".cache/treemacs-persist"
+                                                     user-emacs-directory)
+      treemacs-position                  'left
+      treemacs-read-string-input                 'from-child-frame
+      treemacs-recenter-distance                 0.1
+      treemacs-recenter-after-file-follow        nil
+      treemacs-recenter-after-tag-follow         nil
+      treemacs-recenter-after-project-jump       'always
+      treemacs-recenter-after-project-expand     'on-distance
+      treemacs-litter-directories                '("/node_modules"
+                                              "/.venv"
+                                              "/.cask"
+                                              "/__pycache__")
+      treemacs-project-follow-into-home  nil
+      treemacs-show-cursor                       nil
+      treemacs-show-hidden-files                 t
+      treemacs-silent-filewatch          nil
+      treemacs-silent-refresh                    nil
+      treemacs-sorting                   'alphabetic-asc
+      treemacs-select-when-already-in-treemacs 'move-back
+      treemacs-space-between-root-nodes  t
+      treemacs-tag-follow-cleanup                t
+      treemacs-tag-follow-delay          1.5
+      treemacs-text-scale                        nil
+      treemacs-user-mode-line-format             nil
+      treemacs-user-header-line-format   nil
+      treemacs-wide-toggle-width                 70
+      treemacs-width                             38
+      treemacs-width-increment           1
+      treemacs-width-is-initially-locked         t
+      treemacs-workspace-switch-cleanup  nil)
+
+    ;; The default width and height of the icons is 22 pixels. If you are
+    ;; using a Hi-DPI display, uncomment this to double the icon size.
+    ;;(treemacs-resize-icons 44)
+
+    (treemacs-follow-mode t)
+    (treemacs-filewatch-mode t)
+    (treemacs-fringe-indicator-mode 'always)
+    (when treemacs-python-executable
+      (treemacs-git-commit-diff-mode t))
+    (pcase (cons (not (null (executable-find "git")))
+             (not (null treemacs-python-executable)))
+      (`(t . t)
+        (treemacs-git-mode 'deferred))
+      (`(t . _)
+        (treemacs-git-mode 'simple)))
+    (treemacs-hide-gitignored-files-mode nil))
+
+#+end_src
+
+**** Treemacs Projectile
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  (use-package treemacs-projectile
+    :when (equal custom-project-handler 'custom-project-projectile)
+    :after treemacs projectile)
+
+#+end_src
+
+**** Treemacs dired
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  (use-package treemacs-icons-dired
+    :after treemacs
+    :hook (dired-mode . treemacs-icons-dired-enable-once))
+
+#+end_src
+
+**** Treemacs Persp
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  ;; (use-package treemacs-perspective
+  ;;    :disabled
+  ;;    :after (treemacs persp-mode) ;;or perspective vs. persp-mode
+  ;;    :config (treemacs-set-scope-type 'Perspectives))
+
+  (use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
+    ;;:ensure (:files ("src/extra/treemacs-persp.el" "treemacs-persp-pkg.el"):host github :repo "Alexander-Miller/treemacs")
+    :after (:any treemacs persp-mode) ;;or perspective vs. persp-mode
+    :config (treemacs-set-scope-type 'Perspectives))
+
+#+end_src
+
+**** Treemacs tab-bar
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  (use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
+    :after treemacs
+    :config (treemacs-set-scope-type 'Tabs))
+
+#+end_src
+
+**** Treemacs all-the-icons
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+
+  (use-package treemacs-all-the-icons
+    :after treemacs
+    :if (display-graphic-p))
+
+#+end_src
+
 
 * Visuals
 ** Theme List and Selection
@@ -2248,7 +2471,7 @@ This function simply loads the theme from the theme-list indexed by the ~theme-s
       "Face used for the line delimiting the begin of source blocks.")
 
     (defface org-block
-      '((t (:background "#242635" :extend t :font "Fira Code Retina")))
+      '((t (:background "#242635" :extend t :font "Avenir Next")))
       "Face used for the source block background.")
 
     (defface org-block-end-line
@@ -2395,7 +2618,6 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
     
 #+end_src
 
-
 *** Functions to set the frame size
 
 #+begin_src emacs-lisp
@@ -2459,6 +2681,7 @@ A better version of variable-pitch mode. This keeps certain faces (defined in mi
 
   (defun mifi/update-face-attribute ()
     "Set the font faces."
+    (interactive)
     ;; ====================================
     (set-face-attribute 'default nil
       :family default-font-family
@@ -2566,7 +2789,12 @@ Some key kindings to switch to different screen resolutions.
     (define-key map (kbd "C-S-c 3")
       (lambda () (interactive) (use-large-display-font t)))
     (define-key map (kbd "C-S-c 4")
-      (lambda () (interactive) (use-x-large-display-font t))))
+      (lambda () (interactive) (use-x-large-display-font t)))
+    (which-key-add-key-based-replacements "C-S-c 1" "recenter-with-small-font")
+    (which-key-add-key-based-replacements "C-S-c 2" "recenter-with-medium-font")
+    (which-key-add-key-based-replacements "C-S-c 3" "recenter-with-large-font")
+    (which-key-add-key-based-replacements "C-S-c 4" "recenter-with-x-large-font")
+  )
 
 #+end_src
 
@@ -2587,7 +2815,14 @@ These functions are used to configure the main frame font size. Based upon a mon
       (mifi/frame-recenter)
       ;;else
       (unless enable-frameset-restore (mifi/frame-recenter))))
+  
+#+end_src
 
+***** Select Display Font and optionally Recenter
+These functions resize the font to some pre-defined values and will optiononally resize and recenter the window.
+(see =mifi-custom= defcustom variables for the pre-defined font sizes and font families)
+
+#+begin_src emacs-lisp
   ;;; ##########################################################################
 
   (defun use-small-display-font (&optional force-recenter)
@@ -2612,19 +2847,24 @@ These functions are used to configure the main frame font size. Based upon a mon
     (interactive)
     (mifi/set-frame-font 3)
     (mifi/should-recenter force-recenter))
+  
+#+end_src
 
+***** Early Display Resize
+Apply saved font/window-size early in the startup process.
 
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
   ;; This is done so that the Emacs window is sized early in the init phase along with the default font size.
   ;; Startup works without this but it's nice to see the window expand early...
   (when (display-graphic-p)
     (add-hook 'elpaca-after-init-hook
       (lambda ()
         (progn
-        (mifi/update-face-attribute)
-        (unless (daemonp)
-          (unless enable-frameset-restore (mifi/frame-recenter))))
+  	(mifi/update-face-attribute)
+  	(unless (daemonp)
+            (unless enable-frameset-restore (mifi/frame-recenter))))
         )))
-
 #+end_src
 
 *** Window, mode-line, +more padding
@@ -2969,7 +3209,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 *** Better Bullets
 [[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
 
-#+begin_src emacs-lisp
+#+begin_src emacs-lisp :tangle no
     ;;; ##########################################################################
 
     (use-package org-superstar
@@ -3066,7 +3306,57 @@ While there is standard markdown support built into =org-mode=, this additional 
 
 #+end_src
 
+*** Org Modern
+
+This package implements a modern style for your Org buffers using font locking and text properties. The package styles headlines, keywords, tables and source blocks. The styling is configurable, you can enable, disable or modify the style of each syntax element individually via the org-modern customization group.
+
+Note that org-modern is a full replacement for both org-superstar and org-bullets. You can easily disable styling of certain elements, e.g., org-modern-timestamp, if you only want to use a subset of  org-modern.
+
+#+begin_src emacs-lisp
+
+  (use-package org-modern
+    :when (display-graphic-p)
+    :after org
+    :hook (org-mode . org-modern-mode)
+    :config
+    ;; Add frame borders and window dividers
+    ;; (modify-all-frames-parameters
+    ;;   '((right-divider-width . 40)
+    ;;      (internal-border-width . 40)))
+    ;; (dolist (face '(window-divider
+    ;; 		   window-divider-first-pixel
+    ;; 		   window-divider-last-pixel))
+    ;;   (face-spec-reset-face face)
+    ;;   (set-face-foreground face (face-attribute 'default :background nil)))
+    ;; (set-face-background 'fringe (face-attribute 'default :background nil))
+    ;; (setq
+    ;;   ;; Edit settings
+    ;;   org-auto-align-tags nil
+    ;;   org-tags-column 0
+    ;;   org-catch-invisible-edits 'show-and-error
+    ;;   org-special-ctrl-a/e t
+    ;;   org-insert-heading-respect-content t
+
+    ;;   ;; Org styling, hide markup etc.
+    ;;   org-hide-emphasis-markers nil
+    ;;   org-pretty-entities t
+    ;;   org-ellipsis "…"
+
+    ;;   ;; Agenda styling
+    ;;   org-agenda-tags-column 0
+    ;;   org-agenda-block-separator ?─
+    ;;   org-agenda-time-grid
+    ;;   '((daily today require-timed)
+    ;;      (800 1000 1200 1400 1600 1800 2000)
+    ;;      " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
+    ;;   org-agenda-current-time-string
+    ;;   "◀── now ─────────────────────────────────────────────────")
+    (global-org-modern-mode))
+
+#+end_src
+
 *** Org-Roam
+
 Org Mode is known to be a great tool not just for writing and personal notes but also TODO lists, project planning, time tracking, and more. Once you start to become really invested in Org Mode you’ll eventually have to come up with a system for managing your Org files so that it’s easy to store and find the information you need.
 
 Org Roam is an extension to Org Mode which solves a couple of the biggest problems that I’ve personally had when using Org for personal notes:
@@ -3459,199 +3749,6 @@ This is the default built-in project system. For those not needing the full-feat
     (add-hook 'project-find-functions #'project-find-go-module))
 
 #+end_src
-
-
-* Treemacs
-<<<Treemacs>>> is a file and project explorer similar to NeoTree or vim’s NerdTree, but largely inspired by the Project Explorer in Eclipse. It shows the file system outlines of your projects in a simple tree layout allowing quick navigation and exploration, while also possessing basic file management utilities.
-
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-  ;;; Treemacs
-
-  (use-package treemacs
-    :after (:all winum ace-window)
-    :bind (:map global-map
-            ("M-0"         . treemacs-select-window)
-            ("C-x t 1"   . treemacs-delete-other-windows)
-            ("C-x t t"   . treemacs)
-            ("C-x t d"   . treemacs-select-directory)
-            ("C-x t B"   . treemacs-bookmark)
-            ("C-x t C-t" . treemacs-find-file)
-            ("C-x t M-t" . treemacs-find-tag))
-    :config
-    (setq treemacs-collapse-dirs                  (if treemacs-python-executable 3 0)
-      treemacs-deferred-git-apply-delay  0.5
-      treemacs-directory-name-transformer        #'identity
-      treemacs-display-in-side-window            t
-      treemacs-eldoc-display                     'simple
-      treemacs-file-event-delay          2000
-      treemacs-file-extension-regex              treemacs-last-period-regex-value
-      treemacs-file-follow-delay                 0.2
-      treemacs-file-name-transformer             #'identity
-      treemacs-follow-after-init                 t
-      treemacs-expand-after-init                 t
-      treemacs-find-workspace-method             'find-for-file-or-pick-first
-      treemacs-git-command-pipe          ""
-      treemacs-goto-tag-strategy                 'refetch-index
-      treemacs-header-scroll-indicators  '(nil . "^^^^^^")
-      treemacs-hide-dot-git-directory            t
-      treemacs-indentation                       2
-      treemacs-indentation-string                " "
-      treemacs-is-never-other-window             nil
-      treemacs-max-git-entries           5000
-      treemacs-missing-project-action            'ask
-      treemacs-move-forward-on-expand            nil
-      treemacs-no-png-images                     nil
-      treemacs-no-delete-other-windows   t
-      treemacs-project-follow-cleanup            nil
-      treemacs-persist-file                      (expand-file-name
-                                                     ".cache/treemacs-persist"
-                                                     user-emacs-directory)
-      treemacs-position                  'left
-      treemacs-read-string-input                 'from-child-frame
-      treemacs-recenter-distance                 0.1
-      treemacs-recenter-after-file-follow        nil
-      treemacs-recenter-after-tag-follow         nil
-      treemacs-recenter-after-project-jump       'always
-      treemacs-recenter-after-project-expand     'on-distance
-      treemacs-litter-directories                '("/node_modules"
-                                              "/.venv"
-                                              "/.cask"
-                                              "/__pycache__")
-      treemacs-project-follow-into-home  nil
-      treemacs-show-cursor                       nil
-      treemacs-show-hidden-files                 t
-      treemacs-silent-filewatch          nil
-      treemacs-silent-refresh                    nil
-      treemacs-sorting                   'alphabetic-asc
-      treemacs-select-when-already-in-treemacs 'move-back
-      treemacs-space-between-root-nodes  t
-      treemacs-tag-follow-cleanup                t
-      treemacs-tag-follow-delay          1.5
-      treemacs-text-scale                        nil
-      treemacs-user-mode-line-format             nil
-      treemacs-user-header-line-format   nil
-      treemacs-wide-toggle-width                 70
-      treemacs-width                             38
-      treemacs-width-increment           1
-      treemacs-width-is-initially-locked         t
-      treemacs-workspace-switch-cleanup  nil)
-
-    ;; The default width and height of the icons is 22 pixels. If you are
-    ;; using a Hi-DPI display, uncomment this to double the icon size.
-    ;;(treemacs-resize-icons 44)
-
-    (treemacs-follow-mode t)
-    (treemacs-filewatch-mode t)
-    (treemacs-fringe-indicator-mode 'always)
-    (when treemacs-python-executable
-      (treemacs-git-commit-diff-mode t))
-    (pcase (cons (not (null (executable-find "git")))
-             (not (null treemacs-python-executable)))
-      (`(t . t)
-        (treemacs-git-mode 'deferred))
-      (`(t . _)
-        (treemacs-git-mode 'simple)))
-    (treemacs-hide-gitignored-files-mode nil))
-
-#+end_src
-
-** Treemacs Projectile
-
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-
-  (use-package treemacs-projectile
-    :when (equal custom-project-handler 'custom-project-projectile)
-    :after treemacs projectile)
-
-#+end_src
-
-** Treemacs dired
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-
-  (use-package treemacs-icons-dired
-    :after treemacs
-    :hook (dired-mode . treemacs-icons-dired-enable-once))
-
-#+end_src
-
-** Treemacs Persp
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-
-  ;; (use-package treemacs-perspective
-  ;;    :disabled
-  ;;    :after (treemacs persp-mode) ;;or perspective vs. persp-mode
-  ;;    :config (treemacs-set-scope-type 'Perspectives))
-
-  (use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
-    ;;:ensure (:files ("src/extra/treemacs-persp.el" "treemacs-persp-pkg.el"):host github :repo "Alexander-Miller/treemacs")
-    :after (:any treemacs persp-mode) ;;or perspective vs. persp-mode
-    :config (treemacs-set-scope-type 'Perspectives))
-
-#+end_src
-
-** Treemacs tab-bar
-
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-
-  (use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
-    :after treemacs
-    :config (treemacs-set-scope-type 'Tabs))
-
-#+end_src
-
-** Treemacs all-the-icons
-
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-
-  (use-package treemacs-all-the-icons
-    :after treemacs
-    :if (display-graphic-p))
-
-#+end_src
-
-
-* Dashboard
-<<<Dashboard>>> is an extensible Emacs startup screen showing you what’s most important.
-*** Value of dashboard-startup-banner can be:
-**** =nil= to display no banner
-**** ='official= which displays the official emacs logo
-**** ='logo= which displays an alternative emacs logo
-**** =1, 2 or 3= which displays one of the text banners
-**** ~"path/to/your/image.gif"~,
-~"path/to/your/image.png"~ or
-~"path/to/your/text.txt"~  which displays whatever gif/image/text you would prefer
-**** a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
-
-** Dashboard Setup
-#+begin_src emacs-lisp
-  ;;; ##########################################################################
-
-  (use-package dashboard
-    :custom
-    (dashboard-items '(   (recents . 15)
-                        (bookmarks . 10)
-                        (projects . 10)))
-    (dashboard-center-content t)
-    (dashboard-set-heading-icons t)
-    (dashboard-set-file-icons t)
-    (dashboard-footer-messages '("Greetings Program!"))
-    (dashboard-banner-logo-title "Welcome to Emacs!")
-    (dashboard-startup-banner 'logo)
-    :bind ("C-c d" . dashboard-open)
-    :config
-    ;; (setq initial-buffer-choice (lambda () (get-buffer-create dashboard-buffer-name)))
-    (add-hook 'elpaca-after-init-hook #'dashboard-insert-startupify-lists)
-    (add-hook 'elpaca-after-init-hook #'dashboard-initialize)
-    (dashboard-setup-startup-hook))
-
-#+end_src
-
 
 
 * Integrated Development Environments
@@ -5363,11 +5460,11 @@ Instant Github-flavored Markdown/Org preview using Grip (GitHub Readme Instant P
   
 #+end_src
 
-** Mitch's Minor Mode
+** MiFi's Minor Mode (MmM)
 
 Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It works well when =which-key= is active.
 
-*** Mitch's Minor Mode Functions
+*** Helper Functions
 #+begin_src emacs-lisp
   ;;; ##########################################################################
 
@@ -5390,7 +5487,7 @@ Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It work
 
 #+end_src
 
-*** Mitch's Minor-Mode Standard Keymaps
+*** Standard Keymaps
 
 This is a set of keymaps that do the same things as the popup menu. Both are here for convenience. *Note* that the ~mmm-menu~ is called with either a ="C-c RET RET"= or simply a ="C-c C-<return>"=.
 
@@ -5403,6 +5500,10 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
         (bind-keys :map map
           ("M-RET $" . jinx-correct)
           ("M-RET ?" . eldoc-box-help-at-point)
+          ("M-RET R 1" . eshell)
+          ("M-RET R 2" . eshell)
+          ("M-RET R 3" . eshell)
+          ("M-RET R 4" . eshell)
           ("M-RET S e" . eshell)
           ("M-RET S i" . ielm)
           ("M-RET S v" . vterm-other-window)
@@ -5430,7 +5531,7 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
 
 #+end_src
 
-*** MmM Context-Aware Keys and Descriptions
+*** Context-Aware Keys and Descriptions
 
 For those menus that would normally show up as either =prefix= or =lambda=, given them a better description via the which-key replacement function. This is run via the ~which-key-inhibit-display-hook~ hook which is run just before the which-key popup is
 shown. Plus, some keys are mode specific and will only appear when that major mode is active.
@@ -5441,25 +5542,36 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
   (defun mifi/mmm-handle-context-keys (&optional winframe)
     "Enable or Disable keys based upon featurep context."
     (when winframe
-    (let ((map mmm-keys-minor-mode-map))
-      (when enable-thesaurus
-        (bind-keys :map map
-          ("M-RET m t" . mw-thesaurus-lookup-dwim)))
-      (cond
-        ((equal major-mode 'org-mode)
-          (bind-keys :map map
-            ("M-RET M-RET" . org-insert-heading)
-            ("M-RET o f" . mifi/set-org-fill-column-interactively)
-            ("M-RET o l" . org-toggle-link-display)))
-        ((equal major-mode 'python-mode)
-          (bind-keys :map map
-            ("M-RET P" . 'pydoc-at-point)))
-        (t   ;; Default 
-          (unbind-key "M-RET o f" map)
-          (unbind-key "M-RET o l" map)
-          (unbind-key "M-RET P ?" map)
-          (unbind-key "M-RET M-RET" map))))))
+      (let ((map mmm-keys-minor-mode-map))
+        (when enable-thesaurus
+  	(bind-keys :map map
+            ("M-RET m t" . mw-thesaurus-lookup-dwim)))
+        (cond
+  	((equal major-mode 'org-mode)
+            (bind-keys :map map
+              ("M-RET M-RET" . org-insert-heading)
+              ("M-RET o f" . mifi/set-org-fill-column-interactively)
+              ("M-RET o l" . org-toggle-link-display)))
+  	((equal major-mode 'python-mode)
+            (bind-keys :map map
+              ("M-RET P" . 'pydoc-at-point)))
+  	(t   ;; Default 
+            (unbind-key "M-RET o f" map)
+            (unbind-key "M-RET o l" map)
+            (unbind-key "M-RET P ?" map)
+            (unbind-key "M-RET M-RET" map))))))
+  
+#+end_src
 
+*** Key Description Overrides
+
+Sometimes, the descriptions that which-key provide are not what we want. So, for cases like this, these description replacemens are used.
+
+What's also important with this function is that it calls the ~mifi/mmm-handle-context-keys~ function which updates the context aware keys.
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+  
   (defun mifi/mmm-update-menu (&optional winframe)
     (interactive)
     (mifi/mmm-handle-context-keys nil)
@@ -5471,9 +5583,18 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
     (which-key-add-key-based-replacements "M-RET m" "Thesaurus")
     (which-key-add-key-based-replacements "M-RET f" "set-fill-column")
     (which-key-add-key-based-replacements "M-RET j" "jump-to-register")
+    (which-key-add-key-based-replacements "M-RET C-g" "Exit menu")
     (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
+#+end_src
 
+*** Hooks
+
+These are the hools that update the context-aware menu triggered by various state changes of Emacs buffers and windows.
+
+#+begin_src emacs-lisp
+  ;;; ##########################################################################
+  
   ;; Check the keys when:
   ;; - the whick-key menu is displayed
   (add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)

--- a/emacs-config.org
+++ b/emacs-config.org
@@ -52,7 +52,6 @@ The goal of this Emacs configuration is to make an Emacs configuration that has 
   + Customizable Menu (MmM)
 :END:
 
-
 * README:
 
 --------------------------------------------------------------------------------
@@ -402,8 +401,13 @@ Thes values toggle the availability of specific packages. These options are not 
     :type 'boolean
     :group 'mrf-custom-toggles)
 
+  (defcustom enable-thesaurus t
+    "When set to t, enables the Merriam-Webster Thesaurus."
+    :type 'boolean
+    :group 'mrf-custom-toggles)
+
   ;; Keep as defvar until the frameset save/restore process works better.
-  (defvar enable-frameset-restore nil
+  (defvar enable-frameset-restore t
     "Set to t to enable restoring the last Emacs window size and position
      upon startup.")
     ;; :type 'boolean
@@ -687,12 +691,10 @@ By default, the =user-emacs-directory= points to the .emacs.d* directory from wh
 
   ;;; Put any emacs cusomized variables in a special file
   (setq custom-file (expand-file-name "customized-vars.el" user-emacs-directory))
-  ;; create custom file if it does not exists.
-  (unless (file-exists-p custom-file)
+
+  (unless (file-exists-p custom-file) ;; create custom file if it doesn't exists
     (write-region "" nil custom-file))
-  ;; (add-hook 'elpaca-after-init-hook (lambda () (load custom-file 'noerror 'nomessage)))
   (load custom-file 'noerror 'nomessage)
-  (setq enable-frameset-restore nil) ;; FORCE UNTIL FRAMESET RESTORE IS DONE
 
   ;; ensure that the loaded font values are supported by this OS. If not, try
   ;; to correct them.
@@ -806,17 +808,7 @@ Calls to mode functions that effect various Emacs behavior.
 
 #+end_src
 
-
 ** Save / Restore Frameset
-** Some Common Registers
-
-#+begin_src emacs-lisp
-
-  (setq register-preview-delay 0) ;; Show registers ASAP
-  (set-register ?C (cons 'file (concat emacs-config-directory "/emacs-config.org")))
-
-#+end_src
-
 
 These functions will save and restore Emacs framework. These are normally called when starting and exiting Emacs.
 
@@ -837,21 +829,31 @@ These functions will save and restore Emacs framework. These are normally called
   ;;; --------------------------------------------------------------------------
    
   (defun mifi/restore-desktop-frameset ()
-    (unless (and (daemonp) (not enable-frameset-restore))
+    (unless (and (daemonp) (not enable-frameset-<restore))
       (let
         ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
         (desktop-save-mode 0)
-        (when (f-exists? file) (load file)
+        (when (file-exists-p  file) (load file)
         (desktop-restore-frameset)
         (when (featurep 'spacious-padding)
-          (when spacious-padding-mode
-            (spacious-padding-mode 0)
-            (spacious-padding-mode 1)))))
-        ))
+            (when spacious-padding-mode
+              (spacious-padding-mode 0)
+              (spacious-padding-mode 1)))))))
+
+#+end_src
+
+** Some Common Registers
+These are just some common registers that I have just so I can bookmark files and locations and quckly jump to them.
+
+#+begin_src emacs-lisp
+
+  (setq register-preview-delay 0) ;; Show registers ASAP
+  (set-register ?C (cons 'file (concat emacs-config-directory "emacs-config.org")))
 
 #+end_src
 
 ** Emacs in server mode
+Handle the case of starting the Emacs server when Emacs is started as a foreground or background daemon.
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -872,24 +874,6 @@ These functions will save and restore Emacs framework. These are normally called
 
 These are the common packages that I pretty much use universally in my normal Emacs workflow.
 It excludes packages that can be customized through my =mrf-custom= variables as they are generally in their own section
-
-** F.el
-
-Much inspired by @magnarss excellent s.el and dash.el, f.el is a modern API for working with files and directories in Emacs.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package f
-    :ensure ( :package "f" :source "MELPA" :protocol https :inherit t
-            :depth 1 :fetcher github :repo "rejeep/f.el"
-            :files ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
-                     "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-                     "lisp/*.el" (:exclude ".dir-locals.el" "test.el"
-                                   "tests.el" "*-test.el" "*-tests.el"
-                                   "LICENSE" "README*" "*-pkg.el"))))
-
-#+end_src
 
 ** Hydra
 
@@ -969,7 +953,6 @@ Multiple cursors for Emacs. This is some pretty crazy functionality, so yes, the
 #+end_src
 
 ** Anzu
-
 anzu.el is an Emacs port of anzu.vim. anzu.el provides a minor mode which displays current match and total matches information in the mode-line in various search modes.
 
 #+begin_src emacs-lisp
@@ -1000,8 +983,7 @@ We use [[https://github.com/joostkremers/visual-fill-column][visual-fill-column]
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
-  (use-package visual-fill-column
-    :after org)
+  (use-package visual-fill-column :after org)
 
 #+end_src
 
@@ -1295,11 +1277,9 @@ These are packages located in the ~"lisp"~ directory within the emacs-config-dir
 #+end_src
 
 
-* Undo Systems
-
-*These packages are selected via the =M-x customize= function.*
-
-** Vundo (visual undo)
+* Operational Systems
+** Undo Handlers
+*** Vundo (visual undo)
 
 Vundo displays the undo history as a tree and lets you move in the tree to go back to previous buffer states. To use vundo, type M-x vundo RET in the buffer you want to undo. An undo tree buffer should pop up.
 
@@ -1318,7 +1298,7 @@ Vundo displays the undo history as a tree and lets you move in the tree to go ba
 
 #+end_src
 
-** Undo Tree
+*** Undo Tree
 
 Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode treats undo history as a branching tree of changes, similar to the way Vim handles it. This makes it substantially easier to undo and redo any change, while preserving the entire history of past states. The undo-tree visualizer is particularly helpful in complex cases. An added side bonus is that undo history can in some cases be stored more efficiently, allowing more changes to accumulate before Emacs starts discarding history. Undo history can be saved persistently across sessions with Emacs 24.3 and later. It also sports various other nifty features: storing and restoring past buffer states in registers, a diff view of the changes that will be made by undoing, and probably more besides.
 
@@ -1333,18 +1313,15 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
     (let ((split-height-threshold nil)
          (split-width-threshold 0))
       (apply original-function args)))
-  
-#+end_src
 
-#+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
   ;;
   ;; Sometimes, when behind a firewall, the undo-tree package triggers elpaca
   ;; to queue up the Queue package which then hangs and fails. This happens
-  ;; even if the :unless option is specified in the use-package (only :disabled
+  ;; even if the :unless/:when option is specified in the use-package (only :disabled
   ;; seems to work which isn't what I want). So, we prevent the loading of the
-  ;; page altogether.
+  ;; page altogether unless the undo-handler is set to undo tree.
   ;;
   (when (equal undo-handler 'undo-handler-undo-tree)
     (use-package undo-tree
@@ -1368,6 +1345,777 @@ Instead of treating undo/redo as a linear sequence of changes, undo-tree-mode tr
 
 #+end_src
 
+** Completion Handlers
+Here are a series of completion systems that are available for Emacs.
+
+*** Prescient
+
+prescient.el is a library which sorts and filters lists of candidates, such as appear when you use a package like Ivy or Company. Extension packages such as ivy-prescient.el and company-prescient.el adapt the library for usage with various frameworks.
+
+prescient.el also provides a completion style (prescient) for filtering candidates via Emacs's generic completion, such as in Icomplete, Vertico, and Corfu. These last two have extension packages to correctly set up filtering and sorting.
+
+As compared to other packages which accomplish similar tasks, including IDO, Ivy, Helm, Smex, Flx, Historian, and Company-Statistics, prescient.el aims to be simpler, more predictable, and faster.
+
+TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  
+  (use-package prescient)
+
+#+end_src
+
+*** Orderless
+
+This package provides an orderless completion style that divides the pattern into space-separated components, and matches candidates that match all of the components in any order. Each component can match in any one of several ways: literally, as a regexp, as an initialism, in the flex style, or as multiple word prefixes. By default, regexp and literal matches are enabled.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package orderless
+    :when (or (equal completion-handler 'comphand-vertico)
+            (equal completion-handler 'comphand-ivy-counsel))
+    :custom
+    (completion-styles '(orderless basic))
+    (completion-category-overrides '((file (styles basic partial-completion)))))
+
+#+end_src
+
+*** IVY Mode
+
+<<<Ivy>>> is an excellent completion framework for Emacs.  It provides a minimal yet powerful selection menu that appears when you open files, switch buffers, and for many other tasks in Emacs.  Counsel is a customized set of commands to replace `find-file` with `counsel-find-file`, etc which provide useful commands for each of the default completion commands.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;;; Swiper and IVY mode
+
+  (use-package ivy
+    :when (equal completion-handler 'comphand-ivy-counsel)
+    :bind (("C-s" . swiper)
+            :map ivy-minibuffer-map
+              ;;; ("TAB" . ivy-alt-done)
+            ("C-l" . ivy-alt-done)
+            ("C-j" . ivy-next-line)
+            ("C-k" . ivy-previous-line)
+            :map ivy-switch-buffer-map
+            ("C-k" . ivy-previous-line)
+            ("C-l" . ivy-done)
+            ("C-d" . ivy-switch-buffer-kill)
+            :map ivy-reverse-i-search-map
+            ("C-k" . ivy-previous-line)
+            ("C-d" . ivy-reverse-i-search-kill))
+    :custom
+    (enable-recursive-minibuffers t)
+    (ivy-use-virtual-buffers t)
+    :config
+    (ivy-mode 1)
+    (setq ivy-re-builders-alist '((t . orderless-ivy-re-builder)))
+    (add-to-list 'ivy-highlight-functions-alist
+      '(orderless-ivy-re-builder . orderless-ivy-highlight)))
+
+#+end_src
+
+**** Ivy-rich and ivy-yasnippet
+
+Ivy-rich provides rich transformers for commands from ivy and counsel.
+Ivy-yasnippet lets you preview yasnippet snippets with ivy.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package ivy-rich
+    :when (equal completion-handler 'comphand-ivy-counsel)
+    :after ivy
+    :init
+    (ivy-rich-mode 1)
+    :config
+    (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line))
+
+  (use-package ivy-yasnippet
+    :when (equal completion-handler 'comphand-ivy-counsel)
+    :after (:any yasnippet ivy))
+  ;; :ensure (:host github :repo "mkcms/ivy-yasnippet"))
+
+#+end_src
+
+**** Swiper
+Swiper is an alternative to isearch that uses Ivy to show an overview of all matches.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package swiper
+    :when (equal completion-handler 'comphand-ivy-counsel)
+    :after ivy)
+
+#+end_src
+
+**** Counsel
+
+~ivy-mode~ ensures that any Emacs command using completing-read-function uses ivy for completion.
+Counsel takes this further, providing versions of common Emacs commands that are customised to make the best use of Ivy. For example, ~counsel-find-file~ has some additional keybindings. Pressing =DEL= will move you to the parent directory.
+
+#+begin_src emacs-lisp :results output silent
+  ;;; --------------------------------------------------------------------------
+
+  (use-package counsel
+    :when (equal completion-handler 'comphand-ivy-counsel)
+    :bind ( ("C-M-j" . 'counsel-switch-buffer)
+            ("M-x" . 'counsel-M-x)
+            ("M-g o" . 'counsel-outline)
+            ("C-x C-f" . 'counsel-find-file)
+            ("C-c C-r" . 'ivy-resume)
+            :map minibuffer-local-map
+            ("C-r" . 'counsel-minibuffer-history))
+    :custom
+    (counsel-linux-app-format-function #'counsel-linux-app-format-function-name-only)
+    :config
+    (counsel-mode 1))
+
+#+end_src
+
+**** Ivy Prescient
+~prescient.el~ is a library which sorts and filters lists of candidates, such as appear when you use a package like =Ivy= or =Company=.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package ivy-prescient
+    :when (equal completion-handler 'comphand-ivy-counsel)
+    :after (ivy prescient)
+    :custom
+    (prescient-persist-mode t)
+    (ivy-prescient-mode t)
+    (ivy-prescient-enable-filtering t))
+
+#+end_src
+
+*** Corfu
+
+<<<Corfu>>> enhances in-buffer completion with a small completion popup. The current candidates are shown in a popup below or above the point. The candidates can be selected by moving up and down. Corfu is the minimalistic in-buffer completion counterpart of the Vertico minibuffer UI.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  ;;;; Code Completion
+  (use-package corfu
+    :when (equal completion-handler 'comphand-corfu)
+    ;; Optional customizations
+    :custom
+    (corfu-cycle t)                  ; Allows cycling through candidates
+    (corfu-auto t)                   ; Enable auto completion
+    (corfu-auto-prefix 2)
+    (corfu-auto-delay 0.8)
+    (corfu-popupinfo-delay '(0.5 . 0.2))
+    (corfu-preview-current 'insert) ; insert previewed candidate
+    (corfu-preselect 'prompt)
+    (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
+    ;; Optionally use TAB for cycling, default is `corfu-complete'.
+    :bind (:map corfu-map
+          ("M-SPC"          . corfu-insert-separator)
+          ("TAB"            . corfu-next)
+          ([tab]            . corfu-next)
+          ("S-TAB"          . corfu-previous)
+          ([backtab]    . corfu-previous)
+          ("S-<return>" . corfu-insert)
+          ("RET"            . nil))
+    :init
+    (global-corfu-mode)
+    (corfu-history-mode)
+    (corfu-popupinfo-mode) ; Popup completion info
+    :config
+    (add-hook 'eshell-mode-hook
+      (lambda () (setq-local corfu-quit-at-boundary t
+                 corfu-quit-no-match t
+                 corfu-auto nil)
+        (corfu-mode))))
+  
+#+end_src
+
+**** Cape Configuration
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;; Add extensions
+  (use-package cape
+    :when (equal completion-handler 'comphand-corfu)
+    :after corfu
+    ;; Bind dedicated completion commands
+    ;; Alternative prefix keys: C-c p, M-p, M-+, ...
+    :bind ( ("C-c C-p p" . completion-at-point) ;; capf
+            ("C-c C-p t" . complete-tag)        ;; etags
+            ("C-c C-p d" . cape-dabbrev)        ;; or dabbrev-completion
+            ("C-c C-p h" . cape-history)
+            ("C-c C-p f" . cape-file)
+            ("C-c C-p k" . cape-keyword)
+            ("C-c C-p s" . cape-elisp-symbol)
+            ("C-c C-p e" . cape-elisp-block)
+            ("C-c C-p a" . cape-abbrev)
+            ("C-c C-p l" . cape-line)
+            ("C-c C-p w" . cape-dict)
+            ("C-c C-p :" . cape-emoji)
+            ("C-c C-p \\" . cape-tex)
+            ("C-c C-p _" . cape-tex)
+            ("C-c C-p ^" . cape-tex)
+            ("C-c C-p &" . cape-sgml)
+            ("C-c C-p r" . cape-rfc1345))
+    :init
+    ;; Add to the global default value of `completion-at-point-functions' which is
+    ;; used by `completion-at-point'.  The order of the functions matters, the
+    ;; first function returning a result wins.  Note that the list of buffer-local
+    ;; completion functions takes precedence over the global list.
+    (add-hook 'completion-at-point-functions #'cape-dabbrev)
+    (add-hook 'completion-at-point-functions #'cape-file)
+    (add-hook 'completion-at-point-functions #'cape-elisp-block)
+    ;;(add-hook 'completion-at-point-functions #'cape-history)
+    ;;(add-hook 'completion-at-point-functions #'cape-keyword)
+    ;;(add-hook 'completion-at-point-functions #'cape-tex)
+    ;;(add-hook 'completion-at-point-functions #'cape-sgml)
+    ;;(add-hook 'completion-at-point-functions #'cape-rfc1345)
+    ;;(add-hook 'completion-at-point-functions #'cape-abbrev)
+    ;;(add-hook 'completion-at-point-functions #'cape-dict)
+    ;;(add-hook 'completion-at-point-functions #'cape-elisp-symbol)
+    ;;(add-hook 'completion-at-point-functions #'cape-line)
+    )
+
+#+end_src
+
+**** Corfu-prescient
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  
+  (use-package corfu-prescient
+    :when (equal completion-handler 'comphand-corfu)
+    :after (corfu prescient))
+
+#+end_src
+
+*** Vertico
+
+<<<Vertico>>> provides a performant and minimalistic vertical completion UI based on the default completion system. The focus of Vertico is to provide a UI which behaves correctly under all circumstances. By reusing the built-in facilities system, Vertico achieves full compatibility with built-in Emacs completion commands and completion tables.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package vertico
+    :when (equal completion-handler 'comphand-vertico)
+    :demand t
+    ;;:wait t
+    ;;:ensure (:repo "minad/vertico" :files (:defaults "extensions/vertico-*.el") :fetcher github)
+    :custom
+    (recentf-mode t)
+    (vertico-count 12)
+    (vertico-cycle nil)
+    (vertico-multiform-mode 1)
+    :config
+    (vertico-mode)
+    ;; :bind ("C-x C-f" . ido-find-file)
+    ;; Clean up file path when typing
+    :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
+          ;; Make sure vertico state is saved
+          (minibuffer-setup . vertico-repeat-save)))
+  
+#+end_src
+
+**** Marginalia
+
+Marginalia are marks or annotations placed at the margin of the page of a book or in this case helpful colorful annotations placed at the margin of the  minibuffer for your completion candidates. Marginalia can only add annotations  to the completion candidates. It cannot modify the appearance of the candidates  themselves, which are shown unaltered as supplied by the original command.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package marginalia
+    ;; :when (equal completion-handler 'comphand-vertico)
+    ;; :after vertico
+    :custom
+    (marginalia-max-relative-age 0)
+    (marginalia-align 'left)
+    (marginalia-annotators '(marginalia-annotators-heavy marginalia-annotators-light nil))
+    :config
+    (marginalia-mode t))
+  
+#+end_src
+
+**** Icons for Marginalia
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package all-the-icons-completion
+    :after (marginalia all-the-icons)
+    :hook (marginalia-mode . all-the-icons-completion-marginalia-setup))
+
+#+end_src
+
+**** Consult
+
+Consult provides search and navigation commands based on the Emacs completion function completing-read. Completion allows you to quickly select an item from a list of candidates. Consult offers asynchronous and interactive consult-grep and  consult-ripgrep commands, and the line-based search command consult-line. Furthermore Consult provides an advanced buffer switching command consult-buffer to switch between buffers, recently opened files, bookmarks and buffer-like candidates from other sources. Some of the Consult commands are enhanced versions of built-in Emacs commands.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package consult
+    :when (equal completion-handler 'comphand-vertico)
+    :after vertico
+    :bind
+    ([remap switch-to-buffer] . consult-buffer)
+    ([remap switch-to-buffer-other-window] . consult-buffer-other-window)
+    ([remap switch-to-buffer-other-frame] . consult-buffer-other-frame)
+    ([remap project-switch-to-buffer] . consult-project-buffer)
+    ([remap bookmark-jump] . consult-bookmark)
+    ([remap recentf-open] . consult-recent-file)
+    ([remap yank] . nil)
+    ([remap yank-pop] . consult-yank-pop)
+    ([remap goto-line] . consult-goto-line)
+    ("M-g m" . consult-mark)
+    ("M-g M" . consult-global-mark)
+    ("M-g o" . consult-outline)
+    ("M-g i" . consult-imenu)
+    ("M-g I" . consult-imenu-multi)
+    ("M-s l" . consult-line)
+    ("M-s p" . consult-preview)  
+    ("M-s L" . consult-line-multi)
+    ("M-s k" . consult-keep-lines)
+    ("M-s u" . consult-focus-lines)
+    ("M-s r" . consult-ripgrep)
+    ("M-s f" . consult-find)
+    ("M-s F" . consult-locate)
+    ("M-g e" . consult-compile-error)
+    ("M-g f" . consult-flymake)
+    ([remap repeat-complex-command] . consult-complex-command)
+    ("M-s e" . consult-isearch-history)
+    ([remap isearch-edit-string] . consult-isearch-history)
+    ([remap next-matching-history-element] . consult-history)
+    ([remap previous-matching-history-element] . consult-history)
+    ([remap Info-search] . consult-info)
+    :custom
+    (xref-show-xrefs-function 'consult-xref)
+    (xref-show-definitions-function 'consult-xref)
+    :config
+    (setq consult-buffer-sources
+      '(consult--source-hidden-buffer 
+         consult--source-buffer
+         (:name "Ephemeral" :state consult--buffer-state
+         :narrow 109 :category buffer
+         :items ("*Messages*"  "*scratch*" "*vterm*"
+                  "*Async-native-compile-log*" "*dashboard*"))
+         consult--source-modified-buffer
+         consult--source-recent-file)))
+
+#+end_src
+
+**** Vertico support packages
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package vertico-prescient
+    :when (equal completion-handler 'comphand-vertico)
+    :after vertico prescient)
+  
+#+end_src
+
+vertico-posframe is an vertico extension, which lets vertico use posframe to show its candidate menu.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package vertico-posframe
+    :when (equal completion-handler 'comphand-vertico)
+    :after vertico
+    :custom
+    (setq vertico-multiform-commands
+      '((consult-line
+          posframe
+          (vertico-posframe-poshandler . posframe-poshandler-frame-top-center)
+          (vertico-posframe-border-width . 10)
+          ;; NOTE: This is useful when emacs is used in both in X and
+          ;; terminal, for posframe do not work well in terminal, so
+          ;; vertico-buffer-mode will be used as fallback at the
+          ;; moment.
+          (vertico-posframe-fallback-mode . vertico-buffer-mode))
+         (t posframe)))
+    (vertico-multiform-mode 1)
+    (setq vertico-posframe-parameters
+      '((left-fringe . 8)
+         (right-fringe . 8))))
+  
+#+end_src
+
+*** Built-In (Ido)
+Enable the IDO handler everywhere.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  ;; This has to be evaluated at the end of the init since it's possible that the
+  ;; completion-handler variable will not yet be defined at this point in the
+  ;; init phase using elpaca.
+  (add-hook 'elpaca-after-init-hook
+    (lambda ()
+      (when (equal completion-handler 'comphand-built-in)
+        (ido-everywhere t))))
+
+#+end_src
+
+*** Embark
+
+Embark makes it easy to choose a command to run based on what is near point, both during a minibuffer completion session (in a way familiar to Helm or Counsel users) and in normal buffers. Bind the command  embark-act to a key and it acts like prefix-key for a keymap of actions (commands) relevant to the target around point. With point on an URL in a buffer you can open the URL in a browser or eww or download the file it points to. If while switching buffers you spot an old one, you can kill it right there and continue to select another. Embark comes preconfigured with over a hundred actions for common types of targets such as files, buffers, identifiers, s-expressions, sentences; and it is easy to add more actions and more target types. Embark can also collect all the candidates in a minibuffer to an occur-like buffer or export them to a buffer in a major-mode specific to the type of candidates, such as dired for a set of files, ibuffer for a set of buffers, or customize for a set of variables.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package embark
+    :when enable-embark
+    :bind
+    (("C-." . embark-act)         ;; pick some comfortable binding
+      ("C-;" . embark-dwim)        ;; good alternative: M-.
+      ("C-h B" . embark-bindings)) ;; alternative for `describe-bindings'
+
+    :init
+
+    ;; Optionally replace the key help with a completing-read interface
+    (setq prefix-help-command #'embark-prefix-help-command)
+
+    ;; Show the Embark target at point via Eldoc. You may adjust the
+    ;; Eldoc strategy, if you want to see the documentation from
+    ;; multiple providers. Beware that using this can be a little
+    ;; jarring since the message shown in the minibuffer can be more
+    ;; than one line, causing the modeline to move up and down:
+
+    ;; (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
+    ;; (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
+
+    :config
+
+    ;; Hide the mode line of the Embark live/completions buffers
+    (add-to-list 'display-buffer-alist
+      '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
+         nil
+         (window-parameters (mode-line-format . none)))))
+
+  ;; Consult users will also want the embark-consult package.
+  (use-package embark-consult
+    :when (equal completion-handler 'comphand-vertico)
+    :defer t
+    ;;:ensure t ; only need to install it, embark loads it after consult if found
+    :hook
+    (embark-collect-mode . consult-preview-at-point-mode))
+
+#+end_src
+
+*** Company Mode
+
+[[http://company-mode.github.io/][Company Mode]] provides a nicer in-buffer completion interface than =completion-at-point= which is more reminiscent of what you would expect from an IDE.  We add a simple configuration to make the keybindings a little more useful (=TAB= now completes the selection and initiates completion at the current location if needed).
+
+We also use [[https://github.com/sebastiencs/company-box][company-box]] to further enhance the look of the completions with icons and better overall presentation.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
+  ;; features. They actually collide.
+  
+  (use-package company
+    :unless (equal custom-ide 'custom-ide-lsp-bridge)
+    :custom
+    (company-minimum-prefix-length 2)
+    (company-idle-delay 0.2)
+    :config
+    (global-company-mode +1))
+
+#+end_src
+
+
+#+begin_src emacs-lisp :tangle no
+  ;;; --------------------------------------------------------------------------
+
+  ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
+  ;; features. They actually collide.
+
+  (use-package company
+    :unless (equal custom-ide 'custom-ide-lsp-bridge)
+    :bind (:map company-active-map
+            ("C-n". company-select-next)
+            ("C-p". company-select-previous)
+            ("M-<". company-select-first)
+            ("M->". company-select-last)
+            ("<tab>" . company-complete-selection))
+    :custom
+    (company-minimum-prefix-length 2)
+    (company-idle-delay 0.5)
+    :config
+    (global-company-mode +1))
+
+  ;; IMPORTANT:
+  ;; Don't use company at all if lsp-bridge is active.
+  ;; lsp-bridge already provides similar functionality.
+
+  ;; :config
+  ;; (add-to-list 'company-backends 'company-yasnippet))
+
+#+end_src
+
+**** Company Packages
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package company-box
+    :after company
+    :diminish cb
+    :hook (company-mode . company-box-mode))
+
+  (use-package company-jedi
+    :when  (equal custom-ide 'custom-ide-elpy)
+    :after python company
+    :config
+    (jedi:setup)
+    (defun my/company-jedi-python-mode-hook ()
+      (add-to-list 'company-backends 'company-jedi))
+    (add-hook 'python-mode-hook 'my/company-jedi-python-mode-hook))
+
+  (use-package company-anaconda
+    :when (equal custom-ide 'custom-ide-anaconda)
+    :after anaconda company
+    :hook (python-mode . anaconda-mode)
+    :config
+    (eval-after-load "company"
+      '(add-to-list 'company-backends 'company-anaconda)))
+
+#+end_src
+** Terminals
+*** term-mode
+
+=term-mode= is a built-in terminal emulator in Emacs.  Because it is written in Emacs Lisp, you can start using it immediately with very little configuration.  If you are on Linux or macOS, =term-mode= is a great choice to get started because it supports fairly complex terminal applications (=htop=, =vim=, etc) and works pretty reliably.  However, because it is written in Emacs Lisp, it can be slower than other options like =vterm=.  The speed will only be an issue if you regularly run console apps with a lot of output.
+
+One important thing to understand is =line-mode= versus =char-mode=.  =line-mode= enables you to use normal Emacs keybindings while moving around in the terminal buffer while =char-mode= sends most of your keypresses to the underlying terminal.  While using =term-mode=, you will want to be in =char-mode= for any terminal applications that have their own keybindings.  If you're just in your usual shell, =line-mode= is sufficient and feels more integrated with Emacs.
+
+With =evil-collection= installed, you will automatically switch to =char-mode= when you enter Evil's insert mode (press =i=).  You will automatically be switched back to =line-mode= when you enter Evil's normal mode (press =ESC=).
+
+Run a terminal with =M-x term!=
+
+*Useful key bindings:*
+
+- =C-c C-p= / =C-c C-n= - go back and forward in the buffer's prompts (also =[[= and =]]= with evil-mode)
+- =C-c C-k= - Enter char-mode
+- =C-c C-j= - Return to line-mode
+- If you have =evil-collection= installed, =term-mode= will enter char mode when you use Evil's Insert mode
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package term+
+    ;;:ensure (:repo "tarao/term-plus-el" :fetcher github)
+    :commands term
+    :config
+    (setq explicit-shell-file-name "bash") ;; Change this to zsh, etc
+    ;;(setq explicit-zsh-args '())          ;; Use 'explicit-<shell>-args for shell-specific args
+
+    ;; Match the default Bash shell prompt.  Update this if you have a custom prompt
+    (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *"))
+
+#+end_src
+
+*** Better term-mode colors
+
+The =eterm-256color= package enhances the output of =term-mode= to enable handling of a wider range of color codes so that many popular terminal applications look as you would expect them to.  Keep in mind that this package requires =ncurses= to be installed on your machine so that it has access to the =tic= program.  Most Linux distributions come with this program installed already so you may not have to do anything extra to use it.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package eterm-256color
+    :hook (term-mode . eterm-256color-mode))
+  
+#+end_src
+
+*** vterm
+
+[[https://github.com/akermu/emacs-libvterm/][vterm]] is an improved terminal emulator package which uses a compiled native module to interact with the underlying terminal applications.  This enables it to be much faster than =term-mode= and to also provide a more complete terminal emulation experience.
+
+Make sure that you have the [[https://github.com/akermu/emacs-libvterm/#requirements][necessary dependencies]] installed before trying to use =vterm= because there is a module that will need to be compiled before you can use it successfully.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package vterm
+    ;;:ensure (:fetcher github :repo "akermu/emacs-libvterm")
+    :commands vterm
+    :config
+    (setq vterm-environment ("PS1=\\u@\\h:\\w \n$"))
+    (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *")  ;; Set this to match your custom shell prompt
+    (setq vterm-shell "zsh")                        ;; Set this to customize the shell to launch
+    (setq vterm-max-scrollback 10000))
+
+#+end_src
+
+*** shell-mode
+
+[[https://www.gnu.org/software/emacs/manual/html_node/emacs/Interactive-Shell.html#Interactive-Shell][shell-mode]] is a middle ground between =term-mode= and Eshell.  It is *not* a terminal emulator so more complex terminal programs will not run inside of it.  It does have much better integration with Emacs because all command input in this mode is handled by Emacs and then sent to the underlying shell once you press Enter.  This means that you can use =evil-mode='s editing motions on the command line, unlike in the terminal emulator modes above.
+
+*Useful key bindings:*
+
+- =C-c C-p= / =C-c C-n= - go back and forward in the buffer's prompts (also =[[= and =]]= with evil-mode)
+- =M-p= / =M-n= - go back and forward in the input history
+- =C-c C-u= - delete the current input string backwards up to the cursor
+- =counsel-shell-history= - A searchable history of commands typed into the shell
+
+*** Eshell
+
+[[https://www.gnu.org/software/emacs/manual/html_mono/eshell.html#Contributors-to-Eshell][Eshell]] is Emacs' own shell implementation written in Emacs Lisp.  It provides you with a cross-platform implementation (even on Windows!) of the common GNU utilities you would find on Linux and macOS (=ls=, =rm=, =mv=, =grep=, etc).  It also allows you to call Emacs Lisp functions directly from the shell and you can even set up aliases (like aliasing =vim= to =find-file=).  Eshell is also an Emacs Lisp REPL which allows you to evaluate full expressions at the shell.
+
+The downsides to Eshell are that it can be harder to configure than other packages due to the particularity of where you need to set some options for them to go into effect, the lack of shell completions (by default) for some useful things like Git commands, and that REPL programs sometimes don't work as well.  However, many of these limitations can be dealt with by good configuration and installing external packages, so don't let that discourage you from trying it!
+
+*Useful key bindings:*
+
+- =C-c C-p= / =C-c C-n= - go back and forward in the buffer's prompts (also =[[= and =]]= with evil-mode)
+- =M-p= / =M-n= - go back and forward in the input history
+- =C-c C-u= - delete the current input string backwards up to the cursor
+- =counsel-esh-history= - A searchable history of commands typed into Eshell
+
+We will be covering Eshell more in future videos highlighting other things you can do with it.
+
+For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
+- https://ambrevar.xyz/emacs-eshell/index.html
+- https://ambrevar.xyz/emacs-eshell-versus-shell/index.html
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (defun mifi/configure-eshell ()
+    ;; Save command history when commands are entered
+    (add-hook 'eshell-pre-command-hook 'eshell-save-some-history)
+    ;; Truncate buffer for performance
+    (add-to-list 'eshell-output-filter-functions 'eshell-truncate-buffer)
+    (setq eshell-history-size   10000
+      eshell-buffer-maximum-lines 10000
+      eshell-hist-ignoredups t
+      eshell-scroll-to-bottom-on-input t))
+
+  (use-package eshell-git-prompt
+    :after eshell)
+
+  (use-package eshell
+    :ensure
+    :defer t
+    :hook (eshell-first-time-mode . mifi/configure-eshell)
+    :config
+    (with-eval-after-load 'esh-opt
+      (setq eshell-destroy-buffer-when-process-dies t)
+      (setq eshell-visual-commands '("htop" "zsh" "vim")))
+    (eshell-git-prompt-use-theme 'powerline))
+
+#+end_src
+
+** File Management
+*** Dired
+
+Dired is a built-in file manager for Emacs that does some pretty amazing things!  Here are some key bindings you should try out:
+
+**** Key Bindings
+***** Navigation
+*Emacs* / *Evil*
+- =n= / =j= - next line
+- =p= / =k= - previous line
+- =j= / =J= - jump to file in buffer
+- =RET= - select file or directory
+- =^= - go to parent directory
+- =S-RET= / =g O= - Open file in "other" window
+- =M-RET= - Show file in other window without focusing (previewing files)
+- =g o= (=dired-view-file=) - Open file but in a "preview" mode, close with =q=
+- =g= / =g r= Refresh the buffer with =revert-buffer= after changing configuration (and after filesystem changes!)
+
+***** Marking files
+- =m= - Marks a file
+- =u= - Unmarks a file
+- =U= - Unmarks all files in buffer
+- =* t= / =t= - Inverts marked files in buffer
+- =% m= - Mark files in buffer using regular expression
+- =*= - Lots of other auto-marking functions
+- =k= / =K= - "Kill" marked items (refresh buffer with =g= / =g r= to get them back)
+- Many operations can be done on a single file if there are no active marks!
+
+***** Copying and Renaming files
+- =C= - Copy marked files (or if no files are marked, the current file)
+- Copying single and multiple files
+- =U= - Unmark all files in buffer
+- =R= - Rename marked files, renaming multiple is a move!
+- =% R= - Rename based on regular expression: =^test= , =old-\&=
+
+*Power command*: =C-x C-q= (=dired-toggle-read-only=) - Makes all file names in the buffer editable directly to rename them!  Press =Z Z= to confirm renaming or =Z Q= to abort.
+
+***** Deleting files
+- =D= - Delete marked file
+- =d= - Mark file for deletion
+- =x= - Execute deletion for marks
+- =delete-by-moving-to-trash= - Move to trash instead of deleting permanently
+
+***** Creating and extracting archives
+- =Z= - Compress or uncompress a file or folder to (=.tar.gz=)
+- =c= - Compress selection to a specific file
+- =dired-compress-files-alist= - Bind compression commands to file extension
+
+***** Other common operations
+- =T= - Touch (change timestamp)
+- =M= - Change file mode
+- =O= - Change file owner
+- =G= - Change file group
+- =S= - Create a symbolic link to this file
+- =L= - Load an Emacs Lisp file into Emacs
+  
+**** Configuration
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+    ;; Prefer g-prefixed coreutils version of standard utilities when available
+  (let ((gls (executable-find "gls")))
+    (when gls (setq-default insert-directory-program gls
+              dired-use-ls-dired t
+                ;; Needed to fix an issue on Mac which causes dired to fail
+                dired-listing-switches "-al --group-directories-first")))
+
+  (use-package all-the-icons-dired
+    :after dired
+    :hook (dired-mode . all-the-icons-dired-mode))
+
+  (use-package dired-open
+    :commands (dired dired-jump)
+    :config
+    ;; Doesn't work as expected!
+    ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
+    (setq dired-open-extensions '(("png" . "feh")
+                                 ("mkv" . "mpv"))))
+
+  (use-package dired-hide-dotfiles
+    :after dired-mode
+    :hook (dired-mode . dired-hide-dotfiles-mode))
+
+#+end_src
+
+**** Single Window
+Dired, by default, opens up multiple windows - one for each directory. It would be nice to be able to limit =dired= to use just a single window. [[https://codeberg.org/amano.kenji/dired-single][dired-single]] does just that. We configure =dired-single= to open up a directory while in dired with the =C-<return>=  key combination. This will then open up the directory in the buffer named =*dired*=. Whenever a directory is opened with the =C-<return>= key sequence, that directory will then replace what's currently in the =*dired*= buffer.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+  ;; Single Window dired - don't continually open new buffers
+
+  (defun mifi/dired-single-keymap-init ()
+    "Bunch of stuff to run for dired, either immediately or when it's
+     loaded."
+    (define-key dired-mode-map
+      [remap dired-find-file] 'dired-single-buffer)
+    (define-key dired-mode-map
+      [remap dired-mouse-find-file-other-window] 'dired-single-buffer-mouse)
+    (define-key dired-mode-map
+      [remap dired-up-directory] 'dired-single-up-directory))
+
+  (use-package dired-single
+    :after dired
+    :config
+    (mifi/dired-single-keymap-init))
+#+end_src
 
 
 * Visuals
@@ -1906,7 +2654,8 @@ This package provides a global minor mode to increase the spacing/padding of Ema
 #+end_src
 
 
-* Org Mode
+* Productivity
+** Org Mode
 
 Org Mode is one of the hallmark features of Emacs.  It is a rich document editor, project planner, task and time tracker, blogging engine, and literate coding utility all wrapped up in one package [[https://orgmode.org/][Orgmode]].
 
@@ -1914,7 +2663,7 @@ The =mifi/org-font-setup= function configures various text faces to tweak the si
 
 *NOTE:* Most of the code below has been taken from the [[https://systemcrafters.net][System Crafters]] site run by David Wilson. Please visit that site for lots of great stuff!
 
-** Font setup
+*** Font setup
 
 This function sets up the fonts faces that are used within org-mode.
 
@@ -1993,7 +2742,7 @@ This function sets up the fonts faces that are used within org-mode.
         :height (cdr face))))
 #+end_src
 
-** Setup
+*** Setup
 
 This section contains the basic configuration for =org-mode= plus the configuration for Org agendas and capture templates.
 
@@ -2030,7 +2779,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
-**** Function to setup the agenda
+***** Function to setup the agenda
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -2086,7 +2835,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
-**** The capture-templates function
+***** The capture-templates function
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -2123,7 +2872,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
-**** Todos
+***** Todos
 
 #+begin_src emacs-lisp
 
@@ -2143,7 +2892,28 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
-** The main 'Org' package
+***** User customized faces
+
+#+begin_src emacs-lisp
+
+  (custom-theme-set-faces
+   'user
+   '(org-block ((t (:inherit fixed-pitch))))
+   '(org-code ((t (:inherit (shadow fixed-pitch)))))
+   '(org-document-info ((t (:foreground "dark orange"))))
+   '(org-document-info-keyword ((t (:inherit (shadow fixed-pitch)))))
+   '(org-indent ((t (:inherit (org-hide fixed-pitch)))))
+   '(org-link ((t (:foreground "royal blue" :underline t))))
+   '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+   '(org-property-value ((t (:inherit fixed-pitch))) t)
+   '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+   '(org-table ((t (:inherit fixed-pitch :foreground "#83a598"))))
+   '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
+   '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
+
+#+end_src
+
+*** The main 'Org' package
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
 
@@ -2195,7 +2965,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 #+RESULTS:
 : #s(hash-table size 65 test eql rehash-size 1.5 rehash-threshold 0.8125 data (:use-package (26172 1876 296393 0) :use-package-secs (0 0 907 0) :preface (26171 64968 44297 0) :init (26171 64968 44286 0) :init-secs (0 0 28 0) :preface-secs (0 0 265 0) :config (26171 64988 735976 0) :config-secs (0 0 361702 0)))
 
-** Better Bullets
+*** Better Bullets
 [[https://github.com/sabof/org-bullets][org-bullets]] replaces the heading stars in =org-mode= buffers with nicer looking characters that you can control.  Another option for this is [[https://github.com/integral-dw/org-superstar-mode][org-superstar-mode]].
 
 #+begin_src emacs-lisp
@@ -2234,7 +3004,7 @@ This section contains the basic configuration for =org-mode= plus the configurat
 
 #+end_src
 
-** Export Code
+*** Export Code
 To execute or export code in =org-mode= code blocks, you'll need to set up =org-babel-load-languages= for each language you'd like to use.  [[https://orgmode.org/worg/org-contrib/babel/languages.html][Babel]] documents all of the languages that you can use with =org-babel=.
 
 #+begin_src emacs-lisp
@@ -2268,7 +3038,7 @@ To execute or export code in =org-mode= code blocks, you'll need to set up =org-
   
 #+end_src
 
-** Structure Templates
+*** Structure Templates
 Org Mode's structure templates feature enables you to quickly insert code blocks into your Org files in combination with =org-tempo= by typing =<= followed by the template name like =el= or =py= and then press =TAB=.  For example, to insert an empty =emacs-lisp= block below, you can type =<el= and press =TAB= to expand into such a block.  You can add more =src= block templates below by copying one of the lines and changing the two strings at the end, the first to be the template name and the second to contain the name of the language as it is known by Org Babel.
 
 This snippet adds a hook to =org-mode= buffers so that =mifi/org-babel-tangle-config= gets executed each time such a buffer gets saved.  This function checks to see if the file being saved is the Emacs.org file you're looking at right now, and if so, automatically exports the configuration here to the associated output files.
@@ -2284,7 +3054,7 @@ This snippet adds a hook to =org-mode= buffers so that =mifi/org-babel-tangle-co
 
 #+end_src
 
-** Markdown support
+*** Markdown support
 While there is standard markdown support built into =org-mode=, this additional markdown package can also be used.
 *Disabled for now. Plus there is a large starup time.*
 #+begin_src emacs-lisp :tangle no
@@ -2295,7 +3065,7 @@ While there is standard markdown support built into =org-mode=, this additional 
 
 #+end_src
 
-** Org-Roam
+*** Org-Roam
 Org Mode is known to be a great tool not just for writing and personal notes but also TODO lists, project planning, time tracking, and more. Once you start to become really invested in Org Mode you’ll eventually have to come up with a system for managing your Org files so that it’s easy to store and find the information you need.
 
 Org Roam is an extension to Org Mode which solves a couple of the biggest problems that I’ve personally had when using Org for personal notes:
@@ -2305,7 +3075,7 @@ Org Roam is an extension to Org Mode which solves a couple of the biggest proble
 
 Org Roam solves these problems by making it easy to create topic-focused Org Files and link them together so that you can treat the information as nodes in a network rather than as hierarchical documents. You can think of it like a personal wiki!
 
-*** Some required pacakages 
+**** Some required pacakages 
 
 #+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
@@ -2314,7 +3084,7 @@ Org Roam solves these problems by making it easy to create topic-focused Org Fil
    
 #+end_src
 
-*** Org Agenda from Roam Notes
+**** Org Agenda from Roam Notes
 One of the most useful features of Org Mode is the agenda view. You can actually use your Org Roam notes as the source for this view!
 
 Typically you won’t want to pull in all of your Org Roam notes, so we’ll only use the notes with a specific tag like Project.
@@ -2343,7 +3113,7 @@ Here is a snippet that will find all the notes with a specific tag and then set 
   ;; Build the agenda list the first time for the session
 #+end_src
 
-*** Selecting from a list of notes
+**** Selecting from a list of notes
 The org-roam-node-find function gives us the ability to filter the list of notes that get displayed for selection.
 
 We can define our own function that shows a selection list for notes that have a specific tag like Project which we talked about before. This can be useful to set up a keybinding to quickly select from a specific set of notes!
@@ -2385,7 +3155,7 @@ This means that we can automatically create a new note with our project capture 
   
 #+end_src
 
-*** Keep and inbox of notes and tasks
+**** Keep and inbox of notes and tasks
 If you want to quickly capture new notes and tasks with a single keybinding into a place that you can review later, we can use org-roam-capture- to capture to a single-specific file like Inbox.org!
 
 Even though this file won’t have the timestamped filename, it will still be treated as a node in your Org Roam notes.
@@ -2400,7 +3170,7 @@ Even though this file won’t have the timestamped filename, it will still be tr
   
 #+end_src
 
-*** Insert a node immediately
+**** Insert a node immediately
 
 #+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
@@ -2414,7 +3184,7 @@ Even though this file won’t have the timestamped filename, it will still be tr
       (apply #'org-roam-node-insert args)))
 #+end_src
 
-*** Capture a task
+**** Capture a task
 If you’ve set up project note files like we mentioned earlier, you can set up a capture template that allows you to quickly capture tasks for any project.
 
 Much like the example before, we can either select a project that exists or automatically create a project note when it doesn’t exist yet.
@@ -2437,7 +3207,7 @@ Much like the example before, we can either select a project that exists or auto
                      ("Tasks"))))))
 #+end_src
 
-*** Todo
+**** Todo
 The following snippet sets up a hook for all Org task state changes and then copies the completed (DONE) entry to today’s note file
 
 #+begin_src emacs-lisp :tangle no
@@ -2463,7 +3233,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 #+end_src
 
-*** Table-of-contents
+**** Table-of-contents
 #+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
   
@@ -2477,7 +3247,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 #+end_src
 
-*** Main Org-roam Configuration
+**** Main Org-roam Configuration
 
 #+begin_src emacs-lisp :tangle no
   ;;; --------------------------------------------------------------------------
@@ -2519,7 +3289,7 @@ The following snippet sets up a hook for all Org task state changes and then cop
 
 #+end_src
 
-** Org-transclusion
+*** Org-transclusion
 
 Org-transclusion lets you insert a copy of text content via a file link or ID link within an Org file. It lets you have the same content present in different buffers at the same time without copy-and-pasting it. Edit the source of the content, and you can refresh the transcluded copies to the up-to-date state. Org-transclusion keeps your files clear of the transcluded copies, leaving only the links to the original content.
 
@@ -2536,8 +3306,7 @@ Org-transclusion lets you insert a copy of text content via a file link or ID li
 
 #+end_src
 
-
-* Denote
+** Denote
 
 Denote aims to be a simple-to-use, focused-in-scope, and effective note-taking and file-naming tool for Emacs.
 
@@ -2545,7 +3314,7 @@ Denote is based on the idea that files should follow a predictable and descripti
 
 Denote’s file-naming scheme is not limited to “notes”. It can be used for all types of file, including those that are not editable in Emacs, such as videos. Naming files in a consistent way makes their filtering and retrieval considerably easier. Denote provides relevant facilities to rename files, regardless of file type.
 
-** Denote Keymap
+*** Denote Keymap
 
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -2594,7 +3363,7 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 #+end_src
 
-** Denote Configuration
+*** Denote Configuration
 
 #+begin_src  emacs-lisp
   ;;; --------------------------------------------------------------------------
@@ -2637,6 +3406,56 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
            :jump-to-captured t)))
 
     (add-hook 'context-menu-functions #'denote-context-menu))
+
+#+end_src
+
+** Projectile
+
+[[https://projectile.mx/][Projectile]] is a project management library for Emacs which makes it a lot easier to navigate around code projects for various languages.  Many packages integrate with Projectile so it's a good idea to have it installed even if you don't use its commands directly.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (use-package projectile
+    :when (equal custom-project-handler 'custom-project-projectile)
+    :diminish Proj
+    :config (projectile-mode)
+    :bind-keymap
+    ("C-c p" . projectile-command-map)
+    :init
+    ;; NOTE: Set this to the folder where you keep your Git repos!
+    (when (file-directory-p "~/Developer")
+      (setq projectile-project-search-path '("~/Developer")))
+    (setq projectile-switch-project-action #'projectile-dired))
+
+  (when (equal completion-handler 'comphand-ivy-counsel)
+    (use-package counsel-projectile
+      :when (equal custom-project-handler 'custom-project-projectile)
+      :after projectile
+      :config
+      (setq projectile-completion-system 'ivy)
+      (counsel-projectile-mode)))
+
+#+end_src
+
+** Project.el
+This is the default built-in project system. For those not needing the full-featured ~projectile~, this package is generally enough.
+
+#+begin_src emacs-lisp
+  ;;; --------------------------------------------------------------------------
+
+  (defun project-find-go-module (dir)
+    (when-let ((root (locate-dominating-file dir "go.mod")))
+      (cons 'go-module root)))
+
+  (use-package project
+    :when (equal custom-project-handler 'custom-project-project)
+    :ensure nil
+    :defer t
+    :config
+    (cl-defmethod project-root ((project (head go-module)))
+      (cdr project))
+    (add-hook 'project-find-functions #'project-find-go-module))
 
 #+end_src
 
@@ -2798,15 +3617,15 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 * Dashboard
 <<<Dashboard>>> is an extensible Emacs startup screen showing you what’s most important.
-**** Value of dashboard-startup-banner can be:
-***** =nil= to display no banner
-***** ='official= which displays the official emacs logo
-***** ='logo= which displays an alternative emacs logo
-***** =1, 2 or 3= which displays one of the text banners
-***** ~"path/to/your/image.gif"~,
+*** Value of dashboard-startup-banner can be:
+**** =nil= to display no banner
+**** ='official= which displays the official emacs logo
+**** ='logo= which displays an alternative emacs logo
+**** =1, 2 or 3= which displays one of the text banners
+**** ~"path/to/your/image.gif"~,
 ~"path/to/your/image.png"~ or
 ~"path/to/your/text.txt"~  which displays whatever gif/image/text you would prefer
-***** a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
+**** a cons of '("path/to/your/image.png" . "path/to/your/text.txt")
 
 ** Dashboard Setup
 #+begin_src emacs-lisp
@@ -2838,13 +3657,14 @@ Denote’s file-naming scheme is not limited to “notes”. It can be used for 
 
 The following are configured for Python development and provide an IDE type experience.  It's worth noting that Eglot/LSP can be configured for other languages. The others are Python specific. Use the =configure= system to select which one is used (=Mrf Custom Selection=).
 
-*** Features
+:Features:
 - context-sensitive code completion
 - jump to definitions
 - find references
 - view documentation
 - virtual environment
 - eldoc mode
+:END:
 
 ** EGlot
 
@@ -3099,7 +3919,6 @@ Advantages of lsp-bridge:
 
 #+end_src
 
-
 ** Anaconda-mode
 
 Anaconda-mode provides Code navigation, documentation lookup and completion for Python.
@@ -3174,468 +3993,6 @@ C-c C-d displays documentation for the thing under cursor. The documentation wil
       (bind-keys :map elpy-mode-map
         ("<tab>" . company-indent-or-complete-common)))
     (elpy-enable))
-
-#+end_src
-
-
-
-* Completion Systems
-Here are a series of completion systems that are available for Emacs.
-
-** Prescient
-
-prescient.el is a library which sorts and filters lists of candidates, such as appear when you use a package like Ivy or Company. Extension packages such as ivy-prescient.el and company-prescient.el adapt the library for usage with various frameworks.
-
-prescient.el also provides a completion style (prescient) for filtering candidates via Emacs's generic completion, such as in Icomplete, Vertico, and Corfu. These last two have extension packages to correctly set up filtering and sorting.
-
-As compared to other packages which accomplish similar tasks, including IDO, Ivy, Helm, Smex, Flx, Historian, and Company-Statistics, prescient.el aims to be simpler, more predictable, and faster.
-
-TL;DR prescient.el: simple but effective sorting and filtering for Emacs.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-  
-  (use-package prescient)
-
-#+end_src
-
-** Orderless
-
-This package provides an orderless completion style that divides the pattern into space-separated components, and matches candidates that match all of the components in any order. Each component can match in any one of several ways: literally, as a regexp, as an initialism, in the flex style, or as multiple word prefixes. By default, regexp and literal matches are enabled.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package orderless
-    :when (or (equal completion-handler 'comphand-vertico)
-            (equal completion-handler 'comphand-ivy-counsel))
-    :custom
-    (completion-styles '(orderless basic))
-    (completion-category-overrides '((file (styles basic partial-completion)))))
-
-#+end_src
-
-** IVY Mode
-
-<<<Ivy>>> is an excellent completion framework for Emacs.  It provides a minimal yet powerful selection menu that appears when you open files, switch buffers, and for many other tasks in Emacs.  Counsel is a customized set of commands to replace `find-file` with `counsel-find-file`, etc which provide useful commands for each of the default completion commands.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-  ;;; Swiper and IVY mode
-
-  (use-package ivy
-    :when (equal completion-handler 'comphand-ivy-counsel)
-    :bind (("C-s" . swiper)
-            :map ivy-minibuffer-map
-              ;;; ("TAB" . ivy-alt-done)
-            ("C-l" . ivy-alt-done)
-            ("C-j" . ivy-next-line)
-            ("C-k" . ivy-previous-line)
-            :map ivy-switch-buffer-map
-            ("C-k" . ivy-previous-line)
-            ("C-l" . ivy-done)
-            ("C-d" . ivy-switch-buffer-kill)
-            :map ivy-reverse-i-search-map
-            ("C-k" . ivy-previous-line)
-            ("C-d" . ivy-reverse-i-search-kill))
-    :custom
-    (enable-recursive-minibuffers t)
-    (ivy-use-virtual-buffers t)
-    :config
-    (ivy-mode 1)
-    (setq ivy-re-builders-alist '((t . orderless-ivy-re-builder)))
-    (add-to-list 'ivy-highlight-functions-alist
-      '(orderless-ivy-re-builder . orderless-ivy-highlight)))
-
-#+end_src
-
-*** Ivy-rich and ivy-yasnippet
-
-Ivy-rich provides rich transformers for commands from ivy and counsel.
-Ivy-yasnippet lets you preview yasnippet snippets with ivy.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package ivy-rich
-    :when (equal completion-handler 'comphand-ivy-counsel)
-    :after ivy
-    :init
-    (ivy-rich-mode 1)
-    :config
-    (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line))
-
-  (use-package ivy-yasnippet
-    :when (equal completion-handler 'comphand-ivy-counsel)
-    :after (:any yasnippet ivy))
-  ;; :ensure (:host github :repo "mkcms/ivy-yasnippet"))
-
-#+end_src
-
-*** Swiper
-Swiper is an alternative to isearch that uses Ivy to show an overview of all matches.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package swiper
-    :when (equal completion-handler 'comphand-ivy-counsel)
-    :after ivy)
-
-#+end_src
-
-*** Counsel
-
-~ivy-mode~ ensures that any Emacs command using completing-read-function uses ivy for completion.
-Counsel takes this further, providing versions of common Emacs commands that are customised to make the best use of Ivy. For example, ~counsel-find-file~ has some additional keybindings. Pressing =DEL= will move you to the parent directory.
-
-#+begin_src emacs-lisp :results output silent
-  ;;; --------------------------------------------------------------------------
-
-  (use-package counsel
-    :when (equal completion-handler 'comphand-ivy-counsel)
-    :bind ( ("C-M-j" . 'counsel-switch-buffer)
-            ("M-x" . 'counsel-M-x)
-            ("M-g o" . 'counsel-outline)
-            ("C-x C-f" . 'counsel-find-file)
-            ("C-c C-r" . 'ivy-resume)
-            :map minibuffer-local-map
-            ("C-r" . 'counsel-minibuffer-history))
-    :custom
-    (counsel-linux-app-format-function #'counsel-linux-app-format-function-name-only)
-    :config
-    (counsel-mode 1))
-
-#+end_src
-
-*** Ivy Prescient
-~prescient.el~ is a library which sorts and filters lists of candidates, such as appear when you use a package like =Ivy= or =Company=.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package ivy-prescient
-    :when (equal completion-handler 'comphand-ivy-counsel)
-    :after (ivy prescient)
-    :custom
-    (prescient-persist-mode t)
-    (ivy-prescient-mode t)
-    (ivy-prescient-enable-filtering t))
-
-#+end_src
-
-** Corfu
-
-<<<Corfu>>> enhances in-buffer completion with a small completion popup. The current candidates are shown in a popup below or above the point. The candidates can be selected by moving up and down. Corfu is the minimalistic in-buffer completion counterpart of the Vertico minibuffer UI.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  ;;;; Code Completion
-  (use-package corfu
-    :when (equal completion-handler 'comphand-corfu)
-    ;; Optional customizations
-    :custom
-    (corfu-cycle t)                  ; Allows cycling through candidates
-    (corfu-auto t)                   ; Enable auto completion
-    (corfu-auto-prefix 2)
-    (corfu-auto-delay 0.8)
-    (corfu-popupinfo-delay '(0.5 . 0.2))
-    (corfu-preview-current 'insert) ; insert previewed candidate
-    (corfu-preselect 'prompt)
-    (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
-    ;; Optionally use TAB for cycling, default is `corfu-complete'.
-    :bind (:map corfu-map
-          ("M-SPC"          . corfu-insert-separator)
-          ("TAB"            . corfu-next)
-          ([tab]            . corfu-next)
-          ("S-TAB"          . corfu-previous)
-          ([backtab]    . corfu-previous)
-          ("S-<return>" . corfu-insert)
-          ("RET"            . nil))
-    :init
-    (global-corfu-mode)
-    (corfu-history-mode)
-    (corfu-popupinfo-mode) ; Popup completion info
-    :config
-    (add-hook 'eshell-mode-hook
-      (lambda () (setq-local corfu-quit-at-boundary t
-                 corfu-quit-no-match t
-                 corfu-auto nil)
-        (corfu-mode))))
-  
-#+end_src
-
-*** Cape Configuration
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-  ;; Add extensions
-  (use-package cape
-    :when (equal completion-handler 'comphand-corfu)
-    :after corfu
-    ;; Bind dedicated completion commands
-    ;; Alternative prefix keys: C-c p, M-p, M-+, ...
-    :bind ( ("C-c C-p p" . completion-at-point) ;; capf
-            ("C-c C-p t" . complete-tag)        ;; etags
-            ("C-c C-p d" . cape-dabbrev)        ;; or dabbrev-completion
-            ("C-c C-p h" . cape-history)
-            ("C-c C-p f" . cape-file)
-            ("C-c C-p k" . cape-keyword)
-            ("C-c C-p s" . cape-elisp-symbol)
-            ("C-c C-p e" . cape-elisp-block)
-            ("C-c C-p a" . cape-abbrev)
-            ("C-c C-p l" . cape-line)
-            ("C-c C-p w" . cape-dict)
-            ("C-c C-p :" . cape-emoji)
-            ("C-c C-p \\" . cape-tex)
-            ("C-c C-p _" . cape-tex)
-            ("C-c C-p ^" . cape-tex)
-            ("C-c C-p &" . cape-sgml)
-            ("C-c C-p r" . cape-rfc1345))
-    :init
-    ;; Add to the global default value of `completion-at-point-functions' which is
-    ;; used by `completion-at-point'.  The order of the functions matters, the
-    ;; first function returning a result wins.  Note that the list of buffer-local
-    ;; completion functions takes precedence over the global list.
-    (add-hook 'completion-at-point-functions #'cape-dabbrev)
-    (add-hook 'completion-at-point-functions #'cape-file)
-    (add-hook 'completion-at-point-functions #'cape-elisp-block)
-    ;;(add-hook 'completion-at-point-functions #'cape-history)
-    ;;(add-hook 'completion-at-point-functions #'cape-keyword)
-    ;;(add-hook 'completion-at-point-functions #'cape-tex)
-    ;;(add-hook 'completion-at-point-functions #'cape-sgml)
-    ;;(add-hook 'completion-at-point-functions #'cape-rfc1345)
-    ;;(add-hook 'completion-at-point-functions #'cape-abbrev)
-    ;;(add-hook 'completion-at-point-functions #'cape-dict)
-    ;;(add-hook 'completion-at-point-functions #'cape-elisp-symbol)
-    ;;(add-hook 'completion-at-point-functions #'cape-line)
-    )
-
-#+end_src
-
-*** Corfu-prescient
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-  
-  (use-package corfu-prescient
-    :when (equal completion-handler 'comphand-corfu)
-    :after (corfu prescient))
-
-#+end_src
-
-** Vertico
-
-<<<Vertico>>> provides a performant and minimalistic vertical completion UI based on the default completion system. The focus of Vertico is to provide a UI which behaves correctly under all circumstances. By reusing the built-in facilities system, Vertico achieves full compatibility with built-in Emacs completion commands and completion tables.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package vertico
-    :when (equal completion-handler 'comphand-vertico)
-    :demand t
-    ;;:wait t
-    ;;:ensure (:repo "minad/vertico" :files (:defaults "extensions/vertico-*.el") :fetcher github)
-    :custom
-    (recentf-mode t)
-    (vertico-count 12)
-    (vertico-cycle nil)
-    (vertico-multiform-mode 1)
-    :config
-    (vertico-mode)
-    ;; :bind ("C-x C-f" . ido-find-file)
-    ;; Clean up file path when typing
-    :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
-          ;; Make sure vertico state is saved
-          (minibuffer-setup . vertico-repeat-save)))
-  
-#+end_src
-
-*** Marginalia
-
-Marginalia are marks or annotations placed at the margin of the page of a book or in this case helpful colorful annotations placed at the margin of the  minibuffer for your completion candidates. Marginalia can only add annotations  to the completion candidates. It cannot modify the appearance of the candidates  themselves, which are shown unaltered as supplied by the original command.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package marginalia
-    ;; :when (equal completion-handler 'comphand-vertico)
-    ;; :after vertico
-    :custom
-    (marginalia-max-relative-age 0)
-    (marginalia-align 'left)
-    (marginalia-annotators '(marginalia-annotators-heavy marginalia-annotators-light nil))
-    :config
-    (marginalia-mode t))
-  
-#+end_src
-
-*** Icons for Marginalia
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package all-the-icons-completion
-    :after (marginalia all-the-icons)
-    :hook (marginalia-mode . all-the-icons-completion-marginalia-setup))
-
-#+end_src
-
-*** Consult
-
-Consult provides search and navigation commands based on the Emacs completion function completing-read. Completion allows you to quickly select an item from a list of candidates. Consult offers asynchronous and interactive consult-grep and  consult-ripgrep commands, and the line-based search command consult-line. Furthermore Consult provides an advanced buffer switching command consult-buffer to switch between buffers, recently opened files, bookmarks and buffer-like candidates from other sources. Some of the Consult commands are enhanced versions of built-in Emacs commands.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package consult
-    :when (equal completion-handler 'comphand-vertico)
-    :after vertico
-    :bind
-    ([remap switch-to-buffer] . consult-buffer)
-    ([remap switch-to-buffer-other-window] . consult-buffer-other-window)
-    ([remap switch-to-buffer-other-frame] . consult-buffer-other-frame)
-    ([remap project-switch-to-buffer] . consult-project-buffer)
-    ([remap bookmark-jump] . consult-bookmark)
-    ([remap recentf-open] . consult-recent-file)
-    ([remap yank] . nil)
-    ([remap yank-pop] . consult-yank-pop)
-    ([remap goto-line] . consult-goto-line)
-    ("M-g m" . consult-mark)
-    ("M-g M" . consult-global-mark)
-    ("M-g o" . consult-outline)
-    ("M-g i" . consult-imenu)
-    ("M-g I" . consult-imenu-multi)
-    ("M-s l" . consult-line)
-    ("M-s p" . consult-preview)  
-    ("M-s L" . consult-line-multi)
-    ("M-s k" . consult-keep-lines)
-    ("M-s u" . consult-focus-lines)
-    ("M-s r" . consult-ripgrep)
-    ("M-s f" . consult-find)
-    ("M-s F" . consult-locate)
-    ("M-g e" . consult-compile-error)
-    ("M-g f" . consult-flymake)
-    ([remap repeat-complex-command] . consult-complex-command)
-    ("M-s e" . consult-isearch-history)
-    ([remap isearch-edit-string] . consult-isearch-history)
-    ([remap next-matching-history-element] . consult-history)
-    ([remap previous-matching-history-element] . consult-history)
-    ([remap Info-search] . consult-info)
-    :custom
-    (xref-show-xrefs-function 'consult-xref)
-    (xref-show-definitions-function 'consult-xref)
-    :config
-    (setq consult-buffer-sources
-      '(consult--source-hidden-buffer 
-         consult--source-buffer
-         (:name "Ephemeral" :state consult--buffer-state
-         :narrow 109 :category buffer
-         :items ("*Messages*"  "*scratch*" "*vterm*"
-                  "*Async-native-compile-log*" "*dashboard*"))
-         consult--source-modified-buffer
-         consult--source-recent-file)))
-
-#+end_src
-
-*** Vertico support packages
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package vertico-prescient
-    :when (equal completion-handler 'comphand-vertico)
-    :after vertico prescient)
-  
-#+end_src
-
-vertico-posframe is an vertico extension, which lets vertico use posframe to show its candidate menu.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package vertico-posframe
-    :when (equal completion-handler 'comphand-vertico)
-    :after vertico
-    :custom
-    (setq vertico-multiform-commands
-      '((consult-line
-          posframe
-          (vertico-posframe-poshandler . posframe-poshandler-frame-top-center)
-          (vertico-posframe-border-width . 10)
-          ;; NOTE: This is useful when emacs is used in both in X and
-          ;; terminal, for posframe do not work well in terminal, so
-          ;; vertico-buffer-mode will be used as fallback at the
-          ;; moment.
-          (vertico-posframe-fallback-mode . vertico-buffer-mode))
-         (t posframe)))
-    (vertico-multiform-mode 1)
-    (setq vertico-posframe-parameters
-      '((left-fringe . 8)
-         (right-fringe . 8))))
-  
-#+end_src
-
-** Built-In (Ido)
-Enable the IDO handler everywhere.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  ;; This has to be evaluated at the end of the init since it's possible that the
-  ;; completion-handler variable will not yet be defined at this point in the
-  ;; init phase using elpaca.
-  (add-hook 'elpaca-after-init-hook
-    (lambda ()
-      (when (equal completion-handler 'comphand-built-in)
-        (ido-everywhere t))))
-
-#+end_src
-
-** Embark
-
-Embark makes it easy to choose a command to run based on what is near point, both during a minibuffer completion session (in a way familiar to Helm or Counsel users) and in normal buffers. Bind the command  embark-act to a key and it acts like prefix-key for a keymap of actions (commands) relevant to the target around point. With point on an URL in a buffer you can open the URL in a browser or eww or download the file it points to. If while switching buffers you spot an old one, you can kill it right there and continue to select another. Embark comes preconfigured with over a hundred actions for common types of targets such as files, buffers, identifiers, s-expressions, sentences; and it is easy to add more actions and more target types. Embark can also collect all the candidates in a minibuffer to an occur-like buffer or export them to a buffer in a major-mode specific to the type of candidates, such as dired for a set of files, ibuffer for a set of buffers, or customize for a set of variables.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package embark
-    :when enable-embark
-    :bind
-    (("C-." . embark-act)         ;; pick some comfortable binding
-      ("C-;" . embark-dwim)        ;; good alternative: M-.
-      ("C-h B" . embark-bindings)) ;; alternative for `describe-bindings'
-
-    :init
-
-    ;; Optionally replace the key help with a completing-read interface
-    (setq prefix-help-command #'embark-prefix-help-command)
-
-    ;; Show the Embark target at point via Eldoc. You may adjust the
-    ;; Eldoc strategy, if you want to see the documentation from
-    ;; multiple providers. Beware that using this can be a little
-    ;; jarring since the message shown in the minibuffer can be more
-    ;; than one line, causing the modeline to move up and down:
-
-    ;; (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
-    ;; (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
-
-    :config
-
-    ;; Hide the mode line of the Embark live/completions buffers
-    (add-to-list 'display-buffer-alist
-      '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
-         nil
-         (window-parameters (mode-line-format . none)))))
-
-  ;; Consult users will also want the embark-consult package.
-  (use-package embark-consult
-    :when (equal completion-handler 'comphand-vertico)
-    :defer t
-    ;;:ensure t ; only need to install it, embark loads it after consult if found
-    :hook
-    (embark-collect-mode . consult-preview-at-point-mode))
 
 #+end_src
 
@@ -4718,381 +5075,6 @@ Below are all the necessary functions and definitions for Hydra use under DAP.
 z
 
 
-* Company Mode
-
-[[http://company-mode.github.io/][Company Mode]] provides a nicer in-buffer completion interface than =completion-at-point= which is more reminiscent of what you would expect from an IDE.  We add a simple configuration to make the keybindings a little more useful (=TAB= now completes the selection and initiates completion at the current location if needed).
-
-We also use [[https://github.com/sebastiencs/company-box][company-box]] to further enhance the look of the completions with icons and better overall presentation.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
-  ;; features. They actually collide.
-  
-  (use-package company
-    :unless (equal custom-ide 'custom-ide-lsp-bridge)
-    :custom
-    (company-minimum-prefix-length 2)
-    (company-idle-delay 0.2)
-    :config
-    (global-company-mode +1))
-
-#+end_src
-
-
-#+begin_src emacs-lisp :tangle no
-  ;;; --------------------------------------------------------------------------
-
-  ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
-  ;; features. They actually collide.
-
-  (use-package company
-    :unless (equal custom-ide 'custom-ide-lsp-bridge)
-    :bind (:map company-active-map
-            ("C-n". company-select-next)
-            ("C-p". company-select-previous)
-            ("M-<". company-select-first)
-            ("M->". company-select-last)
-            ("<tab>" . company-complete-selection))
-    :custom
-    (company-minimum-prefix-length 2)
-    (company-idle-delay 0.5)
-    :config
-    (global-company-mode +1))
-
-  ;; IMPORTANT:
-  ;; Don't use company at all if lsp-bridge is active.
-  ;; lsp-bridge already provides similar functionality.
-
-  ;; :config
-  ;; (add-to-list 'company-backends 'company-yasnippet))
-
-#+end_src
-
-** Company Packages :Python:
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package company-box
-    :after company
-    :diminish cb
-    :hook (company-mode . company-box-mode))
-
-  (use-package company-jedi
-    :when  (equal custom-ide 'custom-ide-elpy)
-    :after python company
-    :config
-    (jedi:setup)
-    (defun my/company-jedi-python-mode-hook ()
-      (add-to-list 'company-backends 'company-jedi))
-    (add-hook 'python-mode-hook 'my/company-jedi-python-mode-hook))
-
-  (use-package company-anaconda
-    :when (equal custom-ide 'custom-ide-anaconda)
-    :after anaconda company
-    :hook (python-mode . anaconda-mode)
-    :config
-    (eval-after-load "company"
-      '(add-to-list 'company-backends 'company-anaconda)))
-
-#+end_src
-
-
-
-* Projectile
-
-[[https://projectile.mx/][Projectile]] is a project management library for Emacs which makes it a lot easier to navigate around code projects for various languages.  Many packages integrate with Projectile so it's a good idea to have it installed even if you don't use its commands directly.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package projectile
-    :when (equal custom-project-handler 'custom-project-projectile)
-    :diminish Proj
-    :config (projectile-mode)
-    :bind-keymap
-    ("C-c p" . projectile-command-map)
-    :init
-    ;; NOTE: Set this to the folder where you keep your Git repos!
-    (when (file-directory-p "~/Developer")
-      (setq projectile-project-search-path '("~/Developer")))
-    (setq projectile-switch-project-action #'projectile-dired))
-
-  (when (equal completion-handler 'comphand-ivy-counsel)
-    (use-package counsel-projectile
-      :when (equal custom-project-handler 'custom-project-projectile)
-      :after projectile
-      :config
-      (setq projectile-completion-system 'ivy)
-      (counsel-projectile-mode)))
-
-#+end_src
-
-
-* Project.el
-This is the default built-in project system. For those not needing the full-featured ~projectile~, this package is generally enough.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (defun project-find-go-module (dir)
-    (when-let ((root (locate-dominating-file dir "go.mod")))
-      (cons 'go-module root)))
-
-  (use-package project
-    :when (equal custom-project-handler 'custom-project-project)
-    :ensure nil
-    :defer t
-    :config
-    (cl-defmethod project-root ((project (head go-module)))
-      (cdr project))
-    (add-hook 'project-find-functions #'project-find-go-module))
-
-#+end_src
-
-
-* Terminals
-** term-mode
-
-=term-mode= is a built-in terminal emulator in Emacs.  Because it is written in Emacs Lisp, you can start using it immediately with very little configuration.  If you are on Linux or macOS, =term-mode= is a great choice to get started because it supports fairly complex terminal applications (=htop=, =vim=, etc) and works pretty reliably.  However, because it is written in Emacs Lisp, it can be slower than other options like =vterm=.  The speed will only be an issue if you regularly run console apps with a lot of output.
-
-One important thing to understand is =line-mode= versus =char-mode=.  =line-mode= enables you to use normal Emacs keybindings while moving around in the terminal buffer while =char-mode= sends most of your keypresses to the underlying terminal.  While using =term-mode=, you will want to be in =char-mode= for any terminal applications that have their own keybindings.  If you're just in your usual shell, =line-mode= is sufficient and feels more integrated with Emacs.
-
-With =evil-collection= installed, you will automatically switch to =char-mode= when you enter Evil's insert mode (press =i=).  You will automatically be switched back to =line-mode= when you enter Evil's normal mode (press =ESC=).
-
-Run a terminal with =M-x term!=
-
-*Useful key bindings:*
-
-- =C-c C-p= / =C-c C-n= - go back and forward in the buffer's prompts (also =[[= and =]]= with evil-mode)
-- =C-c C-k= - Enter char-mode
-- =C-c C-j= - Return to line-mode
-- If you have =evil-collection= installed, =term-mode= will enter char mode when you use Evil's Insert mode
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package term+
-    ;;:ensure (:repo "tarao/term-plus-el" :fetcher github)
-    :commands term
-    :config
-    (setq explicit-shell-file-name "bash") ;; Change this to zsh, etc
-    ;;(setq explicit-zsh-args '())          ;; Use 'explicit-<shell>-args for shell-specific args
-
-    ;; Match the default Bash shell prompt.  Update this if you have a custom prompt
-    (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *"))
-
-#+end_src
-
-** Better term-mode colors
-
-The =eterm-256color= package enhances the output of =term-mode= to enable handling of a wider range of color codes so that many popular terminal applications look as you would expect them to.  Keep in mind that this package requires =ncurses= to be installed on your machine so that it has access to the =tic= program.  Most Linux distributions come with this program installed already so you may not have to do anything extra to use it.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package eterm-256color
-    :hook (term-mode . eterm-256color-mode))
-  
-#+end_src
-
-** vterm
-
-[[https://github.com/akermu/emacs-libvterm/][vterm]] is an improved terminal emulator package which uses a compiled native module to interact with the underlying terminal applications.  This enables it to be much faster than =term-mode= and to also provide a more complete terminal emulation experience.
-
-Make sure that you have the [[https://github.com/akermu/emacs-libvterm/#requirements][necessary dependencies]] installed before trying to use =vterm= because there is a module that will need to be compiled before you can use it successfully.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (use-package vterm
-    ;;:ensure (:fetcher github :repo "akermu/emacs-libvterm")
-    :commands vterm
-    :config
-    (setq vterm-environment ("PS1=\\u@\\h:\\w \n$"))
-    (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *")  ;; Set this to match your custom shell prompt
-    (setq vterm-shell "zsh")                        ;; Set this to customize the shell to launch
-    (setq vterm-max-scrollback 10000))
-
-#+end_src
-
-** shell-mode
-
-[[https://www.gnu.org/software/emacs/manual/html_node/emacs/Interactive-Shell.html#Interactive-Shell][shell-mode]] is a middle ground between =term-mode= and Eshell.  It is *not* a terminal emulator so more complex terminal programs will not run inside of it.  It does have much better integration with Emacs because all command input in this mode is handled by Emacs and then sent to the underlying shell once you press Enter.  This means that you can use =evil-mode='s editing motions on the command line, unlike in the terminal emulator modes above.
-
-*Useful key bindings:*
-
-- =C-c C-p= / =C-c C-n= - go back and forward in the buffer's prompts (also =[[= and =]]= with evil-mode)
-- =M-p= / =M-n= - go back and forward in the input history
-- =C-c C-u= - delete the current input string backwards up to the cursor
-- =counsel-shell-history= - A searchable history of commands typed into the shell
-
-** Eshell
-
-[[https://www.gnu.org/software/emacs/manual/html_mono/eshell.html#Contributors-to-Eshell][Eshell]] is Emacs' own shell implementation written in Emacs Lisp.  It provides you with a cross-platform implementation (even on Windows!) of the common GNU utilities you would find on Linux and macOS (=ls=, =rm=, =mv=, =grep=, etc).  It also allows you to call Emacs Lisp functions directly from the shell and you can even set up aliases (like aliasing =vim= to =find-file=).  Eshell is also an Emacs Lisp REPL which allows you to evaluate full expressions at the shell.
-
-The downsides to Eshell are that it can be harder to configure than other packages due to the particularity of where you need to set some options for them to go into effect, the lack of shell completions (by default) for some useful things like Git commands, and that REPL programs sometimes don't work as well.  However, many of these limitations can be dealt with by good configuration and installing external packages, so don't let that discourage you from trying it!
-
-*Useful key bindings:*
-
-- =C-c C-p= / =C-c C-n= - go back and forward in the buffer's prompts (also =[[= and =]]= with evil-mode)
-- =M-p= / =M-n= - go back and forward in the input history
-- =C-c C-u= - delete the current input string backwards up to the cursor
-- =counsel-esh-history= - A searchable history of commands typed into Eshell
-
-We will be covering Eshell more in future videos highlighting other things you can do with it.
-
-For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
-- https://ambrevar.xyz/emacs-eshell/index.html
-- https://ambrevar.xyz/emacs-eshell-versus-shell/index.html
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-  (defun mifi/configure-eshell ()
-    ;; Save command history when commands are entered
-    (add-hook 'eshell-pre-command-hook 'eshell-save-some-history)
-    ;; Truncate buffer for performance
-    (add-to-list 'eshell-output-filter-functions 'eshell-truncate-buffer)
-    (setq eshell-history-size   10000
-      eshell-buffer-maximum-lines 10000
-      eshell-hist-ignoredups t
-      eshell-scroll-to-bottom-on-input t))
-
-  (use-package eshell-git-prompt
-    :after eshell)
-
-  (use-package eshell
-    :ensure
-    :defer t
-    :hook (eshell-first-time-mode . mifi/configure-eshell)
-    :config
-    (with-eval-after-load 'esh-opt
-      (setq eshell-destroy-buffer-when-process-dies t)
-      (setq eshell-visual-commands '("htop" "zsh" "vim")))
-    (eshell-git-prompt-use-theme 'powerline))
-
-#+end_src
-
-
-* File Management
-** Dired
-
-Dired is a built-in file manager for Emacs that does some pretty amazing things!  Here are some key bindings you should try out:
-
-**** Key Bindings
-**** Navigation
-
-*Emacs* / *Evil*
-- =n= / =j= - next line
-- =p= / =k= - previous line
-- =j= / =J= - jump to file in buffer
-- =RET= - select file or directory
-- =^= - go to parent directory
-- =S-RET= / =g O= - Open file in "other" window
-- =M-RET= - Show file in other window without focusing (previewing files)
-- =g o= (=dired-view-file=) - Open file but in a "preview" mode, close with =q=
-- =g= / =g r= Refresh the buffer with =revert-buffer= after changing configuration (and after filesystem changes!)
-
-**** Marking files
-
-- =m= - Marks a file
-- =u= - Unmarks a file
-- =U= - Unmarks all files in buffer
-- =* t= / =t= - Inverts marked files in buffer
-- =% m= - Mark files in buffer using regular expression
-- =*= - Lots of other auto-marking functions
-- =k= / =K= - "Kill" marked items (refresh buffer with =g= / =g r= to get them back)
-- Many operations can be done on a single file if there are no active marks!
-
-**** Copying and Renaming files
-
-- =C= - Copy marked files (or if no files are marked, the current file)
-- Copying single and multiple files
-- =U= - Unmark all files in buffer
-- =R= - Rename marked files, renaming multiple is a move!
-- =% R= - Rename based on regular expression: =^test= , =old-\&=
-
-*Power command*: =C-x C-q= (=dired-toggle-read-only=) - Makes all file names in the buffer editable directly to rename them!  Press =Z Z= to confirm renaming or =Z Q= to abort.
-
-**** Deleting files
-
-- =D= - Delete marked file
-- =d= - Mark file for deletion
-- =x= - Execute deletion for marks
-- =delete-by-moving-to-trash= - Move to trash instead of deleting permanently
-
-**** Creating and extracting archives
-
-- =Z= - Compress or uncompress a file or folder to (=.tar.gz=)
-- =c= - Compress selection to a specific file
-- =dired-compress-files-alist= - Bind compression commands to file extension
-
-**** Other common operations
-
-- =T= - Touch (change timestamp)
-- =M= - Change file mode
-- =O= - Change file owner
-- =G= - Change file group
-- =S= - Create a symbolic link to this file
-- =L= - Load an Emacs Lisp file into Emacs
-
-*** Configuration
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-
-    ;; Prefer g-prefixed coreutils version of standard utilities when available
-  (let ((gls (executable-find "gls")))
-    (when gls (setq-default insert-directory-program gls
-              dired-use-ls-dired t
-                ;; Needed to fix an issue on Mac which causes dired to fail
-                dired-listing-switches "-al --group-directories-first")))
-
-  (use-package all-the-icons-dired
-    :after dired
-    :hook (dired-mode . all-the-icons-dired-mode))
-
-  (use-package dired-open
-    :commands (dired dired-jump)
-    :config
-    ;; Doesn't work as expected!
-    ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
-    (setq dired-open-extensions '(("png" . "feh")
-                                 ("mkv" . "mpv"))))
-
-  (use-package dired-hide-dotfiles
-    :after dired-mode
-    :hook (dired-mode . dired-hide-dotfiles-mode))
-
-#+end_src
-
-
-*** Single Window
-Dired, by default, opens up multiple windows - one for each directory. It would be nice to be able to limit =dired= to use just a single window. [[https://codeberg.org/amano.kenji/dired-single][dired-single]] does just that. We configure =dired-single= to open up a directory while in dired with the =C-<return>=  key combination. This will then open up the directory in the buffer named =*dired*=. Whenever a directory is opened with the =C-<return>= key sequence, that directory will then replace what's currently in the =*dired*= buffer.
-
-#+begin_src emacs-lisp
-  ;;; --------------------------------------------------------------------------
-  ;; Single Window dired - don't continually open new buffers
-
-  (defun mifi/dired-single-keymap-init ()
-    "Bunch of stuff to run for dired, either immediately or when it's
-     loaded."
-    (define-key dired-mode-map
-      [remap dired-find-file] 'dired-single-buffer)
-    (define-key dired-mode-map
-      [remap dired-mouse-find-file-other-window] 'dired-single-buffer-mouse)
-    (define-key dired-mode-map
-      [remap dired-up-directory] 'dired-single-up-directory))
-
-  (use-package dired-single
-    :after dired
-    :config
-    (mifi/dired-single-keymap-init))
-#+end_src
-
-
 * Miscellaneous
 
 The following packages are some additional quality of life features.
@@ -5128,6 +5110,28 @@ The following packages are some additional quality of life features.
     (bind-keys
       ([remap describe-command] . helpful-command)
       ([remap describe-key] . helpful-key)))
+
+#+end_src
+
+** Thesaurus
+#+begin_src emacs-lisp
+
+  (use-package mw-thesaurus
+    :when enable-thesaurus
+    :ensure t
+    :custom
+    (mw-thesaurus-api-key "429331e9-b40e-4f17-9988-0632ef3ddd2d")
+    :defer t
+    :commands mw-thesaurus-lookup-dwim
+    :hook (mw-thesaurus-mode . variable-pitch-mode)
+    :config
+    ;; window on the right side
+    (add-to-list 'display-buffer-alist '(,mw-thesaurus-buffer-name
+                                        (display-buffer-reuse-window
+                                          display-buffer-in-direction)
+                                        (direction . right)
+                                        (window . root)
+                                        (window-width . 0.3))))
 
 #+end_src
 
@@ -5365,18 +5369,23 @@ Mitch's minor mode (or <<<mmm>>>) just defines frequently used hot-keys. It work
 *** Mitch's Minor Mode Functions
 #+begin_src emacs-lisp
   ;;; --------------------------------------------------------------------------
-  
+
   (defun mifi/set-fill-column-interactively (num)
     "Asks for the fill column."
-    (interactive "nfill-column: ")
+    (interactive "fill-column: ")
     (set-fill-column num))
 
   (defun mifi/set-org-fill-column-interactively (num)
     "Asks for the fill column for Org mode."
-    (interactive "norg-fill-column: ")
+    (interactive "org-fill-column: ")
     (setq custom-org-fill-column num)
     (mifi/org-mode-visual-fill)
     (redraw-display))
+
+  (defun mifi/jump-to-register ()
+    "Asks for a register to jump to."
+    (interactive)
+    (call-interactively 'jump-to-register))
 
 #+end_src
 
@@ -5392,19 +5401,20 @@ This is a set of keymaps that do the same things as the popup menu. Both are her
       (let ((map (make-sparse-keymap)))
         (bind-keys :map map
         ("M-RET $" . jinx-correct)
-          ("M-RET p" . pulsar-pulse-line)
-          ("M-RET d" . dashboard-open)
+          ("M-RET ?" . eldoc-box-help-at-point)
           ("M-RET S e" . eshell)
-          ("M-RET f" . mifi/set-fill-column-interactively)
-          ("M-RET r" . repeat-mode)
           ("M-RET S i" . ielm)
           ("M-RET S v" . vterm-other-window)
-          ("M-RET t" . treemacs)
-          ("M-RET |" . global-display-fill-column-indicator-mode)
           ("M-RET T +" . next-theme)
           ("M-RET T -" . previous-theme)
           ("M-RET T ?" . which-theme)
-          ("M-RET ?" . eldoc-box-help-at-point))
+          ("M-RET d" . dashboard-open)
+          ("M-RET e" . treemacs) ;; e for Explore
+          ("M-RET f" . mifi/set-fill-column-interactively)
+          ("M-RET p" . pulsar-pulse-line)
+          ("M-RET r" . repeat-mode)
+        ("M-RET j" . mifi/jump-to-register)
+          ("M-RET |" . global-display-fill-column-indicator-mode))
         map)
       "mmm-keys-minor-mode keymap.")
 
@@ -5433,6 +5443,9 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
       (unbind-key "M-RET o l" map)
       (unbind-key "M-RET P ?" map)
       (unbind-key "M-RET M-RET" map)
+      (when enable-thesaurus
+        (bind-keys :map map
+        ("M-RET m t" . mw-thesaurus-lookup-dwim)))
       (cond
         ((equal major-mode 'org-mode)
         (bind-keys :map map
@@ -5450,8 +5463,10 @@ shown. Plus, some keys are mode specific and will only appear when that major mo
     (which-key-add-key-based-replacements "M-RET T" "theme-keys")
     (which-key-add-key-based-replacements "M-RET P" "python-menu")
     (which-key-add-key-based-replacements "M-RET o" "org-menu")
-    (which-key-add-key-based-replacements "M-RET t" "treemacs-toggle")
+    (which-key-add-key-based-replacements "M-RET e" "treemacs-toggle")
+    (which-key-add-key-based-replacements "M-RET m" "Thesaurus")
     (which-key-add-key-based-replacements "M-RET f" "set-fill-column")
+    (which-key-add-key-based-replacements "M-RET j" "jump-to-register")
     (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
   (add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)

--- a/init.el
+++ b/init.el
@@ -57,7 +57,7 @@
 (elpaca elpaca-use-package
   (elpaca-use-package-mode 1)
   (setq elpaca-use-package-by-default t))
-;; (use-package emacs :ensure nil :config (setq ring-bell-function #'ignore))
+;;    (use-package emacs :ensure nil :config (setq ring-bell-function #'ignore))
 
 ;;; ##########################################################################
 ;;; Define my customization groups
@@ -971,7 +971,7 @@ font size is computed + 20 of this value."
 ;; Add extensions
 (use-package cape
   :when (equal completion-handler 'comphand-corfu)
-  :after corfu
+  :after curfu
   ;; Bind dedicated completion commands
   ;; Alternative prefix keys: C-c p, M-p, M-+, ...
   :bind ( ("C-c C-p p" . completion-at-point) ;; capf
@@ -1188,11 +1188,24 @@ font size is computed + 20 of this value."
 
 (use-package company
   :unless (equal custom-ide 'custom-ide-lsp-bridge)
+  :bind (:map company-active-map
+          ("C-n". company-select-next)
+          ("C-p". company-select-previous)
+          ("M-<". company-select-first)
+          ("M->". company-select-last)
+          ("<tab>" . company-complete-selection))
   :custom
   (company-minimum-prefix-length 2)
-  (company-idle-delay 0.2)
+  (company-idle-delay 0.5)
   :config
   (global-company-mode +1))
+
+;; IMPORTANT:
+;; Don't use company at all if lsp-bridge is active.
+;; lsp-bridge already provides similar functionality.
+
+;; :config
+;; (add-to-list 'company-backends 'company-yasnippet))
 
 ;;; ##########################################################################
 
@@ -1203,7 +1216,7 @@ font size is computed + 20 of this value."
 
 (use-package company-jedi
   :when  (equal custom-ide 'custom-ide-elpy)
-  :after python company
+  :after (:all python company)
   :config
   (jedi:setup)
   (defun my/company-jedi-python-mode-hook ()
@@ -1212,7 +1225,7 @@ font size is computed + 20 of this value."
 
 (use-package company-anaconda
   :when (equal custom-ide 'custom-ide-anaconda)
-  :after anaconda company
+  :after (:all anaconda company)
   :hook (python-mode . anaconda-mode)
   :config
   (eval-after-load "company"
@@ -2114,7 +2127,6 @@ font size is computed + 20 of this value."
 ;;; ##########################################################################
 
 (use-package org
-  :pin gnu-elpa
   :preface
   (mifi/org-theme-override-values)
   :commands (org-capture org-agenda)

--- a/init.el
+++ b/init.el
@@ -1487,18 +1487,27 @@ font size is computed + 20 of this value."
 (defun mifi/load-theme-from-selector (&optional step)
   "Load the theme in `theme-list' indexed by `theme-selector'."
   (interactive)
-  (setq theme-cycle-step nil)
-  (cond
-    ((or (eq step nil) (eq step 0)) (setq theme-cycle-step 0))
-    ((> step 0) (setq theme-cycle-step 1))
-    ((< step 0) (setq theme-cycle-step -1)))
-  (when loaded-theme
-    (disable-theme (intern loaded-theme)))
-  (setq loaded-theme (nth theme-selector theme-list))
-  (setq theme-did-load (load-theme (intern loaded-theme) t))
-  (when (featurep 'org)
-    (mifi/org-font-setup))
-  (set-face-foreground 'line-number "SkyBlue4"))
+  ;; Save value of spacious-padding-mode
+  (let ((spm? (featurep 'spacious-padding)))
+    (if spm?
+      (setq mifi/spm-on-off (default-value 'spacious-padding-mode))
+      (setq mifi/spm-on-off nil))
+    (setq theme-cycle-step nil)
+    (cond
+      ((or (eq step nil) (eq step 0)) (setq theme-cycle-step 0))
+      ((> step 0) (setq theme-cycle-step 1))
+      ((< step 0) (setq theme-cycle-step -1)))
+    (when loaded-theme
+      (when spm?
+	(spacious-padding-mode 0))
+      (disable-theme (intern loaded-theme)))
+    (setq loaded-theme (nth theme-selector theme-list))
+    (setq theme-did-load (load-theme (intern loaded-theme) t))
+    (when (featurep 'org)
+      (mifi/org-font-setup))
+    (when spm?
+      (spacious-padding-mode mifi/spm-on-off))
+    (set-face-foreground 'line-number "SkyBlue4")))
 
 ;;; ##########################################################################
 
@@ -2721,9 +2730,8 @@ font size is computed + 20 of this value."
 (defalias 'quote-region
   (kmacro "C-w \" \" <left> C-y <right>"))
 
-(defalias 're-format-src-block
+(defalias 'reformat-src-block
   (kmacro "C-s b e g i n _ s r c SPC e m a c s - l i s p <return> <down> C-c ' C-x h C-c ] C-x h M-x u n t a b <return> C-c ' C-s e n d _ s r c <return> <down>"))
-
 
 (eval-after-load "python"
   #'(bind-keys :map python-mode-map

--- a/init.el
+++ b/init.el
@@ -158,11 +158,11 @@ The Dashboard will be in the *dashboard* buffer and can also be opened using
   :group 'mrf-custom-toggles)
 
 ;; Keep as defvar until the frameset save/restore process works better.
-(defvar enable-frameset-restore t
+(defcustom enable-frameset-restore t
   "Set to t to enable restoring the last Emacs window size and position
-   upon startup.")
-  ;; :type 'boolean
-  ;; :group 'mrf-custom-toggles)
+   upon startup."
+  :type 'boolean
+  :group 'mrf-custom-toggles)
 
 ;;; --------------------------------------------------------------------------
 

--- a/init.el
+++ b/init.el
@@ -177,9 +177,9 @@ capability to persist undo history across Emacs sessions.
 
 Finally, the standard undo handler can also be chosen."
   :type '(radio
-         (const :tag "Vundo (default)" undo-handler-vundo)
-         (const :tag "Undo-tree" undo-handler-undo-tree)
-         (const :tag "Built-in" undo-handler-built-in))
+           (const :tag "Vundo (default)" undo-handler-vundo)
+           (const :tag "Undo-tree" undo-handler-undo-tree)
+           (const :tag "Built-in" undo-handler-built-in))
   :group 'mifi-custom-features)
 
 (defcustom completion-handler 'comphand-vertico
@@ -195,10 +195,10 @@ also includes Counsel. Counsel provides completion versions of common Emacs
 commands that are customised to make the best use of Ivy.  Swiper is an
 alternative to isearch that uses Ivy to show an overview of all matches."
   :type '(radio
-         (const :tag "Vertico completion system." comphand-vertico)
-         (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
-         (const :tag "Cofu completion systems" comphand-corfu)
-         (const :tag "Built-in Ido" comphand-built-in))
+           (const :tag "Vertico completion system." comphand-vertico)
+           (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
+           (const :tag "Cofu completion systems" comphand-corfu)
+           (const :tag "Built-in Ido" comphand-built-in))
   :group 'mifi-custom-features)
 
 (defcustom debug-adapter 'debug-adapter-dape
@@ -212,8 +212,8 @@ implemented entirely in Emacs Lisp. There are no other external dependencies
 with DAPE. DAPE supports most popular languages, however, not as many as
 dap-mode."
   :type '(radio
-         (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
-         (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
+           (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
+           (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
   :group 'mifi-custom-features)
 
 (defcustom custom-ide 'custom-ide-eglot
@@ -233,11 +233,11 @@ for which there is a language server and an Emacs major mode.
 Anaconda-mode is another IDE for Python very much like Elpy. It is not as
 configurable but has a host of great feaures that just work."
   :type '(radio
-         (const :tag "Elpy: Emacs Lisp Python Environment" custom-ide-elpy)
-         (const :tag "Emacs Polyglot (Eglot)" custom-ide-eglot)
-         (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
-         (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
-         (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
+           (const :tag "Elpy: Emacs Lisp Python Environment" custom-ide-elpy)
+           (const :tag "Emacs Polyglot (Eglot)" custom-ide-eglot)
+           (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
+           (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
+           (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
   :group 'mifi-custom-features)
 
 (defcustom custom-project-handler 'custom-project-project
@@ -349,11 +349,11 @@ font size is computed + 20 of this value."
 (defun mifi/validate-variable-pitch-font ()
   (let* ((variable-pitch-font
            (cond
-           ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
-           ((x-list-fonts "SF Pro")           "SF Pro")
-           ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
-           ((x-list-fonts "Ubuntu")           "Ubuntu")
-           ((x-list-fonts "Helvetica")        "Helvetica")
+             ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
+             ((x-list-fonts "SF Pro")           "SF Pro")
+             ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
+             ((x-list-fonts "Ubuntu")           "Ubuntu")
+             ((x-list-fonts "Helvetica")        "Helvetica")
              ((x-list-fonts "Source Sans Pro")  "Source Sans Pro")
              ((x-list-fonts "Lucida Grande")    "Lucida Grande")
              ((x-list-fonts "Verdana")          "Verdana")
@@ -361,7 +361,7 @@ font size is computed + 20 of this value."
              (nil (warn "Cannot find a Sans Serif Font.  Install Source Sans Pro.")))))
     (if variable-pitch-font
       (when (not (equal variable-pitch-font variable-pitch-font-family))
-      (setq variable-pitch-font-family variable-pitch-font))
+        (setq variable-pitch-font-family variable-pitch-font))
       (message "---- Can't find a variable-pitch font to use.")))
 
   (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
@@ -371,17 +371,17 @@ font size is computed + 20 of this value."
 (defun mifi/validate-monospace-font ()
   (let* ((monospace-font
            (cond
-           ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
-           ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
-           ((x-list-fonts "Fira Code")         "Fira Code")
-           ((x-list-fonts "Source Code Pro")   "Source Code Pro")
-           ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
+             ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
+             ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
+             ((x-list-fonts "Fira Code")         "Fira Code")
+             ((x-list-fonts "Source Code Pro")   "Source Code Pro")
+             ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
              ((x-family-fonts "Monospaced")      "Monospaced")
              (nil (warn "Cannot find a monospaced Font.  Install Source Code Pro.")))))
     (if monospace-font
       (when (not (equal monospace-font variable-pitch-font-family))
-      (setq mono-spaced-font-family monospace-font)
-      (setq default-font-family monospace-font))
+        (setq mono-spaced-font-family monospace-font)
+        (setq default-font-family monospace-font))
       (message "---- Can't find a monospace font to use.")))
 
   (message (format ">>> monospace font is %s" mono-spaced-font-family)))
@@ -428,11 +428,11 @@ font size is computed + 20 of this value."
     ;; Add every non-hidden subdir of PARENT-DIR to `load-path'.
     (let ((default-directory site-lisp-dir))
       (setq load-path
-          (append
-           (cl-remove-if-not
+        (append
+          (cl-remove-if-not
             #'file-directory-p
-             (directory-files (expand-file-name site-lisp-dir) t "^[^\\.]"))
-            load-path)))))
+            (directory-files (expand-file-name site-lisp-dir) t "^[^\\.]"))
+          load-path)))))
 
 ;;; ##########################################################################
 
@@ -456,9 +456,9 @@ font size is computed + 20 of this value."
   fill-column 79             ;; Default line limit for fills
   ;; Triggers project for directories with any of the following files:
   project-vc-extra-root-markers '(".dir-locals.el"
-                                 "requirements.txt"
-                                 "Gemfile"
-                                 "package.json"))
+                                   "requirements.txt"
+                                   "Gemfile"
+                                   "package.json"))
 
 ;;; ##########################################################################
 (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
@@ -467,9 +467,9 @@ font size is computed + 20 of this value."
 (setq history-delete-duplicates t)
 (setq savehist-save-minibuffer-history 1)
 (setq savehist-additional-variables
-      '(kill-ring
-        search-ring
-        regexp-search-ring))
+  '(kill-ring
+     search-ring
+     regexp-search-ring))
 
 ;;; ##########################################################################
 ;; (global-display-line-numbers-mode 1) ;; Line numbers appear everywhere
@@ -520,14 +520,14 @@ font size is computed + 20 of this value."
       ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
       (desktop-save-mode 0)
       (if (file-exists-p file)
-      (progn
-        (load file)
-        (desktop-restore-frameset)
-        (when (featurep 'spacious-padding)
+        (progn
+          (load file)
+          (desktop-restore-frameset)
+          (when (featurep 'spacious-padding)
             (when spacious-padding-mode
               (spacious-padding-mode 0)
               (spacious-padding-mode 1))))
-      (use-medium-display-font t)))))
+        (use-medium-display-font t)))))
 
 (setq register-preview-delay 0) ;; Show registers ASAP
 (set-register ?O (cons 'file (concat emacs-config-directory "emacs-config.org")))
@@ -595,9 +595,9 @@ font size is computed + 20 of this value."
 
 (use-package multiple-cursors
   :bind (("C-S-c C-S-c" . mc/edit-lines)
-        ("C->" . mc/mark-next-like-this)
-        ("C-<" . mc/mark-previous-like-this)
-        ("C-c C-<" . mc/mark-all-like-this)))
+          ("C->" . mc/mark-next-like-this)
+          ("C-<" . mc/mark-previous-like-this)
+          ("C-c C-<" . mc/mark-all-like-this)))
 
 ;;; ##########################################################################
 
@@ -631,10 +631,10 @@ font size is computed + 20 of this value."
 ;; Macintosh specific configurations.
 (when *is-a-mac*
   (setq mac-command-modifier       'meta
-        mac-option-modifier         nil
-        mac-control-modifier       'control
-        mac-right-command-modifier 'super
-        mac-right-control-modifier 'hyper))
+    mac-option-modifier         nil
+    mac-control-modifier       'control
+    mac-right-command-modifier 'super
+    mac-right-control-modifier 'hyper))
 
 ;;; ##########################################################################
 
@@ -708,7 +708,7 @@ font size is computed + 20 of this value."
 
 (use-package yasnippet
   :bind (:map yas-minor-mode-map
-        ("<C-'>" . yas-expand))
+          ("<C-'>" . yas-expand))
   :config
   (setq yas-global-mode t)
   (setq yas-minor-mode t)
@@ -773,7 +773,7 @@ font size is computed + 20 of this value."
   :ensure (:host github :repo "minad/jinx")
   ;;:hook (emacs-startup . global-jinx-mode)
   :bind (("C-c C-$" . jinx-correct)
-         ("C-x C-$" . jinx-languages))
+          ("C-x C-$" . jinx-languages))
   :config
   (dolist (hook '(text-mode-hook prog-mode-hook org-mode-hook))
     (add-hook hook #'jinx-mode)))
@@ -812,7 +812,7 @@ font size is computed + 20 of this value."
 (defun undo-tree-split-side-by-side (original-function &rest args)
   "Split undo-tree side-by-side"
   (let ((split-height-threshold nil)
-       (split-width-threshold 0))
+         (split-width-threshold 0))
     (apply original-function args)))
 
 ;;; ##########################################################################
@@ -948,13 +948,13 @@ font size is computed + 20 of this value."
   (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
   ;; Optionally use TAB for cycling, default is `corfu-complete'.
   :bind (:map corfu-map
-        ("M-SPC"          . corfu-insert-separator)
-        ("TAB"            . corfu-next)
-        ([tab]            . corfu-next)
-        ("S-TAB"          . corfu-previous)
-        ([backtab]    . corfu-previous)
-        ("S-<return>" . corfu-insert)
-        ("RET"            . nil))
+          ("M-SPC"          . corfu-insert-separator)
+          ("TAB"            . corfu-next)
+          ([tab]            . corfu-next)
+          ("S-TAB"          . corfu-previous)
+          ([backtab]    . corfu-previous)
+          ("S-<return>" . corfu-insert)
+          ("RET"            . nil))
   :init
   (global-corfu-mode)
   (corfu-history-mode)
@@ -962,8 +962,8 @@ font size is computed + 20 of this value."
   :config
   (add-hook 'eshell-mode-hook
     (lambda () (setq-local corfu-quit-at-boundary t
-               corfu-quit-no-match t
-               corfu-auto nil)
+                 corfu-quit-no-match t
+                 corfu-auto nil)
       (corfu-mode))))
 
 ;;; ##########################################################################
@@ -1032,8 +1032,8 @@ font size is computed + 20 of this value."
   ;; :bind ("C-x C-f" . ido-find-file)
   ;; Clean up file path when typing
   :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
-        ;; Make sure vertico state is saved
-        (minibuffer-setup . vertico-repeat-save)))
+          ;; Make sure vertico state is saved
+          (minibuffer-setup . vertico-repeat-save)))
 
 ;;; ##########################################################################
 
@@ -1097,9 +1097,9 @@ font size is computed + 20 of this value."
     '(consult--source-hidden-buffer 
        consult--source-buffer
        (:name "Ephemeral" :state consult--buffer-state
-       :narrow 109 :category buffer
-       :items ("*Messages*"  "*scratch*" "*vterm*"
-                "*Async-native-compile-log*" "*dashboard*"))
+         :narrow 109 :category buffer
+         :items ("*Messages*"  "*scratch*" "*vterm*"
+                  "*Async-native-compile-log*" "*dashboard*"))
        consult--source-modified-buffer
        consult--source-recent-file)))
 
@@ -1272,10 +1272,10 @@ font size is computed + 20 of this value."
 
 ;;; ##########################################################################
 
-  ;; Prefer g-prefixed coreutils version of standard utilities when available
+;; Prefer g-prefixed coreutils version of standard utilities when available
 (let ((gls (executable-find "gls")))
   (when gls (setq-default insert-directory-program gls
-            dired-use-ls-dired t
+              dired-use-ls-dired t
               ;; Needed to fix an issue on Mac which causes dired to fail
               dired-listing-switches "-al --group-directories-first")))
 
@@ -1289,7 +1289,7 @@ font size is computed + 20 of this value."
   ;; Doesn't work as expected!
   ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
   (setq dired-open-extensions '(("png" . "feh")
-                               ("mkv" . "mpv"))))
+                                 ("mkv" . "mpv"))))
 
 (use-package dired-hide-dotfiles
   :after dired-mode
@@ -1353,8 +1353,8 @@ font size is computed + 20 of this value."
     treemacs-no-delete-other-windows   t
     treemacs-project-follow-cleanup            nil
     treemacs-persist-file                      (expand-file-name
-                                                   ".cache/treemacs-persist"
-                                                   user-emacs-directory)
+                                                 ".cache/treemacs-persist"
+                                                 user-emacs-directory)
     treemacs-position                  'left
     treemacs-read-string-input                 'from-child-frame
     treemacs-recenter-distance                 0.1
@@ -1363,9 +1363,9 @@ font size is computed + 20 of this value."
     treemacs-recenter-after-project-jump       'always
     treemacs-recenter-after-project-expand     'on-distance
     treemacs-litter-directories                '("/node_modules"
-                                            "/.venv"
-                                            "/.cask"
-                                            "/__pycache__")
+                                                  "/.venv"
+                                                  "/.cask"
+                                                  "/__pycache__")
     treemacs-project-follow-into-home  nil
     treemacs-show-cursor                       nil
     treemacs-show-hidden-files                 t
@@ -1467,11 +1467,11 @@ font size is computed + 20 of this value."
   (when (not (eq theme-cycle-step nil))
     (let ((step theme-cycle-step) (result 0))
       (when step
-      (setq result (+ step theme-selector))
-      (when (< result 0)
-        (setq result (- (length theme-list) 1)))
-      (when (> result (- (length theme-list) 1))
-        (setq result 0)))
+        (setq result (+ step theme-selector))
+        (when (< result 0)
+          (setq result (- (length theme-list) 1)))
+        (when (> result (- (length theme-list) 1))
+          (setq result 0)))
       (setq-default theme-selector result))))
 
 ;; This is used to trigger the cycling of the theme-selector
@@ -1603,14 +1603,14 @@ font size is computed + 20 of this value."
   (progn
     (if (not elpaca-after-init-time)
       (add-hook 'elpaca-after-init-hook
-      (lambda ()
-        (unless theme-did-load
-          (mifi/load-theme-from-selector))))
+        (lambda ()
+          (unless theme-did-load
+            (mifi/load-theme-from-selector))))
       ;; else
       (add-hook 'window-setup-hook
-      (lambda ()
-        (unless theme-did-load
-          (mifi/load-theme-from-selector))))
+        (lambda ()
+          (unless theme-did-load
+            (mifi/load-theme-from-selector))))
       )))
 
 ;;; ##########################################################################
@@ -1734,9 +1734,9 @@ font size is computed + 20 of this value."
     (when (display-graphic-p)
       (mifi/update-face-attribute)
       (unless (daemonp)
-      (if enable-frameset-restore
+        (if enable-frameset-restore
           (mifi/restore-desktop-frameset)
-        (mifi/frame-recenter)))
+          (mifi/frame-recenter)))
       )))
 
 ;;; ##########################################################################
@@ -1757,27 +1757,27 @@ font size is computed + 20 of this value."
   (cond
     ((equal mifi/font-size-slot 3)
       (setq custom-default-font-size mifi/x-large-font-size
-            custom-default-mono-font-size mifi/x-large-mono-font-size
-            mifi/default-variable-font-size (+ custom-default-font-size 20)
-            mifi/font-size-slot 2)
+        custom-default-mono-font-size mifi/x-large-mono-font-size
+        mifi/default-variable-font-size (+ custom-default-font-size 20)
+        mifi/font-size-slot 2)
       (mifi/update-face-attribute))
     ((equal mifi/font-size-slot 2)
       (setq custom-default-font-size mifi/large-font-size
-            custom-default-mono-font-size mifi/large-mono-font-size
-            mifi/default-variable-font-size (+ custom-default-font-size 20)
-            mifi/font-size-slot 1)
+        custom-default-mono-font-size mifi/large-mono-font-size
+        mifi/default-variable-font-size (+ custom-default-font-size 20)
+        mifi/font-size-slot 1)
       (mifi/update-face-attribute))
     ((equal mifi/font-size-slot 1)
       (setq custom-default-font-size mifi/medium-font-size
-            custom-default-mono-font-size mifi/medium-mono-font-size
-            mifi/default-variable-font-size (+ custom-default-font-size 20)
-            mifi/font-size-slot 0)
+        custom-default-mono-font-size mifi/medium-mono-font-size
+        mifi/default-variable-font-size (+ custom-default-font-size 20)
+        mifi/font-size-slot 0)
       (mifi/update-face-attribute))
     ((equal mifi/font-size-slot 0)
       (setq custom-default-font-size mifi/small-font-size
-            custom-default-mono-font-size mifi/small-mono-font-size
-            mifi/default-variable-font-size (+ custom-default-font-size 20)
-            mifi/font-size-slot 3)
+        custom-default-mono-font-size mifi/small-mono-font-size
+        mifi/default-variable-font-size (+ custom-default-font-size 20)
+        mifi/font-size-slot 3)
       (mifi/update-face-attribute))))
 
 ;;; ##########################################################################
@@ -1801,7 +1801,7 @@ font size is computed + 20 of this value."
   (which-key-add-key-based-replacements "C-S-c 2" "recenter-with-medium-font")
   (which-key-add-key-based-replacements "C-S-c 3" "recenter-with-large-font")
   (which-key-add-key-based-replacements "C-S-c 4" "recenter-with-x-large-font")
-)
+  )
 
 ;;; ##########################################################################
 ;; Frame support functions
@@ -1849,8 +1849,8 @@ font size is computed + 20 of this value."
   (add-hook 'elpaca-after-init-hook
     (lambda ()
       (progn
-      (mifi/update-face-attribute)
-      (unless (daemonp)
+        (mifi/update-face-attribute)
+        (unless (daemonp)
           (unless enable-frameset-restore (mifi/frame-recenter))))
       )))
 
@@ -2031,31 +2031,31 @@ font size is computed + 20 of this value."
   (setq org-capture-templates
     `(("t" "Tasks / Projects")
        ("tt" "Task" entry (file+olp "~/Projects/Code/emacs-from-scratch/OrgFiles/Tasks.org" "Inbox")
-       "* TODO %?\n  %U\n  %a\n        %i" :empty-lines 1)
+         "* TODO %?\n  %U\n  %a\n        %i" :empty-lines 1)
 
        ("j" "Journal Entries")
        ("jj" "Journal" entry
-       (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-       "\n* %<%I:%M %p> - Journal :journal:\n\n%?\n\n"
-       ;; ,(dw/read-file-as-string "~/Notes/Templates/Daily.org")
-       :clock-in :clock-resume
-       :empty-lines 1)
+         (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+         "\n* %<%I:%M %p> - Journal :journal:\n\n%?\n\n"
+         ;; ,(dw/read-file-as-string "~/Notes/Templates/Daily.org")
+         :clock-in :clock-resume
+         :empty-lines 1)
        ("jm" "Meeting" entry
-       (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-       "* %<%I:%M %p> - %a :meetings:\n\n%?\n\n"
-       :clock-in :clock-resume
-       :empty-lines 1)
+         (file+olp+datetree "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+         "* %<%I:%M %p> - %a :meetings:\n\n%?\n\n"
+         :clock-in :clock-resume
+         :empty-lines 1)
 
        ("w" "Workflows")
        ("we" "Checking Email" entry (file+olp+datetree
-                                    "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
-       "* Checking Email :email:\n\n%?" :clock-in :clock-resume :empty-lines 1)
+                                      "~/Projects/Code/emacs-from-scratch/OrgFiles/Journal.org")
+         "* Checking Email :email:\n\n%?" :clock-in :clock-resume :empty-lines 1)
 
        ("m" "Metrics Capture")
        ("mw" "Weight" table-line (file+headline
-                                 "~/Projects/Code/emacs-from-scratch/OrgFiles/Metrics.org"
-                                 "Weight")
-       "| %U | %^{Weight} | %^{Notes} |" :kill-buffer t))))
+                                   "~/Projects/Code/emacs-from-scratch/OrgFiles/Metrics.org"
+                                   "Weight")
+         "| %U | %^{Weight} | %^{Notes} |" :kill-buffer t))))
 
 (defun mifi/org-setup-todos ()
   "Setup the org TODO keywords and colors."
@@ -2077,19 +2077,19 @@ font size is computed + 20 of this value."
        ("CANCELLED" :inherit (region org-todo) :foreground "green4"   :weight bold))))
 
 (custom-theme-set-faces
- 'user
- '(org-block ((t (:inherit fixed-pitch))))
- '(org-code ((t (:inherit (shadow fixed-pitch)))))
- '(org-document-info ((t (:foreground "dark orange"))))
- '(org-document-info-keyword ((t (:inherit (shadow fixed-pitch)))))
- '(org-indent ((t (:inherit (org-hide fixed-pitch)))))
- '(org-link ((t (:foreground "royal blue" :underline t))))
- '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
- '(org-property-value ((t (:inherit fixed-pitch))) t)
- '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
- '(org-table ((t (:inherit fixed-pitch :foreground "#83a598"))))
- '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
- '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
+  'user
+  '(org-block ((t (:inherit fixed-pitch))))
+  '(org-code ((t (:inherit (shadow fixed-pitch)))))
+  '(org-document-info ((t (:foreground "dark orange"))))
+  '(org-document-info-keyword ((t (:inherit (shadow fixed-pitch)))))
+  '(org-indent ((t (:inherit (org-hide fixed-pitch)))))
+  '(org-link ((t (:foreground "royal blue" :underline t))))
+  '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+  '(org-property-value ((t (:inherit fixed-pitch))) t)
+  '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+  '(org-table ((t (:inherit fixed-pitch :foreground "#83a598"))))
+  '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
+  '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
 
 ;;; ##########################################################################
 
@@ -2143,25 +2143,25 @@ font size is computed + 20 of this value."
     'org-babel-load-languages
     (seq-filter
       (lambda (pair)
-      (locate-library (concat "ob-" (symbol-name (car pair)))))
+        (locate-library (concat "ob-" (symbol-name (car pair)))))
       '((emacs-lisp . t)
-       (ditaa . t)
-       (dot . t)
-       (emacs-lisp . t)
-       (gnuplot . t)
-       (haskell . nil)
-       (latex . t)
-       (ledger . t)
-       (ocaml . nil)
-       (octave . t)
-       (plantuml . t)
-       (python . t)
-       (ruby . t)
-       (screen . nil)
-       (sh . t) ;; obsolete
-       (shell . t)
-       (sql . t)
-       (sqlite . t))))
+         (ditaa . t)
+         (dot . t)
+         (emacs-lisp . t)
+         (gnuplot . t)
+         (haskell . nil)
+         (latex . t)
+         (ledger . t)
+         (ocaml . nil)
+         (octave . t)
+         (plantuml . t)
+         (python . t)
+         (ruby . t)
+         (screen . nil)
+         (sh . t) ;; obsolete
+         (shell . t)
+         (sql . t)
+         (sqlite . t))))
   (push '("conf-unix" . conf-unix) org-src-lang-modes))
 
 ;;; ##########################################################################
@@ -2182,8 +2182,8 @@ font size is computed + 20 of this value."
     '((right-divider-width . 40)
        (internal-border-width . 40)))
   (dolist (face '(window-divider
-                 window-divider-first-pixel
-                 window-divider-last-pixel))
+                   window-divider-first-pixel
+                   window-divider-last-pixel))
     (face-spec-reset-face face)
     (set-face-foreground face (face-attribute 'default :background nil)))
   (set-face-background 'fringe (face-attribute 'default :background nil))
@@ -2484,8 +2484,8 @@ font size is computed + 20 of this value."
 (use-package lsp-bridge
   :when (equal custom-ide 'custom-ide-lsp-bridge)
   :ensure ( :host github :repo "manateelazycat/lsp-bridge"
-          :files (:defaults "*.el" "*.py" "acm" "core" "langserver"
-                   "multiserver" "resources") :build (:not compile))
+            :files (:defaults "*.el" "*.py" "acm" "core" "langserver"
+                     "multiserver" "resources") :build (:not compile))
   :custom
   (lsp-bridge-python-lsp-server "pylsp")
   :config
@@ -2501,9 +2501,9 @@ font size is computed + 20 of this value."
 (use-package anaconda-mode
   :when (equal custom-ide 'custom-ide-anaconda)
   :bind (:map python-mode-map
-        ("C-c g o" . anaconda-mode-find-definitions-other-frame)
-        ("C-c g g" . anaconda-mode-find-definitions)
-        ("C-c C-x" . next-error))
+          ("C-c g o" . anaconda-mode-find-definitions-other-frame)
+          ("C-c g g" . anaconda-mode-find-definitions)
+          ("C-c C-x" . next-error))
   :config
   (which-key-add-key-based-replacements "C-c g o" "find-defitions-other-window")
   (which-key-add-key-based-replacements "C-c g g" "find-defitions")
@@ -2524,10 +2524,10 @@ font size is computed + 20 of this value."
   (display-fill-column-indicator-mode 1)
   (highlight-indentation-mode nil)
   :bind (:map python-mode-map
-        ("C-c g a" . elpy-goto-assignment)
-        ("C-c g o" . elpy-goto-definition-other-window)
-        ("C-c g g" . elpy-goto-definition)
-        ("C-c g ?" . elpy-doc))
+          ("C-c g a" . elpy-goto-assignment)
+          ("C-c g o" . elpy-goto-definition-other-window)
+          ("C-c g g" . elpy-goto-definition)
+          ("C-c g ?" . elpy-doc))
   :config
   (use-package jedi)
   (use-package flycheck
@@ -2721,6 +2721,10 @@ font size is computed + 20 of this value."
 (defalias 'quote-region
   (kmacro "C-w \" \" <left> C-y <right>"))
 
+(defalias 're-format-src-block
+  (kmacro "C-s b e g i n _ s r c SPC e m a c s - l i s p <return> <down> C-c ' C-x h C-c ] C-x h M-x u n t a b <return> C-c ' C-s e n d _ s r c <return> <down>"))
+
+
 (eval-after-load "python"
   #'(bind-keys :map python-mode-map
       ("C-c C-q" . quote-region)
@@ -2755,11 +2759,11 @@ font size is computed + 20 of this value."
   (cond
     ((equal debug-adapter 'debug-adapter-dap-mode)
       (bind-keys :map typescript-mode-map
-      ("C-c ." . dap-hydra/body))
+        ("C-c ." . dap-hydra/body))
       (dap-node-setup))
     ((equal debug-adapter 'debug-adapter-dape)
       (bind-keys :map typescript-mode-map
-      ("C-c ." . dape-hydra/body)))))
+        ("C-c ." . dape-hydra/body)))))
 
 ;;; ##########################################################################
 
@@ -2789,8 +2793,8 @@ font size is computed + 20 of this value."
 (use-package js2-mode
   :hook (js-mode . js2-minor-mode)
   :bind (:map js2-mode-map
-        ("{" . paredit-open-curly)
-        ("}" . paredit-close-curly-and-newline))
+          ("{" . paredit-open-curly)
+          ("}" . paredit-close-curly-and-newline))
   :mode ("\\.js\\'" "\\.mjs\\'" "\\.json$")
   :custom (js2-highlight-level 3))
 
@@ -2813,10 +2817,10 @@ font size is computed + 20 of this value."
   (unless (file-exists-p "Makefile")
     (set (make-local-variable 'compile-command)
       (let ((file (file-name-nondirectory buffer-file-name)))
-      (format "%s -o %s %s"
-        (if  (equal (file-name-extension file) "cpp") "g++" "gcc" )
-        (file-name-sans-extension file)
-        file)))
+        (format "%s -o %s %s"
+          (if  (equal (file-name-extension file) "cpp") "g++" "gcc" )
+          (file-name-sans-extension file)
+          file)))
     (compile compile-command)))
 
 (global-set-key [f9] 'code-compile)
@@ -2898,12 +2902,12 @@ font size is computed + 20 of this value."
   :defer t
   :after rust-mode
   :ensure (:fetcher github :repo "ayrat555/cargo-mode"
-          :files ("*.el" "*.el.in" "dir" "*.info" "*.texi"
-                   "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
-                   "doc/*.texinfo" "lisp/*.el"
-                   (:exclude ".dir-locals.el" "test.el" "tests.el"
-                     "*-test.el" "*-tests.el" "LICENSE" "README*"
-                     "*-pkg.el"))))
+            :files ("*.el" "*.el.in" "dir" "*.info" "*.texi"
+                     "*.texinfo" "doc/dir" "doc/*.info" "doc/*.texi"
+                     "doc/*.texinfo" "lisp/*.el"
+                     (:exclude ".dir-locals.el" "test.el" "tests.el"
+                       "*-test.el" "*-tests.el" "LICENSE" "README*"
+                       "*-pkg.el"))))
 
 ;;; ##########################################################################
 
@@ -2916,7 +2920,7 @@ font size is computed + 20 of this value."
   :custom
   (compile-command "go build -v && go test -v && go vet")
   :bind (:map go-mode-map
-        ("C-c C-c" . 'compile))
+          ("C-c C-c" . 'compile))
   :config
   (eglot-format-buffer-on-save)
   (define-key (current-local-map) "\C-c\C-c" 'compile)
@@ -2996,16 +3000,16 @@ font size is computed + 20 of this value."
   (with-eval-after-load
     (add-to-list 'dape-configs
       `(delve
-       modes (go-mode go-ts-mode)
-       command "dlv"
-       command-args ("dap" "--listen" "127.0.0.1:55878")
-       command-cwd dape-cwd-fn
-       host "127.0.0.1"
-       port 55878
-       :type "debug"  ;; needed to set the adapterID correctly as a string type
-       :request "launch"
-       :cwd dape-cwd-fn
-       :program dape-cwd-fn))))
+         modes (go-mode go-ts-mode)
+         command "dlv"
+         command-args ("dap" "--listen" "127.0.0.1:55878")
+         command-cwd dape-cwd-fn
+         host "127.0.0.1"
+         port 55878
+         :type "debug"  ;; needed to set the adapterID correctly as a string type
+         :request "launch"
+         :cwd dape-cwd-fn
+         :program dape-cwd-fn))))
 
 ;;; ##########################################################################
 
@@ -3127,8 +3131,8 @@ font size is computed + 20 of this value."
   :defer t
   :after dap-mode
   :ensure (:package "dap-cpptools" :source nil :protocol https :inherit t :depth 1 :type git :host github :repo "emacs-lsp/dap-mode"))
-  ;; :config
-  ;; (dap-cpptools-setup))
+;; :config
+;; (dap-cpptools-setup))
 
 ;;; ##########################################################################
 
@@ -3265,18 +3269,18 @@ font size is computed + 20 of this value."
   :config
   ;; window on the right side
   (add-to-list 'display-buffer-alist '(,mw-thesaurus-buffer-name
-                                      (display-buffer-reuse-window
-                                        display-buffer-in-direction)
-                                      (direction . right)
-                                      (window . root)
-                                      (window-width . 0.3))))
+                                        (display-buffer-reuse-window
+                                          display-buffer-in-direction)
+                                        (direction . right)
+                                        (window . root)
+                                        (window-width . 0.3))))
 
 ;;; ##########################################################################
 
 (use-package solaire-mode
   :after treemacs
   :ensure (:package "solaire-mode" :source "MELPA"
-         :repo "hlissner/emacs-solaire-mode" :fetcher github)
+            :repo "hlissner/emacs-solaire-mode" :fetcher github)
   :hook (elpaca-after-init . solaire-global-mode)
   :config
   (push '(treemacs-window-background-face . solaire-default-face) solaire-mode-remap-alist)
@@ -3293,19 +3297,19 @@ font size is computed + 20 of this value."
   (golden-ratio-wide-adjust-factor .4)
   (golden-ratio-max-width 100)
   (golden-ratio-exclude-modes '(
-                               prog-mode
-                               dashboard-mode
-                               ;;inferior-emacs-lisp-mode
-                               ;;inferior-python-mode
-                               comint-mode
-                               ;;lisp-interaction-mode
-                               treemacs-mode
-                               undo-tree-visualizer-mode
-                               vundo-mode
-                               ))
+                                 prog-mode
+                                 dashboard-mode
+                                 ;;inferior-emacs-lisp-mode
+                                 ;;inferior-python-mode
+                                 comint-mode
+                                 ;;lisp-interaction-mode
+                                 treemacs-mode
+                                 undo-tree-visualizer-mode
+                                 vundo-mode
+                                 ))
   (golden-ratio-exclude-buffer-regexp '("dap*"
-                                       "*dape*"
-                                       "*python*"))
+                                         "*dape*"
+                                         "*python*"))
   :config
   (golden-ratio-mode 1))
 
@@ -3313,9 +3317,9 @@ font size is computed + 20 of this value."
 
 (use-package buffer-move
   :bind (("C-S-<up>"     . buf-move-up)
-        ("C-S-<down>"  . buf-move-down)
-        ("C-S-<left>"  . buf-move-left)
-        ("C-S-<right>" . buf-move-right)))
+          ("C-S-<down>"  . buf-move-down)
+          ("C-S-<left>"  . buf-move-left)
+          ("C-S-<right>" . buf-move-right)))
 
 ;;; ##########################################################################
 
@@ -3336,7 +3340,7 @@ font size is computed + 20 of this value."
   (centaur-tabs-set-icons t)
   (centaur-tabs-set-modified-marker t)
   :bind (("C-c <" . centaur-tabs-backward)
-        ("C-c >" . centaur-tabs-forward))
+          ("C-c >" . centaur-tabs-forward))
   :config ;; Enable centaur-tabs
   (centaur-tabs-mode t))
 
@@ -3430,18 +3434,18 @@ font size is computed + 20 of this value."
   (when winframe
     (let ((map mmm-keys-minor-mode-map))
       (when enable-thesaurus
-      (bind-keys :map map
+        (bind-keys :map map
           ("M-RET m t" . mw-thesaurus-lookup-dwim)))
       (cond
-      ((equal major-mode 'org-mode)
+        ((equal major-mode 'org-mode)
           (bind-keys :map map
             ("M-RET M-RET" . org-insert-heading)
             ("M-RET o f" . mifi/set-org-fill-column-interactively)
             ("M-RET o l" . org-toggle-link-display)))
-      ((equal major-mode 'python-mode)
+        ((equal major-mode 'python-mode)
           (bind-keys :map map
             ("M-RET P" . 'pydoc-at-point)))
-      (t   ;; Default 
+        (t   ;; Default 
           (unbind-key "M-RET o f" map)
           (unbind-key "M-RET o l" map)
           (unbind-key "M-RET P ?" map)
@@ -3488,15 +3492,15 @@ font size is computed + 20 of this value."
   (lambda ()
     (setq-default initial-scratch-message
       (format
-      ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
-      ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
+        ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
+        ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
     (when dashboard-landing-screen (dashboard-open))))
 
 (when dashboard-landing-screen
   ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
   (add-hook 'elpaca-after-init-hook
-      (lambda ()
-        (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
+    (lambda ()
+      (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
 
 ;;; ##########################################################################
 
@@ -3507,9 +3511,9 @@ font size is computed + 20 of this value."
     (copy-file
       (expand-file-name "init.el" emacs-config-directory)
       (expand-file-name "init.el" backdir) t)))
-    ;; (copy-file
-    ;;   (expand-file-name "emacs-config.org" emacs-config-directory)
-    ;;   (expand-file-name "emacs-config.org" backdir) t)))
+;; (copy-file
+;;   (expand-file-name "emacs-config.org" emacs-config-directory)
+;;   (expand-file-name "emacs-config.org" backdir) t)))
 
 (add-hook 'kill-emacs-hook #'mifi/cleanup-when-exiting)
 

--- a/init.el
+++ b/init.el
@@ -277,12 +277,12 @@ If additional themes are added, they must be previously installed."
   :type 'natnum)
 
 ;;; Font related
-(defcustom default-font-family "Fira Code Retina"
+(defcustom default-font-family "Menlo"
   "The font family used as the default font."
   :type 'string
   :group 'mifi-custom-fonts)
 
-(defcustom mono-spaced-font-family "Fira Code Retina"
+(defcustom mono-spaced-font-family "Andale Mono"
   "The font family used as the mono-spaced font."
   :type 'string
   :group 'mifi-custom-fonts)
@@ -416,6 +416,21 @@ font size is computed + 20 of this value."
 
 (add-to-list 'load-path (expand-file-name "lisp" emacs-config-directory))
 (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
+
+;;; ##########################################################################
+
+;; Add both site-lisp and its immediate subdirs to `load-path'
+(let ((site-lisp-dir (expand-file-name "site-lisp/" emacs-config-directory)))
+  (when (file-directory-p site-lisp-dir)
+    (push site-lisp-dir load-path)
+    ;; Add every non-hidden subdir of PARENT-DIR to `load-path'.
+    (let ((default-directory site-lisp-dir))
+      (setq load-path
+          (append
+           (cl-remove-if-not
+            #'file-directory-p
+             (directory-files (expand-file-name site-lisp-dir) t "^[^\\.]"))
+            load-path)))))
 
 ;;; ##########################################################################
 
@@ -719,8 +734,31 @@ font size is computed + 20 of this value."
 ;;; Window Number
 
 (use-package winum
-  ;;:ensure (:host github :repo "deb0ch/emacs-winum")
+  ;; :vc syntax below works, just for testing. Elpaca handles it for now.
+  ;; :vc ( :url "https://github.com/deb0ch/emacs-winum"
+  ;; 	:branch "master"
+  ;; 	:main-file "winum.el")
   :config (winum-mode))
+
+;;; ##########################################################################
+
+(use-package dashboard
+  :custom
+  (dashboard-items '(   (recents . 15)
+                      (bookmarks . 10)
+                      (projects . 10)))
+  (dashboard-center-content t)
+  (dashboard-set-heading-icons t)
+  (dashboard-set-file-icons t)
+  (dashboard-footer-messages '("Greetings Program!"))
+  (dashboard-banner-logo-title "Welcome to Emacs!")
+  (dashboard-startup-banner 'logo)
+  :bind ("C-c d" . dashboard-open)
+  :config
+  ;; (setq initial-buffer-choice (lambda () (get-buffer-create dashboard-buffer-name)))
+  (add-hook 'elpaca-after-init-hook #'dashboard-insert-startupify-lists)
+  (add-hook 'elpaca-after-init-hook #'dashboard-initialize)
+  (dashboard-setup-startup-hook))
 
 ;;; ##########################################################################
 (use-package jinx
@@ -733,6 +771,8 @@ font size is computed + 20 of this value."
     (add-hook hook #'jinx-mode)))
 
 ;;; ##########################################################################
+;; These are packages located in the site-lisp or lisp directories in the
+;; 'emacs-config-directory'
 
 ;;; ##########################################################################
 
@@ -1256,6 +1296,131 @@ font size is computed + 20 of this value."
   (mifi/dired-single-keymap-init))
 
 ;;; ##########################################################################
+;;; Treemacs
+
+(use-package treemacs
+  :after (:all winum ace-window)
+  :bind (:map global-map
+          ("M-0"         . treemacs-select-window)
+          ("C-x t 1"   . treemacs-delete-other-windows)
+          ("C-x t t"   . treemacs)
+          ("C-x t d"   . treemacs-select-directory)
+          ("C-x t B"   . treemacs-bookmark)
+          ("C-x t C-t" . treemacs-find-file)
+          ("C-x t M-t" . treemacs-find-tag))
+  :config
+  (setq treemacs-collapse-dirs                  (if treemacs-python-executable 3 0)
+    treemacs-deferred-git-apply-delay  0.5
+    treemacs-directory-name-transformer        #'identity
+    treemacs-display-in-side-window            t
+    treemacs-eldoc-display                     'simple
+    treemacs-file-event-delay          2000
+    treemacs-file-extension-regex              treemacs-last-period-regex-value
+    treemacs-file-follow-delay                 0.2
+    treemacs-file-name-transformer             #'identity
+    treemacs-follow-after-init                 t
+    treemacs-expand-after-init                 t
+    treemacs-find-workspace-method             'find-for-file-or-pick-first
+    treemacs-git-command-pipe          ""
+    treemacs-goto-tag-strategy                 'refetch-index
+    treemacs-header-scroll-indicators  '(nil . "^^^^^^")
+    treemacs-hide-dot-git-directory            t
+    treemacs-indentation                       2
+    treemacs-indentation-string                " "
+    treemacs-is-never-other-window             nil
+    treemacs-max-git-entries           5000
+    treemacs-missing-project-action            'ask
+    treemacs-move-forward-on-expand            nil
+    treemacs-no-png-images                     nil
+    treemacs-no-delete-other-windows   t
+    treemacs-project-follow-cleanup            nil
+    treemacs-persist-file                      (expand-file-name
+                                                   ".cache/treemacs-persist"
+                                                   user-emacs-directory)
+    treemacs-position                  'left
+    treemacs-read-string-input                 'from-child-frame
+    treemacs-recenter-distance                 0.1
+    treemacs-recenter-after-file-follow        nil
+    treemacs-recenter-after-tag-follow         nil
+    treemacs-recenter-after-project-jump       'always
+    treemacs-recenter-after-project-expand     'on-distance
+    treemacs-litter-directories                '("/node_modules"
+                                            "/.venv"
+                                            "/.cask"
+                                            "/__pycache__")
+    treemacs-project-follow-into-home  nil
+    treemacs-show-cursor                       nil
+    treemacs-show-hidden-files                 t
+    treemacs-silent-filewatch          nil
+    treemacs-silent-refresh                    nil
+    treemacs-sorting                   'alphabetic-asc
+    treemacs-select-when-already-in-treemacs 'move-back
+    treemacs-space-between-root-nodes  t
+    treemacs-tag-follow-cleanup                t
+    treemacs-tag-follow-delay          1.5
+    treemacs-text-scale                        nil
+    treemacs-user-mode-line-format             nil
+    treemacs-user-header-line-format   nil
+    treemacs-wide-toggle-width                 70
+    treemacs-width                             38
+    treemacs-width-increment           1
+    treemacs-width-is-initially-locked         t
+    treemacs-workspace-switch-cleanup  nil)
+
+  ;; The default width and height of the icons is 22 pixels. If you are
+  ;; using a Hi-DPI display, uncomment this to double the icon size.
+  ;;(treemacs-resize-icons 44)
+
+  (treemacs-follow-mode t)
+  (treemacs-filewatch-mode t)
+  (treemacs-fringe-indicator-mode 'always)
+  (when treemacs-python-executable
+    (treemacs-git-commit-diff-mode t))
+  (pcase (cons (not (null (executable-find "git")))
+           (not (null treemacs-python-executable)))
+    (`(t . t)
+      (treemacs-git-mode 'deferred))
+    (`(t . _)
+      (treemacs-git-mode 'simple)))
+  (treemacs-hide-gitignored-files-mode nil))
+
+;;; ##########################################################################
+
+(use-package treemacs-projectile
+  :when (equal custom-project-handler 'custom-project-projectile)
+  :after treemacs projectile)
+
+;;; ##########################################################################
+
+(use-package treemacs-icons-dired
+  :after treemacs
+  :hook (dired-mode . treemacs-icons-dired-enable-once))
+
+;;; ##########################################################################
+
+;; (use-package treemacs-perspective
+;;    :disabled
+;;    :after (treemacs persp-mode) ;;or perspective vs. persp-mode
+;;    :config (treemacs-set-scope-type 'Perspectives))
+
+(use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
+  ;;:ensure (:files ("src/extra/treemacs-persp.el" "treemacs-persp-pkg.el"):host github :repo "Alexander-Miller/treemacs")
+  :after (:any treemacs persp-mode) ;;or perspective vs. persp-mode
+  :config (treemacs-set-scope-type 'Perspectives))
+
+;;; ##########################################################################
+
+(use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
+  :after treemacs
+  :config (treemacs-set-scope-type 'Tabs))
+
+;;; ##########################################################################
+
+(use-package treemacs-all-the-icons
+  :after treemacs
+  :if (display-graphic-p))
+
+;;; ##########################################################################
 
 ;;
 ;; 1. The function `mifi/load-theme-from-selector' is called from the
@@ -1355,7 +1520,7 @@ font size is computed + 20 of this value."
     "Face used for the line delimiting the begin of source blocks.")
 
   (defface org-block
-    '((t (:background "#242635" :extend t :font "Fira Code Retina")))
+    '((t (:background "#242635" :extend t :font "Avenir Next")))
     "Face used for the source block background.")
 
   (defface org-block-end-line
@@ -1525,6 +1690,7 @@ font size is computed + 20 of this value."
 
 (defun mifi/update-face-attribute ()
   "Set the font faces."
+  (interactive)
   ;; ====================================
   (set-face-attribute 'default nil
     :family default-font-family
@@ -1612,7 +1778,12 @@ font size is computed + 20 of this value."
   (define-key map (kbd "C-S-c 3")
     (lambda () (interactive) (use-large-display-font t)))
   (define-key map (kbd "C-S-c 4")
-    (lambda () (interactive) (use-x-large-display-font t))))
+    (lambda () (interactive) (use-x-large-display-font t)))
+  (which-key-add-key-based-replacements "C-S-c 1" "recenter-with-small-font")
+  (which-key-add-key-based-replacements "C-S-c 2" "recenter-with-medium-font")
+  (which-key-add-key-based-replacements "C-S-c 3" "recenter-with-large-font")
+  (which-key-add-key-based-replacements "C-S-c 4" "recenter-with-x-large-font")
+)
 
 ;;; ##########################################################################
 ;; Frame support functions
@@ -1653,16 +1824,16 @@ font size is computed + 20 of this value."
   (mifi/set-frame-font 3)
   (mifi/should-recenter force-recenter))
 
-
+;;; ##########################################################################
 ;; This is done so that the Emacs window is sized early in the init phase along with the default font size.
 ;; Startup works without this but it's nice to see the window expand early...
 (when (display-graphic-p)
   (add-hook 'elpaca-after-init-hook
     (lambda ()
       (progn
-      (mifi/update-face-attribute)
-      (unless (daemonp)
-        (unless enable-frameset-restore (mifi/frame-recenter))))
+	(mifi/update-face-attribute)
+	(unless (daemonp)
+          (unless enable-frameset-restore (mifi/frame-recenter))))
       )))
 
 ;;; ##########################################################################
@@ -1948,39 +2119,6 @@ font size is computed + 20 of this value."
 
 ;;; ##########################################################################
 
-  (use-package org-superstar
-    :after org
-    :custom
-    (org-superstar-leading-bullet " ")
-    (org-superstar-special-todo-items t)
-    (org-superstar-todo-bullet-alist '( ("TODO" . 9744)
-                                    ("INPROG-TODO" . 9744)
-                                    ("HW" . 9744)
-                                    ("STUDY" . 9744)
-                                    ("SOMEDAY" . 9744)
-                                    ("READ" . 9744)
-                                    ("PROJ" . 9744)
-                                    ("CONTACT" . 9744)
-                                    ("DONE" . 9745)))
-    ;; (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
-    :hook (org-mode . org-superstar-mode))
-
-  (use-package org-appear
-    :init
-    (setq org-hide-emphasis-markers t)
-    (setq org-appear-autoemphasis t) ;; Enable org-appear on emphasis
-    (setq org-appear-autolinks t) ;; Enable on links
-    (setq org-appear-autosubmarkers t) ;; Enable on sub and superscript
-    :commands (org-appear-mode)
-    :hook (or-mode . org-appear-mode))
-
-;; Automatically change bullet type when indenting
-;; Ex: indenting a + makes the bullet a *.
-(setq org-list-demote-modify-bullet
-'(("+" ・ "*"）（"*" ・ "-"）（"-" . "+")))
-
-;;; ##########################################################################
-
 (with-eval-after-load 'org
   (org-babel-do-load-languages
     'org-babel-load-languages
@@ -2014,6 +2152,45 @@ font size is computed + 20 of this value."
   (add-to-list 'org-structure-template-alist '("sh" . "src shell"))
   (add-to-list 'org-structure-template-alist '("el" . "src emacs-lisp"))
   (add-to-list 'org-structure-template-alist '("py" . "src python")))
+
+(use-package org-modern
+  :when (display-graphic-p)
+  :after org
+  :hook (org-mode . org-modern-mode)
+  :config
+  ;; Add frame borders and window dividers
+  ;; (modify-all-frames-parameters
+  ;;   '((right-divider-width . 40)
+  ;;      (internal-border-width . 40)))
+  ;; (dolist (face '(window-divider
+  ;; 		   window-divider-first-pixel
+  ;; 		   window-divider-last-pixel))
+  ;;   (face-spec-reset-face face)
+  ;;   (set-face-foreground face (face-attribute 'default :background nil)))
+  ;; (set-face-background 'fringe (face-attribute 'default :background nil))
+  ;; (setq
+  ;;   ;; Edit settings
+  ;;   org-auto-align-tags nil
+  ;;   org-tags-column 0
+  ;;   org-catch-invisible-edits 'show-and-error
+  ;;   org-special-ctrl-a/e t
+  ;;   org-insert-heading-respect-content t
+
+  ;;   ;; Org styling, hide markup etc.
+  ;;   org-hide-emphasis-markers nil
+  ;;   org-pretty-entities t
+  ;;   org-ellipsis "…"
+
+  ;;   ;; Agenda styling
+  ;;   org-agenda-tags-column 0
+  ;;   org-agenda-block-separator ?─
+  ;;   org-agenda-time-grid
+  ;;   '((daily today require-timed)
+  ;;      (800 1000 1200 1400 1600 1800 2000)
+  ;;      " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
+  ;;   org-agenda-current-time-string
+  ;;   "◀── now ─────────────────────────────────────────────────")
+  (global-org-modern-mode))
 
 ;;; ##########################################################################
 
@@ -2136,151 +2313,6 @@ font size is computed + 20 of this value."
   (cl-defmethod project-root ((project (head go-module)))
     (cdr project))
   (add-hook 'project-find-functions #'project-find-go-module))
-
-;;; ##########################################################################
-;;; Treemacs
-
-(use-package treemacs
-  :after (:all winum ace-window)
-  :bind (:map global-map
-          ("M-0"         . treemacs-select-window)
-          ("C-x t 1"   . treemacs-delete-other-windows)
-          ("C-x t t"   . treemacs)
-          ("C-x t d"   . treemacs-select-directory)
-          ("C-x t B"   . treemacs-bookmark)
-          ("C-x t C-t" . treemacs-find-file)
-          ("C-x t M-t" . treemacs-find-tag))
-  :config
-  (setq treemacs-collapse-dirs                  (if treemacs-python-executable 3 0)
-    treemacs-deferred-git-apply-delay  0.5
-    treemacs-directory-name-transformer        #'identity
-    treemacs-display-in-side-window            t
-    treemacs-eldoc-display                     'simple
-    treemacs-file-event-delay          2000
-    treemacs-file-extension-regex              treemacs-last-period-regex-value
-    treemacs-file-follow-delay                 0.2
-    treemacs-file-name-transformer             #'identity
-    treemacs-follow-after-init                 t
-    treemacs-expand-after-init                 t
-    treemacs-find-workspace-method             'find-for-file-or-pick-first
-    treemacs-git-command-pipe          ""
-    treemacs-goto-tag-strategy                 'refetch-index
-    treemacs-header-scroll-indicators  '(nil . "^^^^^^")
-    treemacs-hide-dot-git-directory            t
-    treemacs-indentation                       2
-    treemacs-indentation-string                " "
-    treemacs-is-never-other-window             nil
-    treemacs-max-git-entries           5000
-    treemacs-missing-project-action            'ask
-    treemacs-move-forward-on-expand            nil
-    treemacs-no-png-images                     nil
-    treemacs-no-delete-other-windows   t
-    treemacs-project-follow-cleanup            nil
-    treemacs-persist-file                      (expand-file-name
-                                                   ".cache/treemacs-persist"
-                                                   user-emacs-directory)
-    treemacs-position                  'left
-    treemacs-read-string-input                 'from-child-frame
-    treemacs-recenter-distance                 0.1
-    treemacs-recenter-after-file-follow        nil
-    treemacs-recenter-after-tag-follow         nil
-    treemacs-recenter-after-project-jump       'always
-    treemacs-recenter-after-project-expand     'on-distance
-    treemacs-litter-directories                '("/node_modules"
-                                            "/.venv"
-                                            "/.cask"
-                                            "/__pycache__")
-    treemacs-project-follow-into-home  nil
-    treemacs-show-cursor                       nil
-    treemacs-show-hidden-files                 t
-    treemacs-silent-filewatch          nil
-    treemacs-silent-refresh                    nil
-    treemacs-sorting                   'alphabetic-asc
-    treemacs-select-when-already-in-treemacs 'move-back
-    treemacs-space-between-root-nodes  t
-    treemacs-tag-follow-cleanup                t
-    treemacs-tag-follow-delay          1.5
-    treemacs-text-scale                        nil
-    treemacs-user-mode-line-format             nil
-    treemacs-user-header-line-format   nil
-    treemacs-wide-toggle-width                 70
-    treemacs-width                             38
-    treemacs-width-increment           1
-    treemacs-width-is-initially-locked         t
-    treemacs-workspace-switch-cleanup  nil)
-
-  ;; The default width and height of the icons is 22 pixels. If you are
-  ;; using a Hi-DPI display, uncomment this to double the icon size.
-  ;;(treemacs-resize-icons 44)
-
-  (treemacs-follow-mode t)
-  (treemacs-filewatch-mode t)
-  (treemacs-fringe-indicator-mode 'always)
-  (when treemacs-python-executable
-    (treemacs-git-commit-diff-mode t))
-  (pcase (cons (not (null (executable-find "git")))
-           (not (null treemacs-python-executable)))
-    (`(t . t)
-      (treemacs-git-mode 'deferred))
-    (`(t . _)
-      (treemacs-git-mode 'simple)))
-  (treemacs-hide-gitignored-files-mode nil))
-
-;;; ##########################################################################
-
-(use-package treemacs-projectile
-  :when (equal custom-project-handler 'custom-project-projectile)
-  :after treemacs projectile)
-
-;;; ##########################################################################
-
-(use-package treemacs-icons-dired
-  :after treemacs
-  :hook (dired-mode . treemacs-icons-dired-enable-once))
-
-;;; ##########################################################################
-
-;; (use-package treemacs-perspective
-;;    :disabled
-;;    :after (treemacs persp-mode) ;;or perspective vs. persp-mode
-;;    :config (treemacs-set-scope-type 'Perspectives))
-
-(use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
-  ;;:ensure (:files ("src/extra/treemacs-persp.el" "treemacs-persp-pkg.el"):host github :repo "Alexander-Miller/treemacs")
-  :after (:any treemacs persp-mode) ;;or perspective vs. persp-mode
-  :config (treemacs-set-scope-type 'Perspectives))
-
-;;; ##########################################################################
-
-(use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
-  :after treemacs
-  :config (treemacs-set-scope-type 'Tabs))
-
-;;; ##########################################################################
-
-(use-package treemacs-all-the-icons
-  :after treemacs
-  :if (display-graphic-p))
-
-;;; ##########################################################################
-
-(use-package dashboard
-  :custom
-  (dashboard-items '(   (recents . 15)
-                      (bookmarks . 10)
-                      (projects . 10)))
-  (dashboard-center-content t)
-  (dashboard-set-heading-icons t)
-  (dashboard-set-file-icons t)
-  (dashboard-footer-messages '("Greetings Program!"))
-  (dashboard-banner-logo-title "Welcome to Emacs!")
-  (dashboard-startup-banner 'logo)
-  :bind ("C-c d" . dashboard-open)
-  :config
-  ;; (setq initial-buffer-choice (lambda () (get-buffer-create dashboard-buffer-name)))
-  (add-hook 'elpaca-after-init-hook #'dashboard-insert-startupify-lists)
-  (add-hook 'elpaca-after-init-hook #'dashboard-initialize)
-  (dashboard-setup-startup-hook))
 
 ;;; ##########################################################################
 ;;; Emacs Polyglot is the Emacs LSP client that stays out of your way:
@@ -3346,6 +3378,10 @@ font size is computed + 20 of this value."
       (bind-keys :map map
         ("M-RET $" . jinx-correct)
         ("M-RET ?" . eldoc-box-help-at-point)
+        ("M-RET R 1" . eshell)
+        ("M-RET R 2" . eshell)
+        ("M-RET R 3" . eshell)
+        ("M-RET R 4" . eshell)
         ("M-RET S e" . eshell)
         ("M-RET S i" . ielm)
         ("M-RET S v" . vterm-other-window)
@@ -3376,24 +3412,26 @@ font size is computed + 20 of this value."
 (defun mifi/mmm-handle-context-keys (&optional winframe)
   "Enable or Disable keys based upon featurep context."
   (when winframe
-  (let ((map mmm-keys-minor-mode-map))
-    (when enable-thesaurus
-      (bind-keys :map map
-        ("M-RET m t" . mw-thesaurus-lookup-dwim)))
-    (cond
-      ((equal major-mode 'org-mode)
-        (bind-keys :map map
-          ("M-RET M-RET" . org-insert-heading)
-          ("M-RET o f" . mifi/set-org-fill-column-interactively)
-          ("M-RET o l" . org-toggle-link-display)))
-      ((equal major-mode 'python-mode)
-        (bind-keys :map map
-          ("M-RET P" . 'pydoc-at-point)))
-      (t   ;; Default 
-        (unbind-key "M-RET o f" map)
-        (unbind-key "M-RET o l" map)
-        (unbind-key "M-RET P ?" map)
-        (unbind-key "M-RET M-RET" map))))))
+    (let ((map mmm-keys-minor-mode-map))
+      (when enable-thesaurus
+	(bind-keys :map map
+          ("M-RET m t" . mw-thesaurus-lookup-dwim)))
+      (cond
+	((equal major-mode 'org-mode)
+          (bind-keys :map map
+            ("M-RET M-RET" . org-insert-heading)
+            ("M-RET o f" . mifi/set-org-fill-column-interactively)
+            ("M-RET o l" . org-toggle-link-display)))
+	((equal major-mode 'python-mode)
+          (bind-keys :map map
+            ("M-RET P" . 'pydoc-at-point)))
+	(t   ;; Default 
+          (unbind-key "M-RET o f" map)
+          (unbind-key "M-RET o l" map)
+          (unbind-key "M-RET P ?" map)
+          (unbind-key "M-RET M-RET" map))))))
+
+;;; ##########################################################################
 
 (defun mifi/mmm-update-menu (&optional winframe)
   (interactive)
@@ -3406,8 +3444,10 @@ font size is computed + 20 of this value."
   (which-key-add-key-based-replacements "M-RET m" "Thesaurus")
   (which-key-add-key-based-replacements "M-RET f" "set-fill-column")
   (which-key-add-key-based-replacements "M-RET j" "jump-to-register")
+  (which-key-add-key-based-replacements "M-RET C-g" "Exit menu")
   (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
+;;; ##########################################################################
 
 ;; Check the keys when:
 ;; - the whick-key menu is displayed

--- a/init.el
+++ b/init.el
@@ -11,7 +11,7 @@
 ;; (setq debug-on-error t)
 ;;
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defvar elpaca-installer-version 0.7)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))
@@ -59,30 +59,30 @@
   (setq elpaca-use-package-by-default t))
 ;; (use-package emacs :ensure nil :config (setq ring-bell-function #'ignore))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Define my customization groups
 
-(defgroup mrf-custom nil
+(defgroup mifi-custom nil
   "M.R. Fisher's configuration section."
   :group 'Local)
 
-(defgroup mrf-custom-toggles nil
+(defgroup mifi-custom-toggles nil
   "A set of toggles that enable or disable  specific packages."
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
-(defgroup mrf-custom-features nil
+(defgroup mifi-custom-features nil
   "Customization from a selection of specific features and handlers."
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
-(defgroup mrf-custom-fonts nil
+(defgroup mifi-custom-fonts nil
   "Customization of fonts and sizes."
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
-(defgroup mrf-custom-theming nil
+(defgroup mifi-custom-theming nil
   "Custom theming values."
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defcustom dashboard-landing-screen t
   "If set to t, the `dashboard' package will be displayed once emacs has
@@ -92,79 +92,79 @@ shown instead.
 The Dashboard will be in the *dashboard* buffer and can also be opened using
 \"C-c d\" or \"M-RET d\" from anywhere even if this value is nil."
   :type 'boolean
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
 (defcustom custom-docs-dir "~/Documents/Emacs-Related"
   "A directory used to store documents and customized data."
   :type 'string
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
 (defcustom working-files-directory
   (expand-file-name "emacs-working-files" custom-docs-dir)
   "The directory where to store Emacs working files."
   :type 'string
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
 (defcustom custom-org-fill-column 120
   "The fill column width for Org mode text.
     Note that the text is also centered on the screen so that should
     be taken into consideration when providing a width."
   :type 'natnum
-  :group 'mrf-custom)
+  :group 'mifi-custom)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Feature Toggles
 
 (defcustom enable-gb-dev nil
   "If set to t, the z80-mode and other GameBoy related packages
     will be enabled."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-ts nil
   "Set to t to enable TypeScript handling."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-centaur-tabs nil
   "Set to t to enable `centaur-tabs' which uses tabs to represent open buffer."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-neotree nil
   "Set to t to enable the `neotree' package."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-golden-ratio nil
   "Set to t to enable `golden-ratio-mode' which resizes the active buffer
    window to the dimensions of a golden-rectangle"
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-org-fill-column-centering nil
   "Set to t to center the visual-fill column of the Org display."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-embark nil
   "Set to t to enable the Embark package."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 (defcustom enable-thesaurus t
   "When set to t, enables the Merriam-Webster Thesaurus."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
 ;; Keep as defvar until the frameset save/restore process works better.
 (defcustom enable-frameset-restore t
   "Set to t to enable restoring the last Emacs window size and position
    upon startup."
   :type 'boolean
-  :group 'mrf-custom-toggles)
+  :group 'mifi-custom-toggles)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defcustom undo-handler 'undo-handler-vundo
   "Select the undo handler to use.
@@ -180,7 +180,7 @@ Finally, the standard undo handler can also be chosen."
          (const :tag "Vundo (default)" undo-handler-vundo)
          (const :tag "Undo-tree" undo-handler-undo-tree)
          (const :tag "Built-in" undo-handler-built-in))
-  :group 'mrf-custom-features)
+  :group 'mifi-custom-features)
 
 (defcustom completion-handler 'comphand-vertico
   "Select the default minibuffer completion handler.
@@ -199,7 +199,7 @@ alternative to isearch that uses Ivy to show an overview of all matches."
          (const :tag "Ivy, Counsel, Swiper completion systems" comphand-ivy-counsel)
          (const :tag "Cofu completion systems" comphand-corfu)
          (const :tag "Built-in Ido" comphand-built-in))
-  :group 'mrf-custom-features)
+  :group 'mifi-custom-features)
 
 (defcustom debug-adapter 'debug-adapter-dape
   "Select the debug adapter to use for debugging applications.  dap-mode is an
@@ -214,7 +214,7 @@ dap-mode."
   :type '(radio
          (const :tag "Debug Adapter Protocol (DAP)" debug-adapter-dap-mode)
          (const :tag "Debug Adapter Protocol for Emacs (DAPE)" debug-adapter-dape))
-  :group 'mrf-custom-features)
+  :group 'mifi-custom-features)
 
 (defcustom custom-ide 'custom-ide-eglot
   "Select which IDE will be used for Python development.
@@ -238,15 +238,15 @@ configurable but has a host of great feaures that just work."
          (const :tag "Language Server Protocol (LSP)" custom-ide-lsp)
          (const :tag "LSP Bridge (standalone)" custom-ide-lsp-bridge)
          (const :tag "Python Anaconda-mode for Emacs" custom-ide-anaconda))
-  :group 'mrf-custom-features)
+  :group 'mifi-custom-features)
 
 (defcustom custom-project-handler 'custom-project-project
   "Select which project handler to use."
   :type '(radio (const :tag "Projectile" custom-project-projectile)
            (const :tag "Built-in project" custom-project-project))
-  :group 'mrf-custom-features)
+  :group 'mifi-custom-features)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Theming related
 
 (defcustom theme-list '("palenight-deeper-blue"
@@ -263,86 +263,86 @@ configurable but has a host of great feaures that just work."
 
   "My personal list of themes to cycle through indexed by `theme-selector'.
 If additional themes are added, they must be previously installed."
-  :group 'mrf-custom-theming
+  :group 'mifi-custom-theming
   :type '(repeat string))
 
 (defcustom default-terminal-theme "sanityinc-tomorrow-bright"
   "The default theme used for a terminal invocation of Emacs."
-  :group 'mrf-custom-theming
+  :group 'mifi-custom-theming
   :type 'string)
 
 (defcustom theme-selector 0
   "The index into the list of custom themes."
-  :group 'mrf-custom-theming
+  :group 'mifi-custom-theming
   :type 'natnum)
 
 ;;; Font related
 (defcustom default-font-family "Fira Code Retina"
   "The font family used as the default font."
   :type 'string
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom mono-spaced-font-family "Fira Code Retina"
   "The font family used as the mono-spaced font."
   :type 'string
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom variable-pitch-font-family "Helvetica Neue"
   "The font family used as the default proportional font."
   :type 'string
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom small-mono-font-size 150
   "The small font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom medium-mono-font-size 170
   "The medium font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom large-mono-font-size 190
   "The large font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom x-large-mono-font-size 220
   "The extra-large font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom small-variable-font-size 170
   "The small font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom medium-variable-font-size 190
   "The small font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom large-variable-font-size 210
   "The small font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom x-large-variable-font-size 240
   "The small font size in pixels."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defcustom custom-default-font-size 170
   "A place to store the most current (face-attribute 'default :height).  This
 is specifically for the mono-spaced and default font. The variable type-face
 font size is computed + 20 of this value."
   :type 'natnum
-  :group 'mrf-custom-fonts)
+  :group 'mifi-custom-fonts)
 
 (defvar custom-default-mono-font-size 170
   "Storage for the current mono-spaced font height.")
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/validate-variable-pitch-font ()
   (let* ((variable-pitch-font
@@ -364,7 +364,7 @@ font size is computed + 20 of this value."
 
   (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/validate-monospace-font ()
   (let* ((monospace-font
@@ -384,7 +384,7 @@ font size is computed + 20 of this value."
 
   (message (format ">>> monospace font is %s" mono-spaced-font-family)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Set a variable that represents the actual emacs configuration directory.
 ;;; This is being done so that the user-emacs-directory which normally points
 ;;; to the .emacs.d directory can be re-assigned so that customized files don't
@@ -412,12 +412,12 @@ font size is computed + 20 of this value."
 (mifi/validate-variable-pitch-font)
 (mifi/validate-monospace-font)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (add-to-list 'load-path (expand-file-name "lisp" emacs-config-directory))
 (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (setq-default
   window-resize-pixelwise t ;; enable smooth resizing
@@ -443,7 +443,7 @@ font size is computed + 20 of this value."
                                  "Gemfile"
                                  "package.json"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 (setq savehist-file (expand-file-name "savehist" user-emacs-directory))
 (savehist-mode t)
 (setq history-length t)
@@ -454,7 +454,7 @@ font size is computed + 20 of this value."
         search-ring
         regexp-search-ring))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; (global-display-line-numbers-mode 1) ;; Line numbers appear everywhere
 ;; A cool mode to revert a window configuration
 (winner-mode 1)
@@ -468,7 +468,7 @@ font size is computed + 20 of this value."
 ;; (repeat-mode 1)
 (add-hook 'prog-mode-hook 'display-line-numbers-mode)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; Used to highlight matching delimiters '( { [ ] } )
 (use-package paren
@@ -482,7 +482,7 @@ font size is computed + 20 of this value."
   :config
   (show-paren-mode 1))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/save-desktop-frameset ()
   (unless (daemonp)
@@ -495,24 +495,27 @@ font size is computed + 20 of this value."
 
 (add-hook 'kill-emacs-hook 'mifi/save-desktop-frameset)
 
-;;; --------------------------------------------------------------------------
- 
+;;; ##########################################################################
+
 (defun mifi/restore-desktop-frameset ()
   (unless (and (daemonp) (not enable-frameset-<restore))
     (let
       ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
       (desktop-save-mode 0)
-      (when (file-exists-p  file) (load file)
-      (desktop-restore-frameset)
-      (when (featurep 'spacious-padding)
-          (when spacious-padding-mode
-            (spacious-padding-mode 0)
-            (spacious-padding-mode 1)))))))
+      (if (file-exists-p file)
+	(progn
+	  (load file)
+	  (desktop-restore-frameset)
+	  (when (featurep 'spacious-padding)
+            (when spacious-padding-mode
+              (spacious-padding-mode 0)
+              (spacious-padding-mode 1))))
+	(use-medium-display-font t)))))
 
 (setq register-preview-delay 0) ;; Show registers ASAP
-(set-register ?C (cons 'file (concat emacs-config-directory "emacs-config.org")))
+(set-register ?O (cons 'file (concat emacs-config-directory "emacs-config.org")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Allow access from emacsclient
 (add-hook 'elpaca-after-init-hook
   (lambda ()
@@ -523,13 +526,13 @@ font size is computed + 20 of this value."
 ;; (when (fboundp 'pixel-scroll-precision-mode)
 ;;    (pixel-scroll-precision-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package hydra
   :ensure (:repo "abo-abo/hydra" :fetcher github
             :files (:defaults (:exclude "lv.el"))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/set-diminish ()
   (when (equal custom-project-handler 'custom-project-projectile)
@@ -551,7 +554,7 @@ font size is computed + 20 of this value."
       (lambda () (run-with-timer 0.5 nil 'mifi/set-diminish)))
     (run-with-timer 1.0 nil 'mifi/set-diminsh)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package which-key
   :diminish which-key-mode
@@ -565,7 +568,7 @@ font size is computed + 20 of this value."
   (which-key-mode)
   (which-key-setup-minibuffer))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package multiple-cursors
   :bind (("C-S-c C-S-c" . mc/edit-lines)
@@ -573,7 +576,7 @@ font size is computed + 20 of this value."
         ("C-<" . mc/mark-previous-like-this)
         ("C-c C-<" . mc/mark-all-like-this)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package anzu
   :custom
@@ -591,16 +594,16 @@ font size is computed + 20 of this value."
   (define-key isearch-mode-map
     [remap isearch-query-replace-regexp] #'anzu-isearch-query-replace-regexp))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package visual-fill-column :after org)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package default-text-scale
   :hook (elpaca-after-init . default-text-scale-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; Macintosh specific configurations.
 (when *is-a-mac*
@@ -608,11 +611,9 @@ font size is computed + 20 of this value."
         mac-option-modifier         nil
         mac-control-modifier       'control
         mac-right-command-modifier 'super
-        mac-right-control-modifier 'hyper)
+        mac-right-control-modifier 'hyper))
 
-  (global-set-key (kbd "<escape>") 'keyboard-escape-quit))
-
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (bind-key "C-c ]" 'indent-region prog-mode-map)
 (bind-key "C-c }" 'indent-region prog-mode-map)
@@ -640,7 +641,7 @@ font size is computed + 20 of this value."
 (global-unset-key (kbd "C-<wheel-down>"))
 (global-unset-key (kbd "C-<wheel-up>"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; prevent (emacs) eldoc loaded before Elpaca activation warning.
 ;; (Warning only displayed during first Elpaca installation)
@@ -665,7 +666,7 @@ font size is computed + 20 of this value."
   :config
   (global-eldoc-mode t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Automatic Package Updates
 
 (use-package auto-package-update
@@ -679,7 +680,7 @@ font size is computed + 20 of this value."
   (auto-package-update-maybe)
   (auto-package-update-at-time "09:00"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; YASnippets
 
 (use-package yasnippet
@@ -698,30 +699,30 @@ font size is computed + 20 of this value."
     (prettify-symbols-mode))
   (add-hook 'yas-after-exit-snippet-hook #'help/yas-after-exit-snippet-hook-fn))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package yasnippet-snippets
   :after yasnippet)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package all-the-icons
   :when (display-graphic-p))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package ace-window
   ;;:ensure (:repo "abo-abo/ace-window" :fetcher github)
   :bind ("M-o" . ace-window))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Window Number
 
 (use-package winum
   ;;:ensure (:host github :repo "deb0ch/emacs-winum")
   :config (winum-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 (use-package jinx
   :ensure (:host github :repo "minad/jinx")
   ;;:hook (emacs-startup . global-jinx-mode)
@@ -731,9 +732,9 @@ font size is computed + 20 of this value."
   (dolist (hook '(text-mode-hook prog-mode-hook org-mode-hook))
     (add-hook hook #'jinx-mode)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package vundo
   ;;:ensure ( :host github :repo "casouri/vundo")
@@ -745,7 +746,7 @@ font size is computed + 20 of this value."
   (set-face-attribute 'vundo-default nil :family "Symbola")
   (setq vundo-glyph-alist vundo-unicode-symbols))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/undo-tree-hook ()
   (set-frame-width (selected-frame) 20))
@@ -756,7 +757,7 @@ font size is computed + 20 of this value."
        (split-width-threshold 0))
     (apply original-function args)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;;
 ;; Sometimes, when behind a firewall, the undo-tree package triggers elpaca
@@ -785,11 +786,11 @@ font size is computed + 20 of this value."
       ("C-g" . undo-tree-visualizer-abort))
     (setq undo-tree-auto-save-history nil)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package prescient)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package orderless
   :when (or (equal completion-handler 'comphand-vertico)
@@ -798,7 +799,7 @@ font size is computed + 20 of this value."
   (completion-styles '(orderless basic))
   (completion-category-overrides '((file (styles basic partial-completion)))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Swiper and IVY mode
 
 (use-package ivy
@@ -825,7 +826,7 @@ font size is computed + 20 of this value."
   (add-to-list 'ivy-highlight-functions-alist
     '(orderless-ivy-re-builder . orderless-ivy-highlight)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package ivy-rich
   :when (equal completion-handler 'comphand-ivy-counsel)
@@ -840,13 +841,13 @@ font size is computed + 20 of this value."
   :after (:any yasnippet ivy))
 ;; :ensure (:host github :repo "mkcms/ivy-yasnippet"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package swiper
   :when (equal completion-handler 'comphand-ivy-counsel)
   :after ivy)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package counsel
   :when (equal completion-handler 'comphand-ivy-counsel)
@@ -862,7 +863,7 @@ font size is computed + 20 of this value."
   :config
   (counsel-mode 1))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package ivy-prescient
   :when (equal completion-handler 'comphand-ivy-counsel)
@@ -872,7 +873,7 @@ font size is computed + 20 of this value."
   (ivy-prescient-mode t)
   (ivy-prescient-enable-filtering t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;;;; Code Completion
 (use-package corfu
@@ -907,7 +908,7 @@ font size is computed + 20 of this value."
                corfu-auto nil)
       (corfu-mode))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Add extensions
 (use-package cape
   :when (equal completion-handler 'comphand-corfu)
@@ -950,13 +951,13 @@ font size is computed + 20 of this value."
   ;;(add-hook 'completion-at-point-functions #'cape-line)
   )
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package corfu-prescient
   :when (equal completion-handler 'comphand-corfu)
   :after (corfu prescient))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package vertico
   :when (equal completion-handler 'comphand-vertico)
@@ -976,7 +977,7 @@ font size is computed + 20 of this value."
         ;; Make sure vertico state is saved
         (minibuffer-setup . vertico-repeat-save)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package marginalia
   ;; :when (equal completion-handler 'comphand-vertico)
@@ -988,13 +989,13 @@ font size is computed + 20 of this value."
   :config
   (marginalia-mode t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package all-the-icons-completion
   :after (marginalia all-the-icons)
   :hook (marginalia-mode . all-the-icons-completion-marginalia-setup))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package consult
   :when (equal completion-handler 'comphand-vertico)
@@ -1044,13 +1045,13 @@ font size is computed + 20 of this value."
        consult--source-modified-buffer
        consult--source-recent-file)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package vertico-prescient
   :when (equal completion-handler 'comphand-vertico)
   :after vertico prescient)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package vertico-posframe
   :when (equal completion-handler 'comphand-vertico)
@@ -1072,7 +1073,7 @@ font size is computed + 20 of this value."
     '((left-fringe . 8)
        (right-fringe . 8))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; This has to be evaluated at the end of the init since it's possible that the
 ;; completion-handler variable will not yet be defined at this point in the
@@ -1082,7 +1083,7 @@ font size is computed + 20 of this value."
     (when (equal completion-handler 'comphand-built-in)
       (ido-everywhere t))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package embark
   :when enable-embark
@@ -1121,7 +1122,7 @@ font size is computed + 20 of this value."
   :hook
   (embark-collect-mode . consult-preview-at-point-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; Don't use lsp-bridge with company as lsp-bridge already provides the same
 ;; features. They actually collide.
@@ -1134,7 +1135,7 @@ font size is computed + 20 of this value."
   :config
   (global-company-mode +1))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package company-box
   :after company
@@ -1158,7 +1159,7 @@ font size is computed + 20 of this value."
   (eval-after-load "company"
     '(add-to-list 'company-backends 'company-anaconda)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package term+
   ;;:ensure (:repo "tarao/term-plus-el" :fetcher github)
@@ -1170,12 +1171,12 @@ font size is computed + 20 of this value."
   ;; Match the default Bash shell prompt.  Update this if you have a custom prompt
   (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package eterm-256color
   :hook (term-mode . eterm-256color-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package vterm
   ;;:ensure (:fetcher github :repo "akermu/emacs-libvterm")
@@ -1186,7 +1187,7 @@ font size is computed + 20 of this value."
   (setq vterm-shell "zsh")                        ;; Set this to customize the shell to launch
   (setq vterm-max-scrollback 10000))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/configure-eshell ()
   ;; Save command history when commands are entered
@@ -1211,7 +1212,7 @@ font size is computed + 20 of this value."
     (setq eshell-visual-commands '("htop" "zsh" "vim")))
   (eshell-git-prompt-use-theme 'powerline))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
   ;; Prefer g-prefixed coreutils version of standard utilities when available
 (let ((gls (executable-find "gls")))
@@ -1236,7 +1237,7 @@ font size is computed + 20 of this value."
   :after dired-mode
   :hook (dired-mode . dired-hide-dotfiles-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Single Window dired - don't continually open new buffers
 
 (defun mifi/dired-single-keymap-init ()
@@ -1254,7 +1255,7 @@ font size is computed + 20 of this value."
   :config
   (mifi/dired-single-keymap-init))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;;
 ;; 1. The function `mifi/load-theme-from-selector' is called from the
@@ -1275,7 +1276,7 @@ font size is computed + 20 of this value."
 (add-to-list 'savehist-additional-variables 'theme-selector)
 (add-to-list 'savehist-additional-variables 'custom-default-mono-font-size)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/cycle-theme-selector (&rest theme)
   "Cycle the `theme-selector' by 1, resetting to 0 if beyond array bounds."
@@ -1295,7 +1296,7 @@ font size is computed + 20 of this value."
 ;; `mifi/load-theme-from-selector' function.
 (add-hook 'disable-theme-functions #'mifi/cycle-theme-selector)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defvar theme-did-load nil
   "Set to true if the last Theme was loaded.")
@@ -1316,7 +1317,7 @@ font size is computed + 20 of this value."
     (mifi/org-font-setup))
   (set-face-foreground 'line-number "SkyBlue4"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/print-custom-theme-name ()
   "Print the current loaded theme from the `theme-list' on the modeline."
@@ -1346,7 +1347,7 @@ font size is computed + 20 of this value."
 ;; Print current theme
 (global-set-key (kbd "C-c C-?") 'which-theme)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/org-theme-override-values ()
   (defface org-block-begin-line
@@ -1365,7 +1366,7 @@ font size is computed + 20 of this value."
     '((t (:strike-through "green" :weight bold)))
     "Face used for the Horizontal like (-----)"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/customize-modus-theme ()
   (when (featurep 'org)
@@ -1390,7 +1391,7 @@ font size is computed + 20 of this value."
 ;;(add-hook 'org-load-hook 'mifi/customize-ef-theme)
 (add-hook 'elpaca-after-init-hook 'mifi/customize-ef-theme)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (add-to-list 'custom-theme-load-path (expand-file-name "Themes" custom-docs-dir))
 
@@ -1405,7 +1406,7 @@ font size is computed + 20 of this value."
 (use-package darktooth-theme :ensure t)
 (use-package zenburn-theme :defer t)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; (add-hook 'emacs-startup-hook #'(mifi/load-theme-from-selector))
 ;; (mifi/load-theme-from-selector)
 ;; For terminal mode we choose Material theme
@@ -1429,7 +1430,7 @@ font size is computed + 20 of this value."
           (mifi/load-theme-from-selector))))
       )))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; Frame (view) setup including fonts.
 ;; You will most likely need to adjust this font size for your system!
@@ -1459,7 +1460,7 @@ font size is computed + 20 of this value."
 
 (setq frame-resize-pixelwise t)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package mixed-pitch
   :defer t
@@ -1469,7 +1470,7 @@ font size is computed + 20 of this value."
   (dolist (face '(org-date org-priority org-special-keyword org-tag))
     (add-to-list 'mixed-pitch-fixed-pitch-faces face)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Functions to set the frame size
 
 (defun mifi/frame-recenter (&optional frame)
@@ -1518,7 +1519,7 @@ font size is computed + 20 of this value."
   (add-to-list 'default-frame-alist '(fullscreen . maximized))
   (unless enable-frameset-restore (mifi/frame-recenter)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; Default fonts
 
@@ -1554,7 +1555,7 @@ font size is computed + 20 of this value."
         (mifi/frame-recenter)))
       )))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/default-font-height-change ()
   (setq-default custom-default-font-size (face-attribute 'default :height))
@@ -1563,7 +1564,7 @@ font size is computed + 20 of this value."
 
 (add-hook 'after-setting-font-hook 'mifi/default-font-height-change)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Frame font selection
 
 (defvar mifi/font-size-slot 1)
@@ -1595,7 +1596,7 @@ font size is computed + 20 of this value."
             mifi/font-size-slot 3)
       (mifi/update-face-attribute))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Some alternate keys below....
 
 (bind-keys ("C-c 1". use-small-display-font)
@@ -1613,7 +1614,7 @@ font size is computed + 20 of this value."
   (define-key map (kbd "C-S-c 4")
     (lambda () (interactive) (use-x-large-display-font t))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Frame support functions
 
 (defun mifi/set-frame-font (slot)
@@ -1627,7 +1628,7 @@ font size is computed + 20 of this value."
     ;;else
     (unless enable-frameset-restore (mifi/frame-recenter))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun use-small-display-font (&optional force-recenter)
   (interactive)
@@ -1664,7 +1665,7 @@ font size is computed + 20 of this value."
         (unless enable-frameset-restore (mifi/frame-recenter))))
       )))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package spacious-padding
   :custom
@@ -1685,7 +1686,7 @@ font size is computed + 20 of this value."
 ;;       `( :mode-line-active 'default
 ;;          :mode-line-inactive vertical-border))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package faces :ensure nil)
 (defun mifi/org-font-setup ()
@@ -1758,7 +1759,7 @@ font size is computed + 20 of this value."
     (set-face-attribute (car face) nil :font "Helvetica Neue" :weight 'regular
       :height (cdr face))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/org-mode-visual-fill ()
   (interactive)
@@ -1788,7 +1789,7 @@ font size is computed + 20 of this value."
     '(("Archive.org" :maxlevel . 1)
        ("Tasks.org" :maxlevel . 1))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/org-setup-agenda ()
   (setq org-agenda-custom-commands
@@ -1839,7 +1840,7 @@ font size is computed + 20 of this value."
                (org-agenda-files org-agenda-files)))))))
   ) ;; mifi/org-setup-agenda
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/org-setup-capture-templates ()
   (setq org-capture-templates
@@ -1900,7 +1901,7 @@ font size is computed + 20 of this value."
  '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
  '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package org
   :pin gnu-elpa
@@ -1945,7 +1946,7 @@ font size is computed + 20 of this value."
   (define-key global-map (kbd "C-c j")
     (lambda () (interactive) (org-capture nil "jj"))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
   (use-package org-superstar
     :after org
@@ -1978,7 +1979,7 @@ font size is computed + 20 of this value."
 (setq org-list-demote-modify-bullet
 '(("+" ・ "*"）（"*" ・ "-"）（"-" . "+")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (with-eval-after-load 'org
   (org-babel-do-load-languages
@@ -2006,7 +2007,7 @@ font size is computed + 20 of this value."
        (sqlite . t))))
   (push '("conf-unix" . conf-unix) org-src-lang-modes))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (with-eval-after-load 'org
   ;; This is needed as of Org 9.2
@@ -2014,7 +2015,7 @@ font size is computed + 20 of this value."
   (add-to-list 'org-structure-template-alist '("el" . "src emacs-lisp"))
   (add-to-list 'org-structure-template-alist '("py" . "src python")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/define-denote-keymap ()
   (interactive)
@@ -2058,7 +2059,7 @@ font size is computed + 20 of this value."
   (if (mifi/minor-mode-is-active 'which-key-mode)
     (which-key-add-key-based-replacements "C-c n f" "denote-find")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package denote
   :custom
@@ -2099,7 +2100,7 @@ font size is computed + 20 of this value."
 
   (add-hook 'context-menu-functions #'denote-context-menu))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package projectile
   :when (equal custom-project-handler 'custom-project-projectile)
@@ -2121,7 +2122,7 @@ font size is computed + 20 of this value."
     (setq projectile-completion-system 'ivy)
     (counsel-projectile-mode)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun project-find-go-module (dir)
   (when-let ((root (locate-dominating-file dir "go.mod")))
@@ -2136,7 +2137,7 @@ font size is computed + 20 of this value."
     (cdr project))
   (add-hook 'project-find-functions #'project-find-go-module))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Treemacs
 
 (use-package treemacs
@@ -2225,19 +2226,19 @@ font size is computed + 20 of this value."
       (treemacs-git-mode 'simple)))
   (treemacs-hide-gitignored-files-mode nil))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package treemacs-projectile
   :when (equal custom-project-handler 'custom-project-projectile)
   :after treemacs projectile)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package treemacs-icons-dired
   :after treemacs
   :hook (dired-mode . treemacs-icons-dired-enable-once))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; (use-package treemacs-perspective
 ;;    :disabled
@@ -2249,19 +2250,19 @@ font size is computed + 20 of this value."
   :after (:any treemacs persp-mode) ;;or perspective vs. persp-mode
   :config (treemacs-set-scope-type 'Perspectives))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package treemacs-tab-bar ;;treemacs-tab-bar if you use tab-bar-mode
   :after treemacs
   :config (treemacs-set-scope-type 'Tabs))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package treemacs-all-the-icons
   :after treemacs
   :if (display-graphic-p))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package dashboard
   :custom
@@ -2281,7 +2282,7 @@ font size is computed + 20 of this value."
   (add-hook 'elpaca-after-init-hook #'dashboard-initialize)
   (dashboard-setup-startup-hook))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Emacs Polyglot is the Emacs LSP client that stays out of your way:
 
 (defvar mifi/clangd-path (executable-find "clangd")
@@ -2309,7 +2310,7 @@ font size is computed + 20 of this value."
   (unless theme-did-load
     (mifi/load-theme-from-selector)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package eglot
   :when (equal custom-ide 'custom-ide-eglot)
@@ -2347,7 +2348,7 @@ font size is computed + 20 of this value."
       ("<tab>" . company-indent-or-complete-common))
     (message "Eglot: Company was expected to be loaded but wasn't.")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Language Server Protocol
 
 ;; (when (equal custom-ide 'custom-ide-lsp)
@@ -2366,7 +2367,7 @@ font size is computed + 20 of this value."
   (mifi/define-rust-lsp-values)
   (lsp-enable-which-key-integration t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package lsp-ui
   :when (equal custom-ide 'custom-ide-lsp)
@@ -2390,7 +2391,7 @@ font size is computed + 20 of this value."
           ("C-c l d" . lsp-ui-doc-focus-frame))
   :hook (lsp-mode . lsp-ui-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; To enable bidirectional synchronization of lsp workspace folders and
 ;;; treemacs projects set lsp-treemacs-sync-mode to 1.
 
@@ -2407,7 +2408,7 @@ font size is computed + 20 of this value."
           (equal completion-handler 'comphand-ivy-counsel))
   :after lsp ivy)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; LSP mode setup hook
 
 (defun mifi/lsp-mode-setup ()
@@ -2418,7 +2419,7 @@ font size is computed + 20 of this value."
     (setq lsp-clangd-binary-path "/usr/bin/clangd")'
     (lsp-headerline-breadcrumb-mode)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/define-rust-lsp-values ()
   (setq-default lsp-rust-analyzer-cargo-watch-command "clippy")
@@ -2436,7 +2437,7 @@ font size is computed + 20 of this value."
   (setq-default lsp-rust-analyzer-display-parameter-hints nil)
   (setq-default lsp-rust-analyzer-display-reborrow-hints nil))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package lsp-bridge
   :when (equal custom-ide 'custom-ide-lsp-bridge)
@@ -2448,12 +2449,12 @@ font size is computed + 20 of this value."
   :config
   (global-lsp-bridge-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package markdown-mode
   :when (equal custom-ide 'custom-ide-lsp-bridge))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package anaconda-mode
   :when (equal custom-ide 'custom-ide-anaconda)
@@ -2471,7 +2472,7 @@ font size is computed + 20 of this value."
       ("<tab>" . company-indent-or-complete-common)))
   (python-mode-hook . anaconda-eldoc-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package elpy
   :when (equal custom-ide 'custom-ide-elpy)
@@ -2502,7 +2503,7 @@ font size is computed + 20 of this value."
       ("<tab>" . company-indent-or-complete-common)))
   (elpy-enable))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package flycheck
   :unless (equal custom-ide 'custom-ide-elpy)
@@ -2517,7 +2518,7 @@ font size is computed + 20 of this value."
 (use-package flycheck-package
   :after flycheck)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/tree-sitter-setup ()
   (tree-sitter-hl-mode t))
@@ -2526,7 +2527,7 @@ font size is computed + 20 of this value."
   (add-hook 'before-save-hook #'lsp-format-buffer t t)
   (add-hook 'before-save-hook #'lsp-organize-imports t t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package tree-sitter
   :defer t
@@ -2550,14 +2551,14 @@ font size is computed + 20 of this value."
 (use-package tree-sitter-langs
   :after tree-sitter)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package treesit-auto
   :demand t
   :config
   (global-treesit-auto-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package transient :defer t)
 (use-package git-commit :after transient :defer t)
@@ -2570,7 +2571,7 @@ font size is computed + 20 of this value."
 (use-package forge :after magit :defer t)
 (use-package treemacs-magit :defer t :after treemacs magit)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/set-custom-ide-python-keymaps ()
   (cond
@@ -2603,7 +2604,7 @@ font size is computed + 20 of this value."
         ("C-c g ?" . lsp-bridge-popup-documentation)))
     ))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/load-python-file-hook ()
   (python-mode)
@@ -2650,7 +2651,7 @@ font size is computed + 20 of this value."
   (add-hook 'before-save-hook 'mifi/before-save)
   (set-fill-column 80))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (add-to-list 'auto-mode-alist '("\\.py\\'" . mifi/load-python-file-hook))
 
@@ -2663,13 +2664,13 @@ font size is computed + 20 of this value."
   (add-to-list 'python-shell-completion-native-disabled-interpreters "python3")
   (setq python-shell-completion-native-disabled-interpreters '("python3")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package py-autopep8
   :after python
   :hook (python-mode . py-autopep8-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; This is a helpful macro that is used to put double quotes around a word.
 (defalias 'quote-word
@@ -2684,13 +2685,13 @@ font size is computed + 20 of this value."
       ("C-c q"   . quote-word)
       ("C-c |"   . display-fill-column-indicator-mode)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package pyvenv-auto
   :after python
   :hook (python-mode . pyvenv-auto-run))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package pydoc
   ;;:ensure (:host github :repo "statmobile/pydoc")
@@ -2699,7 +2700,7 @@ font size is computed + 20 of this value."
   (pydoc-python-command "python3")
   (pydoc-pip-version-command "pip3 --version"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package typescript-mode
   :defer t
@@ -2718,7 +2719,7 @@ font size is computed + 20 of this value."
       (bind-keys :map typescript-mode-map
       ("C-c ." . dape-hydra/body)))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/load-js-file-hook ()
   (js2-mode)
@@ -2741,7 +2742,7 @@ font size is computed + 20 of this value."
 
 (setq nodejs-repl-command #'mifi/nvm-which)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package js2-mode
   :hook (js-mode . js2-minor-mode)
@@ -2755,7 +2756,7 @@ font size is computed + 20 of this value."
   :after js2-mode
   :hook (js2-mode . ac-js2-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/load-c-file-hook ()
   (c-mode)
@@ -2779,7 +2780,7 @@ font size is computed + 20 of this value."
 (global-set-key [f9] 'code-compile)
 (add-to-list 'auto-mode-alist '("\\.c\\'" . mifi/load-c-file-hook))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package z80-mode
   :when enable-gb-dev
@@ -2794,7 +2795,7 @@ font size is computed + 20 of this value."
   :after mwim
   :ensure (:host github :repo "japanoise/rgbds-mode"))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package rustic
   :ensure t
@@ -2826,7 +2827,7 @@ font size is computed + 20 of this value."
     (setq-local buffer-save-without-query t))
   (add-hook 'before-save-hook 'lsp-format-buffer nil t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; (use-package graphql-mode)
 (use-package rust-mode
@@ -2842,7 +2843,7 @@ font size is computed + 20 of this value."
 (use-package rust-playground :ensure t :after rust-mode)
 (use-package toml-mode :ensure t :after rust-mode)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package cargo-mode
   :defer t
@@ -2855,7 +2856,7 @@ font size is computed + 20 of this value."
                      "*-test.el" "*-tests.el" "LICENSE" "README*"
                      "*-pkg.el"))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun eglot-format-buffer-on-save ()
   (add-hook 'before-save-hook #'eglot-format-buffer -10 t))
@@ -2877,7 +2878,7 @@ font size is computed + 20 of this value."
     ((equal custom-ide 'custom-ide-lsp)
       (add-hook 'go-mode-hook 'lsp-deferred))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package go-eldoc
   :after go-mode
@@ -2888,13 +2889,13 @@ font size is computed + 20 of this value."
     :underline t :foreground "green"
     :weight 'bold))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package go-guru
   :after go-mode
   :hook (go-mode . go-guru-hl-identifier-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package slime
   :defer t
@@ -2921,7 +2922,7 @@ font size is computed + 20 of this value."
     ("C-c ." . dape-hydra/body))
   (mifi/additional-dape-configs))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (setq mifi/vscode-js-debug-dir (file-name-concat user-emacs-directory "dape/vscode-js-debug"))
 
@@ -2935,7 +2936,7 @@ font size is computed + 20 of this value."
     (call-process "npm" nil "*snam-install*" t "install")
     (call-process "npx" nil "*snam-install*" t "gulp" "dapDebugServer")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;; (mifi/install-vscode-js-debug)
 
@@ -2957,7 +2958,7 @@ font size is computed + 20 of this value."
        :cwd dape-cwd-fn
        :program dape-cwd-fn))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/dape-end-debug-session ()
   "End the debug session."
@@ -2970,7 +2971,7 @@ font size is computed + 20 of this value."
   (dape-breakpoint-remove-all)
   (mifi/dape-end-debug-session))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun define-dape-hydra ()
   (defhydra dape-hydra (:color pink :hint nil :foreign-keys run)
@@ -3014,7 +3015,7 @@ font size is computed + 20 of this value."
     ("q" mifi/dape-end-debug-session "quit" :color blue)
     ("Q" mifi/dape-delete-all-debug-sessions :color red)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; Debug Adapter Protocol
 (use-package dap-mode
   :when (equal debug-adapter 'debug-adapter-dap-mode)
@@ -3034,7 +3035,7 @@ font size is computed + 20 of this value."
   (dap-ui-controls-mode)
   (dap-ui-mode 1))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;;; DAP for Python
 
 (use-package dap-python
@@ -3045,7 +3046,7 @@ font size is computed + 20 of this value."
   (setq dap-python-executable "python3") ;; Otherwise it looks for 'python' else error.
   (setq dap-python-debugger 'debugpy))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package dap-lldb
   :when (equal debug-adapter 'debug-adapter-dap-mode)
@@ -3080,7 +3081,7 @@ font size is computed + 20 of this value."
   ;; :config
   ;; (dap-cpptools-setup))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (with-eval-after-load 'dap-lldb
   (dap-register-debug-template
@@ -3109,7 +3110,7 @@ font size is computed + 20 of this value."
       :request "launch"
       :name "Python :: Run file (buffer)")))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/dap-end-debug-session ()
   "End the debug session and delete project Python buffers."
@@ -3131,7 +3132,7 @@ font size is computed + 20 of this value."
   (dap-ui-show-many-windows)
   (dap-debug))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun define-dap-hydra ()
   (defhydra dap-hydra (:color pink :hint nil :foreign-keys run)
@@ -3186,7 +3187,7 @@ font size is computed + 20 of this value."
     ("q" mifi/dap-end-debug-session "quit" :color blue)
     ("Q" mifi/dap-delete-all-debug-sessions :color red)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; helpful package
 
 (use-package helpful
@@ -3221,7 +3222,7 @@ font size is computed + 20 of this value."
                                       (window . root)
                                       (window-width . 0.3))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package solaire-mode
   :after treemacs
@@ -3232,7 +3233,7 @@ font size is computed + 20 of this value."
   (push '(treemacs-window-background-face . solaire-default-face) solaire-mode-remap-alist)
   (push '(treemacs-hl-line-face . solaire-hl-line-face) solaire-mode-remap-alist))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Golen Ratio
 
 (use-package golden-ratio
@@ -3259,7 +3260,7 @@ font size is computed + 20 of this value."
   :config
   (golden-ratio-mode 1))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package buffer-move
   :bind (("C-S-<up>"     . buf-move-up)
@@ -3267,7 +3268,7 @@ font size is computed + 20 of this value."
         ("C-S-<left>"  . buf-move-left)
         ("C-S-<right>" . buf-move-right)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package neotree
   :when enable-neotree
@@ -3275,7 +3276,7 @@ font size is computed + 20 of this value."
   (global-set-key [f8] 'neotree-toggle)
   (setq neo-theme (if (display-graphic-p) 'icons 'arrow)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Enable tabs for each buffer
 
 (use-package centaur-tabs
@@ -3290,13 +3291,13 @@ font size is computed + 20 of this value."
   :config ;; Enable centaur-tabs
   (centaur-tabs-mode t))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package diff-hl
   :config
   (global-diff-hl-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package pulsar
   :config
@@ -3308,26 +3309,26 @@ font size is computed + 20 of this value."
   (pulsar-face 'pulsar-magenta)
   (pulsar-highlight-face 'pulsar-yellow))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package rainbow-mode
   :hook (prog-mode . (lambda () (rainbow-mode t))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (use-package highlight-defined
   :hook (emacs-lisp-mode . highlight-defined-mode))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/set-fill-column-interactively (num)
   "Asks for the fill column."
-  (interactive "fill-column: ")
+  (interactive "nfill-column: ")
   (set-fill-column num))
 
 (defun mifi/set-org-fill-column-interactively (num)
   "Asks for the fill column for Org mode."
-  (interactive "org-fill-column: ")
+  (interactive "norg-fill-column: ")
   (setq custom-org-fill-column num)
   (mifi/org-mode-visual-fill)
   (redraw-display))
@@ -3337,13 +3338,13 @@ font size is computed + 20 of this value."
   (interactive)
   (call-interactively 'jump-to-register))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/define-mmm-minor-mode-map ()
   (defvar mmm-keys-minor-mode-map
     (let ((map (make-sparse-keymap)))
       (bind-keys :map map
-      ("M-RET $" . jinx-correct)
+        ("M-RET $" . jinx-correct)
         ("M-RET ?" . eldoc-box-help-at-point)
         ("M-RET S e" . eshell)
         ("M-RET S i" . ielm)
@@ -3356,8 +3357,9 @@ font size is computed + 20 of this value."
         ("M-RET f" . mifi/set-fill-column-interactively)
         ("M-RET p" . pulsar-pulse-line)
         ("M-RET r" . repeat-mode)
-      ("M-RET j" . mifi/jump-to-register)
-        ("M-RET |" . global-display-fill-column-indicator-mode))
+        ("M-RET j" . mifi/jump-to-register)
+        ("M-RET |" . global-display-fill-column-indicator-mode)
+        ("M-RET C-g" . keyboard-quit))
       map)
     "mmm-keys-minor-mode keymap.")
 
@@ -3369,31 +3371,33 @@ font size is computed + 20 of this value."
 (mifi/define-mmm-minor-mode-map)
 (mmm-keys-minor-mode 1)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
-(defun mifi/mmm-handle-context-keys ()
+(defun mifi/mmm-handle-context-keys (&optional winframe)
   "Enable or Disable keys based upon featurep context."
+  (when winframe
   (let ((map mmm-keys-minor-mode-map))
-    (unbind-key "M-RET o f" map)
-    (unbind-key "M-RET o l" map)
-    (unbind-key "M-RET P ?" map)
-    (unbind-key "M-RET M-RET" map)
     (when enable-thesaurus
       (bind-keys :map map
-      ("M-RET m t" . mw-thesaurus-lookup-dwim)))
+        ("M-RET m t" . mw-thesaurus-lookup-dwim)))
     (cond
       ((equal major-mode 'org-mode)
-      (bind-keys :map map
-        ("M-RET M-RET" . org-insert-heading)
-        ("M-RET o f" . mifi/set-org-fill-column-interactively)
-        ("M-RET o l" . org-toggle-link-display)))
+        (bind-keys :map map
+          ("M-RET M-RET" . org-insert-heading)
+          ("M-RET o f" . mifi/set-org-fill-column-interactively)
+          ("M-RET o l" . org-toggle-link-display)))
       ((equal major-mode 'python-mode)
-      (bind-keys :map map
-        ("M-RET P" . 'pydoc-at-point))))))
+        (bind-keys :map map
+          ("M-RET P" . 'pydoc-at-point)))
+      (t   ;; Default 
+        (unbind-key "M-RET o f" map)
+        (unbind-key "M-RET o l" map)
+        (unbind-key "M-RET P ?" map)
+        (unbind-key "M-RET M-RET" map))))))
 
-(defun mifi/mmm-update-menu ()
+(defun mifi/mmm-update-menu (&optional winframe)
   (interactive)
-  (mifi/mmm-handle-context-keys)
+  (mifi/mmm-handle-context-keys nil)
   (which-key-add-key-based-replacements "M-RET S" "shells")
   (which-key-add-key-based-replacements "M-RET T" "theme-keys")
   (which-key-add-key-based-replacements "M-RET P" "python-menu")
@@ -3404,9 +3408,17 @@ font size is computed + 20 of this value."
   (which-key-add-key-based-replacements "M-RET j" "jump-to-register")
   (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
-(add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)
 
-;;; --------------------------------------------------------------------------
+;; Check the keys when:
+;; - the whick-key menu is displayed
+(add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)
+;; - the user updates/changes the buffer - like loading a file
+;;   (but not switching to a new buffer)
+(add-hook 'window-buffer-change-functions 'mifi/mmm-handle-context-keys)
+;; - the user switches windows
+(add-hook 'window-selection-change-functions 'mifi/mmm-handle-context-keys)
+
+;;; ##########################################################################
 
 (add-hook 'elpaca-after-init-hook
   (lambda ()
@@ -3426,7 +3438,7 @@ font size is computed + 20 of this value."
       (lambda ()
         (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 (defun mifi/cleanup-when-exiting ()
   (let ((backdir (format "%s/config-backup" working-files-directory)))
@@ -3441,7 +3453,7 @@ font size is computed + 20 of this value."
 
 (add-hook 'kill-emacs-hook #'mifi/cleanup-when-exiting)
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Ignore Line Numbers for the following modes:
 
 ;; Line #'s appear everywhere if global-display-line-numbers-mode is set
@@ -3459,7 +3471,7 @@ font size is computed + 20 of this value."
                    vterm-mode-hook))
     (add-hook mode (lambda () (display-line-numbers-mode 0)))))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 ;; Supress common annoying warning.
 ;; These can still be found in the  *Warnings* buffer
 (setq warning-suppress-types '((package reinitialization)
@@ -3468,6 +3480,6 @@ font size is computed + 20 of this value."
                                 (use-package)
                                 (python-mode)))
 
-;;; --------------------------------------------------------------------------
+;;; ##########################################################################
 
 ;;; init.el ends here.

--- a/init.el
+++ b/init.el
@@ -152,8 +152,13 @@ The Dashboard will be in the *dashboard* buffer and can also be opened using
   :type 'boolean
   :group 'mrf-custom-toggles)
 
+(defcustom enable-thesaurus t
+  "When set to t, enables the Merriam-Webster Thesaurus."
+  :type 'boolean
+  :group 'mrf-custom-toggles)
+
 ;; Keep as defvar until the frameset save/restore process works better.
-(defvar enable-frameset-restore nil
+(defvar enable-frameset-restore t
   "Set to t to enable restoring the last Emacs window size and position
    upon startup.")
   ;; :type 'boolean
@@ -342,11 +347,11 @@ font size is computed + 20 of this value."
 (defun mifi/validate-variable-pitch-font ()
   (let* ((variable-pitch-font
            (cond
-	     ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
-	     ((x-list-fonts "SF Pro")           "SF Pro")
-	     ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
-	     ((x-list-fonts "Ubuntu")           "Ubuntu")
-	     ((x-list-fonts "Helvetica")        "Helvetica")
+           ((x-list-fonts variable-pitch-font-family) variable-pitch-font-family)
+           ((x-list-fonts "SF Pro")           "SF Pro")
+           ((x-list-fonts "DejaVu Sans")      "DejaVu Sans")
+           ((x-list-fonts "Ubuntu")           "Ubuntu")
+           ((x-list-fonts "Helvetica")        "Helvetica")
              ((x-list-fonts "Source Sans Pro")  "Source Sans Pro")
              ((x-list-fonts "Lucida Grande")    "Lucida Grande")
              ((x-list-fonts "Verdana")          "Verdana")
@@ -354,7 +359,7 @@ font size is computed + 20 of this value."
              (nil (warn "Cannot find a Sans Serif Font.  Install Source Sans Pro.")))))
     (if variable-pitch-font
       (when (not (equal variable-pitch-font variable-pitch-font-family))
-	(setq variable-pitch-font-family variable-pitch-font))
+      (setq variable-pitch-font-family variable-pitch-font))
       (message "---- Can't find a variable-pitch font to use.")))
 
   (message (format ">>> variable-pitch font is %s" variable-pitch-font-family)))
@@ -364,17 +369,17 @@ font size is computed + 20 of this value."
 (defun mifi/validate-monospace-font ()
   (let* ((monospace-font
            (cond
-	     ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
-	     ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
-	     ((x-list-fonts "Fira Code")         "Fira Code")
-	     ((x-list-fonts "Source Code Pro")   "Source Code Pro")
-	     ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
+           ((x-list-fonts mono-spaced-font-family) mono-spaced-font-family)
+           ((x-list-fonts "Fira Code Retina")  "Fira Code Retina")
+           ((x-list-fonts "Fira Code")         "Fira Code")
+           ((x-list-fonts "Source Code Pro")   "Source Code Pro")
+           ((x-list-fonts "Ubuntu Monospaced") "Ubuntu Monospaced")
              ((x-family-fonts "Monospaced")      "Monospaced")
              (nil (warn "Cannot find a monospaced Font.  Install Source Code Pro.")))))
     (if monospace-font
       (when (not (equal monospace-font variable-pitch-font-family))
-	(setq mono-spaced-font-family monospace-font)
-	(setq default-font-family monospace-font))
+      (setq mono-spaced-font-family monospace-font)
+      (setq default-font-family monospace-font))
       (message "---- Can't find a monospace font to use.")))
 
   (message (format ">>> monospace font is %s" mono-spaced-font-family)))
@@ -397,12 +402,10 @@ font size is computed + 20 of this value."
 
 ;;; Put any emacs cusomized variables in a special file
 (setq custom-file (expand-file-name "customized-vars.el" user-emacs-directory))
-;; create custom file if it does not exists.
-(unless (file-exists-p custom-file)
+
+(unless (file-exists-p custom-file) ;; create custom file if it doesn't exists
   (write-region "" nil custom-file))
-;; (add-hook 'elpaca-after-init-hook (lambda () (load custom-file 'noerror 'nomessage)))
 (load custom-file 'noerror 'nomessage)
-(setq enable-frameset-restore nil) ;; FORCE UNTIL FRAMESET RESTORE IS DONE
 
 ;; ensure that the loaded font values are supported by this OS. If not, try
 ;; to correct them.
@@ -479,9 +482,6 @@ font size is computed + 20 of this value."
   :config
   (show-paren-mode 1))
 
-(setq register-preview-delay 0) ;; Show registers ASAP
-(set-register ?C (cons 'file (concat emacs-config-directory "/emacs-config.org")))
-
 ;;; --------------------------------------------------------------------------
 
 (defun mifi/save-desktop-frameset ()
@@ -498,17 +498,19 @@ font size is computed + 20 of this value."
 ;;; --------------------------------------------------------------------------
  
 (defun mifi/restore-desktop-frameset ()
-  (unless (and (daemonp) (not enable-frameset-restore))
+  (unless (and (daemonp) (not enable-frameset-<restore))
     (let
       ((file (expand-file-name "saved-frameset.el" user-emacs-directory)))
       (desktop-save-mode 0)
-      (when (f-exists? file) (load file)
+      (when (file-exists-p  file) (load file)
       (desktop-restore-frameset)
       (when (featurep 'spacious-padding)
-        (when spacious-padding-mode
-          (spacious-padding-mode 0)
-          (spacious-padding-mode 1)))))
-      ))
+          (when spacious-padding-mode
+            (spacious-padding-mode 0)
+            (spacious-padding-mode 1)))))))
+
+(setq register-preview-delay 0) ;; Show registers ASAP
+(set-register ?C (cons 'file (concat emacs-config-directory "emacs-config.org")))
 
 ;;; --------------------------------------------------------------------------
 ;; Allow access from emacsclient
@@ -520,17 +522,6 @@ font size is computed + 20 of this value."
 
 ;; (when (fboundp 'pixel-scroll-precision-mode)
 ;;    (pixel-scroll-precision-mode))
-
-;;; --------------------------------------------------------------------------
-
-(use-package f
-  :ensure ( :package "f" :source "MELPA" :protocol https :inherit t
-          :depth 1 :fetcher github :repo "rejeep/f.el"
-          :files ("*.el" "*.el.in" "dir" "*.info" "*.texi" "*.texinfo"
-                   "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-                   "lisp/*.el" (:exclude ".dir-locals.el" "test.el"
-                                 "tests.el" "*-test.el" "*-tests.el"
-                                 "LICENSE" "README*" "*-pkg.el"))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -602,8 +593,7 @@ font size is computed + 20 of this value."
 
 ;;; --------------------------------------------------------------------------
 
-(use-package visual-fill-column
-  :after org)
+(use-package visual-fill-column :after org)
 
 ;;; --------------------------------------------------------------------------
 
@@ -771,9 +761,9 @@ font size is computed + 20 of this value."
 ;;
 ;; Sometimes, when behind a firewall, the undo-tree package triggers elpaca
 ;; to queue up the Queue package which then hangs and fails. This happens
-;; even if the :unless option is specified in the use-package (only :disabled
+;; even if the :unless/:when option is specified in the use-package (only :disabled
 ;; seems to work which isn't what I want). So, we prevent the loading of the
-;; page altogether.
+;; page altogether unless the undo-handler is set to undo tree.
 ;;
 (when (equal undo-handler 'undo-handler-undo-tree)
   (use-package undo-tree
@@ -794,6 +784,475 @@ font size is computed + 20 of this value."
       ("RET" . undo-tree-visualizer-quit)
       ("C-g" . undo-tree-visualizer-abort))
     (setq undo-tree-auto-save-history nil)))
+
+;;; --------------------------------------------------------------------------
+
+(use-package prescient)
+
+;;; --------------------------------------------------------------------------
+
+(use-package orderless
+  :when (or (equal completion-handler 'comphand-vertico)
+          (equal completion-handler 'comphand-ivy-counsel))
+  :custom
+  (completion-styles '(orderless basic))
+  (completion-category-overrides '((file (styles basic partial-completion)))))
+
+;;; --------------------------------------------------------------------------
+;;; Swiper and IVY mode
+
+(use-package ivy
+  :when (equal completion-handler 'comphand-ivy-counsel)
+  :bind (("C-s" . swiper)
+          :map ivy-minibuffer-map
+            ;;; ("TAB" . ivy-alt-done)
+          ("C-l" . ivy-alt-done)
+          ("C-j" . ivy-next-line)
+          ("C-k" . ivy-previous-line)
+          :map ivy-switch-buffer-map
+          ("C-k" . ivy-previous-line)
+          ("C-l" . ivy-done)
+          ("C-d" . ivy-switch-buffer-kill)
+          :map ivy-reverse-i-search-map
+          ("C-k" . ivy-previous-line)
+          ("C-d" . ivy-reverse-i-search-kill))
+  :custom
+  (enable-recursive-minibuffers t)
+  (ivy-use-virtual-buffers t)
+  :config
+  (ivy-mode 1)
+  (setq ivy-re-builders-alist '((t . orderless-ivy-re-builder)))
+  (add-to-list 'ivy-highlight-functions-alist
+    '(orderless-ivy-re-builder . orderless-ivy-highlight)))
+
+;;; --------------------------------------------------------------------------
+
+(use-package ivy-rich
+  :when (equal completion-handler 'comphand-ivy-counsel)
+  :after ivy
+  :init
+  (ivy-rich-mode 1)
+  :config
+  (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line))
+
+(use-package ivy-yasnippet
+  :when (equal completion-handler 'comphand-ivy-counsel)
+  :after (:any yasnippet ivy))
+;; :ensure (:host github :repo "mkcms/ivy-yasnippet"))
+
+;;; --------------------------------------------------------------------------
+
+(use-package swiper
+  :when (equal completion-handler 'comphand-ivy-counsel)
+  :after ivy)
+
+;;; --------------------------------------------------------------------------
+
+(use-package counsel
+  :when (equal completion-handler 'comphand-ivy-counsel)
+  :bind ( ("C-M-j" . 'counsel-switch-buffer)
+          ("M-x" . 'counsel-M-x)
+          ("M-g o" . 'counsel-outline)
+          ("C-x C-f" . 'counsel-find-file)
+          ("C-c C-r" . 'ivy-resume)
+          :map minibuffer-local-map
+          ("C-r" . 'counsel-minibuffer-history))
+  :custom
+  (counsel-linux-app-format-function #'counsel-linux-app-format-function-name-only)
+  :config
+  (counsel-mode 1))
+
+;;; --------------------------------------------------------------------------
+
+(use-package ivy-prescient
+  :when (equal completion-handler 'comphand-ivy-counsel)
+  :after (ivy prescient)
+  :custom
+  (prescient-persist-mode t)
+  (ivy-prescient-mode t)
+  (ivy-prescient-enable-filtering t))
+
+;;; --------------------------------------------------------------------------
+
+;;;; Code Completion
+(use-package corfu
+  :when (equal completion-handler 'comphand-corfu)
+  ;; Optional customizations
+  :custom
+  (corfu-cycle t)                  ; Allows cycling through candidates
+  (corfu-auto t)                   ; Enable auto completion
+  (corfu-auto-prefix 2)
+  (corfu-auto-delay 0.8)
+  (corfu-popupinfo-delay '(0.5 . 0.2))
+  (corfu-preview-current 'insert) ; insert previewed candidate
+  (corfu-preselect 'prompt)
+  (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
+  ;; Optionally use TAB for cycling, default is `corfu-complete'.
+  :bind (:map corfu-map
+        ("M-SPC"          . corfu-insert-separator)
+        ("TAB"            . corfu-next)
+        ([tab]            . corfu-next)
+        ("S-TAB"          . corfu-previous)
+        ([backtab]    . corfu-previous)
+        ("S-<return>" . corfu-insert)
+        ("RET"            . nil))
+  :init
+  (global-corfu-mode)
+  (corfu-history-mode)
+  (corfu-popupinfo-mode) ; Popup completion info
+  :config
+  (add-hook 'eshell-mode-hook
+    (lambda () (setq-local corfu-quit-at-boundary t
+               corfu-quit-no-match t
+               corfu-auto nil)
+      (corfu-mode))))
+
+;;; --------------------------------------------------------------------------
+;; Add extensions
+(use-package cape
+  :when (equal completion-handler 'comphand-corfu)
+  :after corfu
+  ;; Bind dedicated completion commands
+  ;; Alternative prefix keys: C-c p, M-p, M-+, ...
+  :bind ( ("C-c C-p p" . completion-at-point) ;; capf
+          ("C-c C-p t" . complete-tag)        ;; etags
+          ("C-c C-p d" . cape-dabbrev)        ;; or dabbrev-completion
+          ("C-c C-p h" . cape-history)
+          ("C-c C-p f" . cape-file)
+          ("C-c C-p k" . cape-keyword)
+          ("C-c C-p s" . cape-elisp-symbol)
+          ("C-c C-p e" . cape-elisp-block)
+          ("C-c C-p a" . cape-abbrev)
+          ("C-c C-p l" . cape-line)
+          ("C-c C-p w" . cape-dict)
+          ("C-c C-p :" . cape-emoji)
+          ("C-c C-p \\" . cape-tex)
+          ("C-c C-p _" . cape-tex)
+          ("C-c C-p ^" . cape-tex)
+          ("C-c C-p &" . cape-sgml)
+          ("C-c C-p r" . cape-rfc1345))
+  :init
+  ;; Add to the global default value of `completion-at-point-functions' which is
+  ;; used by `completion-at-point'.  The order of the functions matters, the
+  ;; first function returning a result wins.  Note that the list of buffer-local
+  ;; completion functions takes precedence over the global list.
+  (add-hook 'completion-at-point-functions #'cape-dabbrev)
+  (add-hook 'completion-at-point-functions #'cape-file)
+  (add-hook 'completion-at-point-functions #'cape-elisp-block)
+  ;;(add-hook 'completion-at-point-functions #'cape-history)
+  ;;(add-hook 'completion-at-point-functions #'cape-keyword)
+  ;;(add-hook 'completion-at-point-functions #'cape-tex)
+  ;;(add-hook 'completion-at-point-functions #'cape-sgml)
+  ;;(add-hook 'completion-at-point-functions #'cape-rfc1345)
+  ;;(add-hook 'completion-at-point-functions #'cape-abbrev)
+  ;;(add-hook 'completion-at-point-functions #'cape-dict)
+  ;;(add-hook 'completion-at-point-functions #'cape-elisp-symbol)
+  ;;(add-hook 'completion-at-point-functions #'cape-line)
+  )
+
+;;; --------------------------------------------------------------------------
+
+(use-package corfu-prescient
+  :when (equal completion-handler 'comphand-corfu)
+  :after (corfu prescient))
+
+;;; --------------------------------------------------------------------------
+
+(use-package vertico
+  :when (equal completion-handler 'comphand-vertico)
+  :demand t
+  ;;:wait t
+  ;;:ensure (:repo "minad/vertico" :files (:defaults "extensions/vertico-*.el") :fetcher github)
+  :custom
+  (recentf-mode t)
+  (vertico-count 12)
+  (vertico-cycle nil)
+  (vertico-multiform-mode 1)
+  :config
+  (vertico-mode)
+  ;; :bind ("C-x C-f" . ido-find-file)
+  ;; Clean up file path when typing
+  :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
+        ;; Make sure vertico state is saved
+        (minibuffer-setup . vertico-repeat-save)))
+
+;;; --------------------------------------------------------------------------
+
+(use-package marginalia
+  ;; :when (equal completion-handler 'comphand-vertico)
+  ;; :after vertico
+  :custom
+  (marginalia-max-relative-age 0)
+  (marginalia-align 'left)
+  (marginalia-annotators '(marginalia-annotators-heavy marginalia-annotators-light nil))
+  :config
+  (marginalia-mode t))
+
+;;; --------------------------------------------------------------------------
+
+(use-package all-the-icons-completion
+  :after (marginalia all-the-icons)
+  :hook (marginalia-mode . all-the-icons-completion-marginalia-setup))
+
+;;; --------------------------------------------------------------------------
+
+(use-package consult
+  :when (equal completion-handler 'comphand-vertico)
+  :after vertico
+  :bind
+  ([remap switch-to-buffer] . consult-buffer)
+  ([remap switch-to-buffer-other-window] . consult-buffer-other-window)
+  ([remap switch-to-buffer-other-frame] . consult-buffer-other-frame)
+  ([remap project-switch-to-buffer] . consult-project-buffer)
+  ([remap bookmark-jump] . consult-bookmark)
+  ([remap recentf-open] . consult-recent-file)
+  ([remap yank] . nil)
+  ([remap yank-pop] . consult-yank-pop)
+  ([remap goto-line] . consult-goto-line)
+  ("M-g m" . consult-mark)
+  ("M-g M" . consult-global-mark)
+  ("M-g o" . consult-outline)
+  ("M-g i" . consult-imenu)
+  ("M-g I" . consult-imenu-multi)
+  ("M-s l" . consult-line)
+  ("M-s p" . consult-preview)  
+  ("M-s L" . consult-line-multi)
+  ("M-s k" . consult-keep-lines)
+  ("M-s u" . consult-focus-lines)
+  ("M-s r" . consult-ripgrep)
+  ("M-s f" . consult-find)
+  ("M-s F" . consult-locate)
+  ("M-g e" . consult-compile-error)
+  ("M-g f" . consult-flymake)
+  ([remap repeat-complex-command] . consult-complex-command)
+  ("M-s e" . consult-isearch-history)
+  ([remap isearch-edit-string] . consult-isearch-history)
+  ([remap next-matching-history-element] . consult-history)
+  ([remap previous-matching-history-element] . consult-history)
+  ([remap Info-search] . consult-info)
+  :custom
+  (xref-show-xrefs-function 'consult-xref)
+  (xref-show-definitions-function 'consult-xref)
+  :config
+  (setq consult-buffer-sources
+    '(consult--source-hidden-buffer 
+       consult--source-buffer
+       (:name "Ephemeral" :state consult--buffer-state
+       :narrow 109 :category buffer
+       :items ("*Messages*"  "*scratch*" "*vterm*"
+                "*Async-native-compile-log*" "*dashboard*"))
+       consult--source-modified-buffer
+       consult--source-recent-file)))
+
+;;; --------------------------------------------------------------------------
+
+(use-package vertico-prescient
+  :when (equal completion-handler 'comphand-vertico)
+  :after vertico prescient)
+
+;;; --------------------------------------------------------------------------
+
+(use-package vertico-posframe
+  :when (equal completion-handler 'comphand-vertico)
+  :after vertico
+  :custom
+  (setq vertico-multiform-commands
+    '((consult-line
+        posframe
+        (vertico-posframe-poshandler . posframe-poshandler-frame-top-center)
+        (vertico-posframe-border-width . 10)
+        ;; NOTE: This is useful when emacs is used in both in X and
+        ;; terminal, for posframe do not work well in terminal, so
+        ;; vertico-buffer-mode will be used as fallback at the
+        ;; moment.
+        (vertico-posframe-fallback-mode . vertico-buffer-mode))
+       (t posframe)))
+  (vertico-multiform-mode 1)
+  (setq vertico-posframe-parameters
+    '((left-fringe . 8)
+       (right-fringe . 8))))
+
+;;; --------------------------------------------------------------------------
+
+;; This has to be evaluated at the end of the init since it's possible that the
+;; completion-handler variable will not yet be defined at this point in the
+;; init phase using elpaca.
+(add-hook 'elpaca-after-init-hook
+  (lambda ()
+    (when (equal completion-handler 'comphand-built-in)
+      (ido-everywhere t))))
+
+;;; --------------------------------------------------------------------------
+
+(use-package embark
+  :when enable-embark
+  :bind
+  (("C-." . embark-act)         ;; pick some comfortable binding
+    ("C-;" . embark-dwim)        ;; good alternative: M-.
+    ("C-h B" . embark-bindings)) ;; alternative for `describe-bindings'
+
+  :init
+
+  ;; Optionally replace the key help with a completing-read interface
+  (setq prefix-help-command #'embark-prefix-help-command)
+
+  ;; Show the Embark target at point via Eldoc. You may adjust the
+  ;; Eldoc strategy, if you want to see the documentation from
+  ;; multiple providers. Beware that using this can be a little
+  ;; jarring since the message shown in the minibuffer can be more
+  ;; than one line, causing the modeline to move up and down:
+
+  ;; (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
+  ;; (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
+
+  :config
+
+  ;; Hide the mode line of the Embark live/completions buffers
+  (add-to-list 'display-buffer-alist
+    '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
+       nil
+       (window-parameters (mode-line-format . none)))))
+
+;; Consult users will also want the embark-consult package.
+(use-package embark-consult
+  :when (equal completion-handler 'comphand-vertico)
+  :defer t
+  ;;:ensure t ; only need to install it, embark loads it after consult if found
+  :hook
+  (embark-collect-mode . consult-preview-at-point-mode))
+
+;;; --------------------------------------------------------------------------
+
+;; Don't use lsp-bridge with company as lsp-bridge already provides the same
+;; features. They actually collide.
+
+(use-package company
+  :unless (equal custom-ide 'custom-ide-lsp-bridge)
+  :custom
+  (company-minimum-prefix-length 2)
+  (company-idle-delay 0.2)
+  :config
+  (global-company-mode +1))
+
+;;; --------------------------------------------------------------------------
+
+(use-package company-box
+  :after company
+  :diminish cb
+  :hook (company-mode . company-box-mode))
+
+(use-package company-jedi
+  :when  (equal custom-ide 'custom-ide-elpy)
+  :after python company
+  :config
+  (jedi:setup)
+  (defun my/company-jedi-python-mode-hook ()
+    (add-to-list 'company-backends 'company-jedi))
+  (add-hook 'python-mode-hook 'my/company-jedi-python-mode-hook))
+
+(use-package company-anaconda
+  :when (equal custom-ide 'custom-ide-anaconda)
+  :after anaconda company
+  :hook (python-mode . anaconda-mode)
+  :config
+  (eval-after-load "company"
+    '(add-to-list 'company-backends 'company-anaconda)))
+
+;;; --------------------------------------------------------------------------
+
+(use-package term+
+  ;;:ensure (:repo "tarao/term-plus-el" :fetcher github)
+  :commands term
+  :config
+  (setq explicit-shell-file-name "bash") ;; Change this to zsh, etc
+  ;;(setq explicit-zsh-args '())          ;; Use 'explicit-<shell>-args for shell-specific args
+
+  ;; Match the default Bash shell prompt.  Update this if you have a custom prompt
+  (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *"))
+
+;;; --------------------------------------------------------------------------
+
+(use-package eterm-256color
+  :hook (term-mode . eterm-256color-mode))
+
+;;; --------------------------------------------------------------------------
+
+(use-package vterm
+  ;;:ensure (:fetcher github :repo "akermu/emacs-libvterm")
+  :commands vterm
+  :config
+  (setq vterm-environment ("PS1=\\u@\\h:\\w \n$"))
+  (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *")  ;; Set this to match your custom shell prompt
+  (setq vterm-shell "zsh")                        ;; Set this to customize the shell to launch
+  (setq vterm-max-scrollback 10000))
+
+;;; --------------------------------------------------------------------------
+
+(defun mifi/configure-eshell ()
+  ;; Save command history when commands are entered
+  (add-hook 'eshell-pre-command-hook 'eshell-save-some-history)
+  ;; Truncate buffer for performance
+  (add-to-list 'eshell-output-filter-functions 'eshell-truncate-buffer)
+  (setq eshell-history-size   10000
+    eshell-buffer-maximum-lines 10000
+    eshell-hist-ignoredups t
+    eshell-scroll-to-bottom-on-input t))
+
+(use-package eshell-git-prompt
+  :after eshell)
+
+(use-package eshell
+  :ensure
+  :defer t
+  :hook (eshell-first-time-mode . mifi/configure-eshell)
+  :config
+  (with-eval-after-load 'esh-opt
+    (setq eshell-destroy-buffer-when-process-dies t)
+    (setq eshell-visual-commands '("htop" "zsh" "vim")))
+  (eshell-git-prompt-use-theme 'powerline))
+
+;;; --------------------------------------------------------------------------
+
+  ;; Prefer g-prefixed coreutils version of standard utilities when available
+(let ((gls (executable-find "gls")))
+  (when gls (setq-default insert-directory-program gls
+            dired-use-ls-dired t
+              ;; Needed to fix an issue on Mac which causes dired to fail
+              dired-listing-switches "-al --group-directories-first")))
+
+(use-package all-the-icons-dired
+  :after dired
+  :hook (dired-mode . all-the-icons-dired-mode))
+
+(use-package dired-open
+  :commands (dired dired-jump)
+  :config
+  ;; Doesn't work as expected!
+  ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
+  (setq dired-open-extensions '(("png" . "feh")
+                               ("mkv" . "mpv"))))
+
+(use-package dired-hide-dotfiles
+  :after dired-mode
+  :hook (dired-mode . dired-hide-dotfiles-mode))
+
+;;; --------------------------------------------------------------------------
+;; Single Window dired - don't continually open new buffers
+
+(defun mifi/dired-single-keymap-init ()
+  "Bunch of stuff to run for dired, either immediately or when it's
+   loaded."
+  (define-key dired-mode-map
+    [remap dired-find-file] 'dired-single-buffer)
+  (define-key dired-mode-map
+    [remap dired-mouse-find-file-other-window] 'dired-single-buffer-mouse)
+  (define-key dired-mode-map
+    [remap dired-up-directory] 'dired-single-up-directory))
+
+(use-package dired-single
+  :after dired
+  :config
+  (mifi/dired-single-keymap-init))
 
 ;;; --------------------------------------------------------------------------
 
@@ -1090,9 +1549,9 @@ font size is computed + 20 of this value."
     (when (display-graphic-p)
       (mifi/update-face-attribute)
       (unless (daemonp)
-	(if enable-frameset-restore
+      (if enable-frameset-restore
           (mifi/restore-desktop-frameset)
-	  (mifi/frame-recenter)))
+        (mifi/frame-recenter)))
       )))
 
 ;;; --------------------------------------------------------------------------
@@ -1426,6 +1885,21 @@ font size is computed + 20 of this value."
        ("STUDY" :inherit (region org-todo) :foreground "plum3"   :weight bold)
        ("DONE" . "SeaGreen4"))))
 
+(custom-theme-set-faces
+ 'user
+ '(org-block ((t (:inherit fixed-pitch))))
+ '(org-code ((t (:inherit (shadow fixed-pitch)))))
+ '(org-document-info ((t (:foreground "dark orange"))))
+ '(org-document-info-keyword ((t (:inherit (shadow fixed-pitch)))))
+ '(org-indent ((t (:inherit (org-hide fixed-pitch)))))
+ '(org-link ((t (:foreground "royal blue" :underline t))))
+ '(org-meta-line ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+ '(org-property-value ((t (:inherit fixed-pitch))) t)
+ '(org-special-keyword ((t (:inherit (font-lock-comment-face fixed-pitch)))))
+ '(org-table ((t (:inherit fixed-pitch :foreground "#83a598"))))
+ '(org-tag ((t (:inherit (shadow fixed-pitch) :weight bold :height 0.8))))
+ '(org-verbatim ((t (:inherit (shadow fixed-pitch))))))
+
 ;;; --------------------------------------------------------------------------
 
 (use-package org
@@ -1479,14 +1953,14 @@ font size is computed + 20 of this value."
     (org-superstar-leading-bullet " ")
     (org-superstar-special-todo-items t)
     (org-superstar-todo-bullet-alist '( ("TODO" . 9744)
-  				      ("INPROG-TODO" . 9744)
-  				      ("HW" . 9744)
-  				      ("STUDY" . 9744)
-  				      ("SOMEDAY" . 9744)
-  				      ("READ" . 9744)
-  				      ("PROJ" . 9744)
-  				      ("CONTACT" . 9744)
-  				      ("DONE" . 9745)))
+                                    ("INPROG-TODO" . 9744)
+                                    ("HW" . 9744)
+                                    ("STUDY" . 9744)
+                                    ("SOMEDAY" . 9744)
+                                    ("READ" . 9744)
+                                    ("PROJ" . 9744)
+                                    ("CONTACT" . 9744)
+                                    ("DONE" . 9745)))
     ;; (org-superstar-headline-bullets-list '("✪" "✫" "✦" "✧" "✸" "✺"))
     :hook (org-mode . org-superstar-mode))
 
@@ -1511,25 +1985,25 @@ font size is computed + 20 of this value."
     'org-babel-load-languages
     (seq-filter
       (lambda (pair)
-	(locate-library (concat "ob-" (symbol-name (car pair)))))
+      (locate-library (concat "ob-" (symbol-name (car pair)))))
       '((emacs-lisp . t)
-	 (ditaa . t)
-	 (dot . t)
-	 (emacs-lisp . t)
-	 (gnuplot . t)
-	 (haskell . nil)
-	 (latex . t)
-	 (ledger . t)
-	 (ocaml . nil)
-	 (octave . t)
-	 (plantuml . t)
-	 (python . t)
-	 (ruby . t)
-	 (screen . nil)
-	 (sh . t) ;; obsolete
-	 (shell . t)
-	 (sql . t)
-	 (sqlite . t))))
+       (ditaa . t)
+       (dot . t)
+       (emacs-lisp . t)
+       (gnuplot . t)
+       (haskell . nil)
+       (latex . t)
+       (ledger . t)
+       (ocaml . nil)
+       (octave . t)
+       (plantuml . t)
+       (python . t)
+       (ruby . t)
+       (screen . nil)
+       (sh . t) ;; obsolete
+       (shell . t)
+       (sql . t)
+       (sqlite . t))))
   (push '("conf-unix" . conf-unix) org-src-lang-modes))
 
 ;;; --------------------------------------------------------------------------
@@ -1624,6 +2098,43 @@ font size is computed + 20 of this value."
          :jump-to-captured t)))
 
   (add-hook 'context-menu-functions #'denote-context-menu))
+
+;;; --------------------------------------------------------------------------
+
+(use-package projectile
+  :when (equal custom-project-handler 'custom-project-projectile)
+  :diminish Proj
+  :config (projectile-mode)
+  :bind-keymap
+  ("C-c p" . projectile-command-map)
+  :init
+  ;; NOTE: Set this to the folder where you keep your Git repos!
+  (when (file-directory-p "~/Developer")
+    (setq projectile-project-search-path '("~/Developer")))
+  (setq projectile-switch-project-action #'projectile-dired))
+
+(when (equal completion-handler 'comphand-ivy-counsel)
+  (use-package counsel-projectile
+    :when (equal custom-project-handler 'custom-project-projectile)
+    :after projectile
+    :config
+    (setq projectile-completion-system 'ivy)
+    (counsel-projectile-mode)))
+
+;;; --------------------------------------------------------------------------
+
+(defun project-find-go-module (dir)
+  (when-let ((root (locate-dominating-file dir "go.mod")))
+    (cons 'go-module root)))
+
+(use-package project
+  :when (equal custom-project-handler 'custom-project-project)
+  :ensure nil
+  :defer t
+  :config
+  (cl-defmethod project-root ((project (head go-module)))
+    (cdr project))
+  (add-hook 'project-find-functions #'project-find-go-module))
 
 ;;; --------------------------------------------------------------------------
 ;;; Treemacs
@@ -1993,342 +2504,6 @@ font size is computed + 20 of this value."
 
 ;;; --------------------------------------------------------------------------
 
-(use-package prescient)
-
-;;; --------------------------------------------------------------------------
-
-(use-package orderless
-  :when (or (equal completion-handler 'comphand-vertico)
-          (equal completion-handler 'comphand-ivy-counsel))
-  :custom
-  (completion-styles '(orderless basic))
-  (completion-category-overrides '((file (styles basic partial-completion)))))
-
-;;; --------------------------------------------------------------------------
-;;; Swiper and IVY mode
-
-(use-package ivy
-  :when (equal completion-handler 'comphand-ivy-counsel)
-  :bind (("C-s" . swiper)
-          :map ivy-minibuffer-map
-            ;;; ("TAB" . ivy-alt-done)
-          ("C-l" . ivy-alt-done)
-          ("C-j" . ivy-next-line)
-          ("C-k" . ivy-previous-line)
-          :map ivy-switch-buffer-map
-          ("C-k" . ivy-previous-line)
-          ("C-l" . ivy-done)
-          ("C-d" . ivy-switch-buffer-kill)
-          :map ivy-reverse-i-search-map
-          ("C-k" . ivy-previous-line)
-          ("C-d" . ivy-reverse-i-search-kill))
-  :custom
-  (enable-recursive-minibuffers t)
-  (ivy-use-virtual-buffers t)
-  :config
-  (ivy-mode 1)
-  (setq ivy-re-builders-alist '((t . orderless-ivy-re-builder)))
-  (add-to-list 'ivy-highlight-functions-alist
-    '(orderless-ivy-re-builder . orderless-ivy-highlight)))
-
-;;; --------------------------------------------------------------------------
-
-(use-package ivy-rich
-  :when (equal completion-handler 'comphand-ivy-counsel)
-  :after ivy
-  :init
-  (ivy-rich-mode 1)
-  :config
-  (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line))
-
-(use-package ivy-yasnippet
-  :when (equal completion-handler 'comphand-ivy-counsel)
-  :after (:any yasnippet ivy))
-;; :ensure (:host github :repo "mkcms/ivy-yasnippet"))
-
-;;; --------------------------------------------------------------------------
-
-(use-package swiper
-  :when (equal completion-handler 'comphand-ivy-counsel)
-  :after ivy)
-
-;;; --------------------------------------------------------------------------
-
-(use-package counsel
-  :when (equal completion-handler 'comphand-ivy-counsel)
-  :bind ( ("C-M-j" . 'counsel-switch-buffer)
-          ("M-x" . 'counsel-M-x)
-          ("M-g o" . 'counsel-outline)
-          ("C-x C-f" . 'counsel-find-file)
-          ("C-c C-r" . 'ivy-resume)
-          :map minibuffer-local-map
-          ("C-r" . 'counsel-minibuffer-history))
-  :custom
-  (counsel-linux-app-format-function #'counsel-linux-app-format-function-name-only)
-  :config
-  (counsel-mode 1))
-
-;;; --------------------------------------------------------------------------
-
-(use-package ivy-prescient
-  :when (equal completion-handler 'comphand-ivy-counsel)
-  :after (ivy prescient)
-  :custom
-  (prescient-persist-mode t)
-  (ivy-prescient-mode t)
-  (ivy-prescient-enable-filtering t))
-
-;;; --------------------------------------------------------------------------
-
-;;;; Code Completion
-(use-package corfu
-  :when (equal completion-handler 'comphand-corfu)
-  ;; Optional customizations
-  :custom
-  (corfu-cycle t)                  ; Allows cycling through candidates
-  (corfu-auto t)                   ; Enable auto completion
-  (corfu-auto-prefix 2)
-  (corfu-auto-delay 0.8)
-  (corfu-popupinfo-delay '(0.5 . 0.2))
-  (corfu-preview-current 'insert) ; insert previewed candidate
-  (corfu-preselect 'prompt)
-  (corfu-on-exact-match nil)       ; Don't auto expand tempel snippets
-  ;; Optionally use TAB for cycling, default is `corfu-complete'.
-  :bind (:map corfu-map
-        ("M-SPC"          . corfu-insert-separator)
-        ("TAB"            . corfu-next)
-        ([tab]            . corfu-next)
-        ("S-TAB"          . corfu-previous)
-        ([backtab]    . corfu-previous)
-        ("S-<return>" . corfu-insert)
-        ("RET"            . nil))
-  :init
-  (global-corfu-mode)
-  (corfu-history-mode)
-  (corfu-popupinfo-mode) ; Popup completion info
-  :config
-  (add-hook 'eshell-mode-hook
-    (lambda () (setq-local corfu-quit-at-boundary t
-               corfu-quit-no-match t
-               corfu-auto nil)
-      (corfu-mode))))
-
-;;; --------------------------------------------------------------------------
-;; Add extensions
-(use-package cape
-  :when (equal completion-handler 'comphand-corfu)
-  :after corfu
-  ;; Bind dedicated completion commands
-  ;; Alternative prefix keys: C-c p, M-p, M-+, ...
-  :bind ( ("C-c C-p p" . completion-at-point) ;; capf
-          ("C-c C-p t" . complete-tag)        ;; etags
-          ("C-c C-p d" . cape-dabbrev)        ;; or dabbrev-completion
-          ("C-c C-p h" . cape-history)
-          ("C-c C-p f" . cape-file)
-          ("C-c C-p k" . cape-keyword)
-          ("C-c C-p s" . cape-elisp-symbol)
-          ("C-c C-p e" . cape-elisp-block)
-          ("C-c C-p a" . cape-abbrev)
-          ("C-c C-p l" . cape-line)
-          ("C-c C-p w" . cape-dict)
-          ("C-c C-p :" . cape-emoji)
-          ("C-c C-p \\" . cape-tex)
-          ("C-c C-p _" . cape-tex)
-          ("C-c C-p ^" . cape-tex)
-          ("C-c C-p &" . cape-sgml)
-          ("C-c C-p r" . cape-rfc1345))
-  :init
-  ;; Add to the global default value of `completion-at-point-functions' which is
-  ;; used by `completion-at-point'.  The order of the functions matters, the
-  ;; first function returning a result wins.  Note that the list of buffer-local
-  ;; completion functions takes precedence over the global list.
-  (add-hook 'completion-at-point-functions #'cape-dabbrev)
-  (add-hook 'completion-at-point-functions #'cape-file)
-  (add-hook 'completion-at-point-functions #'cape-elisp-block)
-  ;;(add-hook 'completion-at-point-functions #'cape-history)
-  ;;(add-hook 'completion-at-point-functions #'cape-keyword)
-  ;;(add-hook 'completion-at-point-functions #'cape-tex)
-  ;;(add-hook 'completion-at-point-functions #'cape-sgml)
-  ;;(add-hook 'completion-at-point-functions #'cape-rfc1345)
-  ;;(add-hook 'completion-at-point-functions #'cape-abbrev)
-  ;;(add-hook 'completion-at-point-functions #'cape-dict)
-  ;;(add-hook 'completion-at-point-functions #'cape-elisp-symbol)
-  ;;(add-hook 'completion-at-point-functions #'cape-line)
-  )
-
-;;; --------------------------------------------------------------------------
-
-(use-package corfu-prescient
-  :when (equal completion-handler 'comphand-corfu)
-  :after (corfu prescient))
-
-;;; --------------------------------------------------------------------------
-
-(use-package vertico
-  :when (equal completion-handler 'comphand-vertico)
-  :demand t
-  ;;:wait t
-  ;;:ensure (:repo "minad/vertico" :files (:defaults "extensions/vertico-*.el") :fetcher github)
-  :custom
-  (recentf-mode t)
-  (vertico-count 12)
-  (vertico-cycle nil)
-  (vertico-multiform-mode 1)
-  :config
-  (vertico-mode)
-  ;; :bind ("C-x C-f" . ido-find-file)
-  ;; Clean up file path when typing
-  :hook ((rfn-eshadow-update-overlay . vertico-directory-tidy)
-        ;; Make sure vertico state is saved
-        (minibuffer-setup . vertico-repeat-save)))
-
-;;; --------------------------------------------------------------------------
-
-(use-package marginalia
-  ;; :when (equal completion-handler 'comphand-vertico)
-  ;; :after vertico
-  :custom
-  (marginalia-max-relative-age 0)
-  (marginalia-align 'left)
-  (marginalia-annotators '(marginalia-annotators-heavy marginalia-annotators-light nil))
-  :config
-  (marginalia-mode t))
-
-;;; --------------------------------------------------------------------------
-
-(use-package all-the-icons-completion
-  :after (marginalia all-the-icons)
-  :hook (marginalia-mode . all-the-icons-completion-marginalia-setup))
-
-;;; --------------------------------------------------------------------------
-
-(use-package consult
-  :when (equal completion-handler 'comphand-vertico)
-  :after vertico
-  :bind
-  ([remap switch-to-buffer] . consult-buffer)
-  ([remap switch-to-buffer-other-window] . consult-buffer-other-window)
-  ([remap switch-to-buffer-other-frame] . consult-buffer-other-frame)
-  ([remap project-switch-to-buffer] . consult-project-buffer)
-  ([remap bookmark-jump] . consult-bookmark)
-  ([remap recentf-open] . consult-recent-file)
-  ([remap yank] . nil)
-  ([remap yank-pop] . consult-yank-pop)
-  ([remap goto-line] . consult-goto-line)
-  ("M-g m" . consult-mark)
-  ("M-g M" . consult-global-mark)
-  ("M-g o" . consult-outline)
-  ("M-g i" . consult-imenu)
-  ("M-g I" . consult-imenu-multi)
-  ("M-s l" . consult-line)
-  ("M-s p" . consult-preview)  
-  ("M-s L" . consult-line-multi)
-  ("M-s k" . consult-keep-lines)
-  ("M-s u" . consult-focus-lines)
-  ("M-s r" . consult-ripgrep)
-  ("M-s f" . consult-find)
-  ("M-s F" . consult-locate)
-  ("M-g e" . consult-compile-error)
-  ("M-g f" . consult-flymake)
-  ([remap repeat-complex-command] . consult-complex-command)
-  ("M-s e" . consult-isearch-history)
-  ([remap isearch-edit-string] . consult-isearch-history)
-  ([remap next-matching-history-element] . consult-history)
-  ([remap previous-matching-history-element] . consult-history)
-  ([remap Info-search] . consult-info)
-  :custom
-  (xref-show-xrefs-function 'consult-xref)
-  (xref-show-definitions-function 'consult-xref)
-  :config
-  (setq consult-buffer-sources
-    '(consult--source-hidden-buffer 
-       consult--source-buffer
-       (:name "Ephemeral" :state consult--buffer-state
-       :narrow 109 :category buffer
-       :items ("*Messages*"  "*scratch*" "*vterm*"
-                "*Async-native-compile-log*" "*dashboard*"))
-       consult--source-modified-buffer
-       consult--source-recent-file)))
-
-;;; --------------------------------------------------------------------------
-
-(use-package vertico-prescient
-  :when (equal completion-handler 'comphand-vertico)
-  :after vertico prescient)
-
-;;; --------------------------------------------------------------------------
-
-(use-package vertico-posframe
-  :when (equal completion-handler 'comphand-vertico)
-  :after vertico
-  :custom
-  (setq vertico-multiform-commands
-    '((consult-line
-        posframe
-        (vertico-posframe-poshandler . posframe-poshandler-frame-top-center)
-        (vertico-posframe-border-width . 10)
-        ;; NOTE: This is useful when emacs is used in both in X and
-        ;; terminal, for posframe do not work well in terminal, so
-        ;; vertico-buffer-mode will be used as fallback at the
-        ;; moment.
-        (vertico-posframe-fallback-mode . vertico-buffer-mode))
-       (t posframe)))
-  (vertico-multiform-mode 1)
-  (setq vertico-posframe-parameters
-    '((left-fringe . 8)
-       (right-fringe . 8))))
-
-;;; --------------------------------------------------------------------------
-
-;; This has to be evaluated at the end of the init since it's possible that the
-;; completion-handler variable will not yet be defined at this point in the
-;; init phase using elpaca.
-(add-hook 'elpaca-after-init-hook
-  (lambda ()
-    (when (equal completion-handler 'comphand-built-in)
-      (ido-everywhere t))))
-
-;;; --------------------------------------------------------------------------
-
-(use-package embark
-  :when enable-embark
-  :bind
-  (("C-." . embark-act)         ;; pick some comfortable binding
-    ("C-;" . embark-dwim)        ;; good alternative: M-.
-    ("C-h B" . embark-bindings)) ;; alternative for `describe-bindings'
-
-  :init
-
-  ;; Optionally replace the key help with a completing-read interface
-  (setq prefix-help-command #'embark-prefix-help-command)
-
-  ;; Show the Embark target at point via Eldoc. You may adjust the
-  ;; Eldoc strategy, if you want to see the documentation from
-  ;; multiple providers. Beware that using this can be a little
-  ;; jarring since the message shown in the minibuffer can be more
-  ;; than one line, causing the modeline to move up and down:
-
-  ;; (add-hook 'eldoc-documentation-functions #'embark-eldoc-first-target)
-  ;; (setq eldoc-documentation-strategy #'eldoc-documentation-compose-eagerly)
-
-  :config
-
-  ;; Hide the mode line of the Embark live/completions buffers
-  (add-to-list 'display-buffer-alist
-    '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
-       nil
-       (window-parameters (mode-line-format . none)))))
-
-;; Consult users will also want the embark-consult package.
-(use-package embark-consult
-  :when (equal completion-handler 'comphand-vertico)
-  :defer t
-  ;;:ensure t ; only need to install it, embark loads it after consult if found
-  :hook
-  (embark-collect-mode . consult-preview-at-point-mode))
-
-;;; --------------------------------------------------------------------------
-
 (use-package flycheck
   :unless (equal custom-ide 'custom-ide-elpy)
   :diminish FlM
@@ -2691,7 +2866,7 @@ font size is computed + 20 of this value."
   :custom
   (compile-command "go build -v && go test -v && go vet")
   :bind (:map go-mode-map
-	  ("C-c C-c" . 'compile))
+        ("C-c C-c" . 'compile))
   :config
   (eglot-format-buffer-on-save)
   (define-key (current-local-map) "\C-c\C-c" 'compile)
@@ -3012,176 +3187,6 @@ font size is computed + 20 of this value."
     ("Q" mifi/dap-delete-all-debug-sessions :color red)))
 
 ;;; --------------------------------------------------------------------------
-
-;; Don't use lsp-bridge with company as lsp-bridge already provides the same
-;; features. They actually collide.
-
-(use-package company
-  :unless (equal custom-ide 'custom-ide-lsp-bridge)
-  :custom
-  (company-minimum-prefix-length 2)
-  (company-idle-delay 0.2)
-  :config
-  (global-company-mode +1))
-
-;;; --------------------------------------------------------------------------
-
-(use-package company-box
-  :after company
-  :diminish cb
-  :hook (company-mode . company-box-mode))
-
-(use-package company-jedi
-  :when  (equal custom-ide 'custom-ide-elpy)
-  :after python company
-  :config
-  (jedi:setup)
-  (defun my/company-jedi-python-mode-hook ()
-    (add-to-list 'company-backends 'company-jedi))
-  (add-hook 'python-mode-hook 'my/company-jedi-python-mode-hook))
-
-(use-package company-anaconda
-  :when (equal custom-ide 'custom-ide-anaconda)
-  :after anaconda company
-  :hook (python-mode . anaconda-mode)
-  :config
-  (eval-after-load "company"
-    '(add-to-list 'company-backends 'company-anaconda)))
-
-;;; --------------------------------------------------------------------------
-
-(use-package projectile
-  :when (equal custom-project-handler 'custom-project-projectile)
-  :diminish Proj
-  :config (projectile-mode)
-  :bind-keymap
-  ("C-c p" . projectile-command-map)
-  :init
-  ;; NOTE: Set this to the folder where you keep your Git repos!
-  (when (file-directory-p "~/Developer")
-    (setq projectile-project-search-path '("~/Developer")))
-  (setq projectile-switch-project-action #'projectile-dired))
-
-(when (equal completion-handler 'comphand-ivy-counsel)
-  (use-package counsel-projectile
-    :when (equal custom-project-handler 'custom-project-projectile)
-    :after projectile
-    :config
-    (setq projectile-completion-system 'ivy)
-    (counsel-projectile-mode)))
-
-;;; --------------------------------------------------------------------------
-
-(defun project-find-go-module (dir)
-  (when-let ((root (locate-dominating-file dir "go.mod")))
-    (cons 'go-module root)))
-
-(use-package project
-  :when (equal custom-project-handler 'custom-project-project)
-  :ensure nil
-  :defer t
-  :config
-  (cl-defmethod project-root ((project (head go-module)))
-    (cdr project))
-  (add-hook 'project-find-functions #'project-find-go-module))
-
-;;; --------------------------------------------------------------------------
-
-(use-package term+
-  ;;:ensure (:repo "tarao/term-plus-el" :fetcher github)
-  :commands term
-  :config
-  (setq explicit-shell-file-name "bash") ;; Change this to zsh, etc
-  ;;(setq explicit-zsh-args '())          ;; Use 'explicit-<shell>-args for shell-specific args
-
-  ;; Match the default Bash shell prompt.  Update this if you have a custom prompt
-  (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *"))
-
-;;; --------------------------------------------------------------------------
-
-(use-package eterm-256color
-  :hook (term-mode . eterm-256color-mode))
-
-;;; --------------------------------------------------------------------------
-
-(use-package vterm
-  ;;:ensure (:fetcher github :repo "akermu/emacs-libvterm")
-  :commands vterm
-  :config
-  (setq vterm-environment ("PS1=\\u@\\h:\\w \n$"))
-  (setq term-prompt-regexp "^[^#$%>\n]*[#$%>] *")  ;; Set this to match your custom shell prompt
-  (setq vterm-shell "zsh")                        ;; Set this to customize the shell to launch
-  (setq vterm-max-scrollback 10000))
-
-;;; --------------------------------------------------------------------------
-
-(defun mifi/configure-eshell ()
-  ;; Save command history when commands are entered
-  (add-hook 'eshell-pre-command-hook 'eshell-save-some-history)
-  ;; Truncate buffer for performance
-  (add-to-list 'eshell-output-filter-functions 'eshell-truncate-buffer)
-  (setq eshell-history-size   10000
-    eshell-buffer-maximum-lines 10000
-    eshell-hist-ignoredups t
-    eshell-scroll-to-bottom-on-input t))
-
-(use-package eshell-git-prompt
-  :after eshell)
-
-(use-package eshell
-  :ensure
-  :defer t
-  :hook (eshell-first-time-mode . mifi/configure-eshell)
-  :config
-  (with-eval-after-load 'esh-opt
-    (setq eshell-destroy-buffer-when-process-dies t)
-    (setq eshell-visual-commands '("htop" "zsh" "vim")))
-  (eshell-git-prompt-use-theme 'powerline))
-
-;;; --------------------------------------------------------------------------
-
-  ;; Prefer g-prefixed coreutils version of standard utilities when available
-(let ((gls (executable-find "gls")))
-  (when gls (setq-default insert-directory-program gls
-	      dired-use-ls-dired t
-              ;; Needed to fix an issue on Mac which causes dired to fail
-              dired-listing-switches "-al --group-directories-first")))
-
-(use-package all-the-icons-dired
-  :after dired
-  :hook (dired-mode . all-the-icons-dired-mode))
-
-(use-package dired-open
-  :commands (dired dired-jump)
-  :config
-  ;; Doesn't work as expected!
-  ;;(add-to-list 'dired-open-functions #'dired-open-xdg t)
-  (setq dired-open-extensions '(("png" . "feh")
-                               ("mkv" . "mpv"))))
-
-(use-package dired-hide-dotfiles
-  :after dired-mode
-  :hook (dired-mode . dired-hide-dotfiles-mode))
-
-;;; --------------------------------------------------------------------------
-;; Single Window dired - don't continually open new buffers
-
-(defun mifi/dired-single-keymap-init ()
-  "Bunch of stuff to run for dired, either immediately or when it's
-   loaded."
-  (define-key dired-mode-map
-    [remap dired-find-file] 'dired-single-buffer)
-  (define-key dired-mode-map
-    [remap dired-mouse-find-file-other-window] 'dired-single-buffer-mouse)
-  (define-key dired-mode-map
-    [remap dired-up-directory] 'dired-single-up-directory))
-
-(use-package dired-single
-  :after dired
-  :config
-  (mifi/dired-single-keymap-init))
-
-;;; --------------------------------------------------------------------------
 ;; helpful package
 
 (use-package helpful
@@ -3198,6 +3203,23 @@ font size is computed + 20 of this value."
   (bind-keys
     ([remap describe-command] . helpful-command)
     ([remap describe-key] . helpful-key)))
+
+(use-package mw-thesaurus
+  :when enable-thesaurus
+  :ensure t
+  :custom
+  (mw-thesaurus-api-key "429331e9-b40e-4f17-9988-0632ef3ddd2d")
+  :defer t
+  :commands mw-thesaurus-lookup-dwim
+  :hook (mw-thesaurus-mode . variable-pitch-mode)
+  :config
+  ;; window on the right side
+  (add-to-list 'display-buffer-alist '(,mw-thesaurus-buffer-name
+                                      (display-buffer-reuse-window
+                                        display-buffer-in-direction)
+                                      (direction . right)
+                                      (window . root)
+                                      (window-width . 0.3))))
 
 ;;; --------------------------------------------------------------------------
 
@@ -3300,15 +3322,20 @@ font size is computed + 20 of this value."
 
 (defun mifi/set-fill-column-interactively (num)
   "Asks for the fill column."
-  (interactive "nfill-column: ")
+  (interactive "fill-column: ")
   (set-fill-column num))
 
 (defun mifi/set-org-fill-column-interactively (num)
   "Asks for the fill column for Org mode."
-  (interactive "norg-fill-column: ")
+  (interactive "org-fill-column: ")
   (setq custom-org-fill-column num)
   (mifi/org-mode-visual-fill)
   (redraw-display))
+
+(defun mifi/jump-to-register ()
+  "Asks for a register to jump to."
+  (interactive)
+  (call-interactively 'jump-to-register))
 
 ;;; --------------------------------------------------------------------------
 
@@ -3316,20 +3343,21 @@ font size is computed + 20 of this value."
   (defvar mmm-keys-minor-mode-map
     (let ((map (make-sparse-keymap)))
       (bind-keys :map map
-	("M-RET $" . jinx-correct)
-        ("M-RET p" . pulsar-pulse-line)
-        ("M-RET d" . dashboard-open)
+      ("M-RET $" . jinx-correct)
+        ("M-RET ?" . eldoc-box-help-at-point)
         ("M-RET S e" . eshell)
-        ("M-RET f" . mifi/set-fill-column-interactively)
-        ("M-RET r" . repeat-mode)
         ("M-RET S i" . ielm)
         ("M-RET S v" . vterm-other-window)
-        ("M-RET t" . treemacs)
-        ("M-RET |" . global-display-fill-column-indicator-mode)
         ("M-RET T +" . next-theme)
         ("M-RET T -" . previous-theme)
         ("M-RET T ?" . which-theme)
-        ("M-RET ?" . eldoc-box-help-at-point))
+        ("M-RET d" . dashboard-open)
+        ("M-RET e" . treemacs) ;; e for Explore
+        ("M-RET f" . mifi/set-fill-column-interactively)
+        ("M-RET p" . pulsar-pulse-line)
+        ("M-RET r" . repeat-mode)
+      ("M-RET j" . mifi/jump-to-register)
+        ("M-RET |" . global-display-fill-column-indicator-mode))
       map)
     "mmm-keys-minor-mode keymap.")
 
@@ -3350,6 +3378,9 @@ font size is computed + 20 of this value."
     (unbind-key "M-RET o l" map)
     (unbind-key "M-RET P ?" map)
     (unbind-key "M-RET M-RET" map)
+    (when enable-thesaurus
+      (bind-keys :map map
+      ("M-RET m t" . mw-thesaurus-lookup-dwim)))
     (cond
       ((equal major-mode 'org-mode)
       (bind-keys :map map
@@ -3367,8 +3398,10 @@ font size is computed + 20 of this value."
   (which-key-add-key-based-replacements "M-RET T" "theme-keys")
   (which-key-add-key-based-replacements "M-RET P" "python-menu")
   (which-key-add-key-based-replacements "M-RET o" "org-menu")
-  (which-key-add-key-based-replacements "M-RET t" "treemacs-toggle")
+  (which-key-add-key-based-replacements "M-RET e" "treemacs-toggle")
+  (which-key-add-key-based-replacements "M-RET m" "Thesaurus")
   (which-key-add-key-based-replacements "M-RET f" "set-fill-column")
+  (which-key-add-key-based-replacements "M-RET j" "jump-to-register")
   (which-key-add-key-based-replacements "M-RET" "Mitch's Menu"))
 
 (add-hook 'which-key-inhibit-display-hook 'mifi/mmm-update-menu)
@@ -3383,15 +3416,15 @@ font size is computed + 20 of this value."
   (lambda ()
     (setq-default initial-scratch-message
       (format
-	";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
-	";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
+      ";; Hello, World and Happy hacking %s!\n%s\n\n" user-login-name
+      ";; Press M-RET (Meta-RET) to open Mitch's Context Aware Menu"))
     (when dashboard-landing-screen (dashboard-open))))
 
 (when dashboard-landing-screen
   ;; (add-hook 'inferior-emacs-lisp-mode 'dashboard-open) ;; IELM open?
   (add-hook 'elpaca-after-init-hook
-	(lambda ()
-	  (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
+      (lambda ()
+        (add-hook 'lisp-interaction-mode-hook #'dashboard-open))))
 
 ;;; --------------------------------------------------------------------------
 

--- a/init.el
+++ b/init.el
@@ -752,15 +752,16 @@ font size is computed + 20 of this value."
 
 (use-package dashboard
   :custom
-  (dashboard-items '(   (recents . 15)
-                      (bookmarks . 10)
-                      (projects . 10)))
+  (dashboard-items '( (recents   . 12)
+                      (bookmarks . 5)
+                      (projects  . 5)
+                      (agenda    . 5)))
   (dashboard-center-content t)
   (dashboard-set-heading-icons t)
   (dashboard-set-file-icons t)
   (dashboard-footer-messages '("Greetings Program!"))
   (dashboard-banner-logo-title "Welcome to Emacs!")
-  (dashboard-startup-banner 'logo)
+  (dashboard-startup-banner (expand-file-name "Emacs-modern-is-sexy-v1.png" user-emacs-directory))
   :bind ("C-c d" . dashboard-open)
   :config
   ;; (setq initial-buffer-choice (lambda () (get-buffer-create dashboard-buffer-name)))
@@ -1993,6 +1994,9 @@ font size is computed + 20 of this value."
 ;;; ##########################################################################
 
 (defun mifi/org-setup-agenda ()
+  "Function to setup basic org-agenda settings."
+  (bind-key "C-c a" 'org-agenda org-mode-map)
+  
   (setq org-agenda-custom-commands
     '(("d" "Dashboard"
         ((agenda "" ((org-deadline-warning-days 7)))

--- a/lisp/palenight-deeper-blue-theme.el
+++ b/lisp/palenight-deeper-blue-theme.el
@@ -300,5 +300,6 @@
 
 ;; Local Variables:
 ;; no-byte-compile: t
+;; End:
 
 ;;; palenight-deeper-blue-theme.el ends here.

--- a/lisp/rainbow-mode.el
+++ b/lisp/rainbow-mode.el
@@ -1,0 +1,1218 @@
+;;; rainbow-mode.el --- Colorize color names in buffers  -*- lexical-binding: nil -*-
+
+;; Copyright (C) 2010-2020 Free Software Foundation, Inc
+
+;; Author: Julien Danjou <julien@danjou.info>
+;; Keywords: faces
+;; Version: 1.0.6
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; This minor mode sets background color to strings that match color
+;; names, e.g. #0000ff is displayed in white with a blue background.
+;;
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'regexp-opt)
+(require 'faces)
+(require 'color)
+
+(unless (require 'xterm-color nil t)
+  (require 'ansi-color))
+
+(defgroup rainbow nil
+  "Show color strings with a background color."
+  :tag "Rainbow"
+  :group 'help)
+
+;;; Hexadecimal colors
+
+(defvar rainbow-hexadecimal-colors-font-lock-keywords
+  '(("[^&]\\(#\\(?:[0-9a-fA-F]\\{3\\}\\)\\{1,4\\}\\)\\b"
+     (1 (rainbow-colorize-itself 1)))
+    ("^\\(#\\(?:[0-9a-fA-F]\\{3\\}\\)\\{1,4\\}\\)\\b"
+     (0 (rainbow-colorize-itself)))
+    ("[Rr][Gg][Bb]:[0-9a-fA-F]\\{1,4\\}/[0-9a-fA-F]\\{1,4\\}/[0-9a-fA-F]\\{1,4\\}"
+     (0 (rainbow-colorize-itself)))
+    ("[Rr][Gg][Bb][Ii]:[0-9.]+/[0-9.]+/[0-9.]+"
+     (0 (rainbow-colorize-itself)))
+    ("\\(?:[Cc][Ii][Ee]\\(?:[Xx][Yy][Zz]\\|[Uu][Vv][Yy]\\|[Xx][Yy][Yy]\\|[Ll][Aa][Bb]\\|[Ll][Uu][Vv]\\)\\|[Tt][Ee][Kk][Hh][Vv][Cc]\\):[+-]?[0-9.]+\\(?:[Ee][+-]?[0-9]+\\)?/[+-]?[0-9.]+\\(?:[Ee][+-]?[0-9]+\\)?/[+-]?[0-9.]+\\(?:[Ee][+-]?[0-9]+\\)?"
+     (0 (rainbow-colorize-itself))))
+  "Font-lock keywords to add for hexadecimal colors.")
+
+;;; rgb() colors
+
+(defvar rainbow-html-rgb-colors-font-lock-keywords
+  '(("rgb(\s*\\([0-9]\\{1,3\\}\\(?:\.[0-9]\\)?\\(?:\s*%\\)?\\)\s*,\s*\\([0-9]\\{1,3\\}\\(?:\\.[0-9]\\)?\\(?:\s*%\\)?\\)\s*,\s*\\([0-9]\\{1,3\\}\\(?:\\.[0-9]\\)?\\(?:\s*%\\)?\\)\s*)"
+     (0 (rainbow-colorize-rgb)))
+    ("rgba(\s*\\([0-9]\\{1,3\\}\\(?:\\.[0-9]\\)?\\(?:\s*%\\)?\\)\s*,\s*\\([0-9]\\{1,3\\}\\(?:\\.[0-9]\\)?\\(?:\s*%\\)?\\)\s*,\s*\\([0-9]\\{1,3\\}\\(?:\\.[0-9]\\)?\\(?:\s*%\\)?\\)\s*,\s*[0-9]*\.?[0-9]+\s*%?\s*)"
+     (0 (rainbow-colorize-rgb)))
+    ("hsl(\s*\\([0-9]\\{1,3\\}\\)\s*,\s*\\([0-9]\\{1,3\\}\\)\s*%\s*,\s*\\([0-9]\\{1,3\\}\\)\s*%\s*)"
+     (0 (rainbow-colorize-hsl)))
+    ("hsla(\s*\\([0-9]\\{1,3\\}\\)\s*,\s*\\([0-9]\\{1,3\\}\\)\s*%\s*,\s*\\([0-9]\\{1,3\\}\\)\s*%\s*,\s*[0-9]*\.?[0-9]+\s*%?\s*)"
+     (0 (rainbow-colorize-hsl))))
+  "Font-lock keywords to add for RGB colors.")
+
+;;; HTML colors
+
+(defvar rainbow-html-colors-font-lock-keywords nil
+  "Font-lock keywords to add for HTML colors.")
+(make-variable-buffer-local 'rainbow-html-colors-font-lock-keywords)
+
+(defcustom rainbow-html-colors-alist
+  '(("AliceBlue" . "#F0F8FF")
+    ("AntiqueWhite" . "#FAEBD7")
+    ("Aqua" . "#00FFFF")
+    ("Aquamarine" . "#7FFFD4")
+    ("Azure" . "#F0FFFF")
+    ("Beige" . "#F5F5DC")
+    ("Bisque" . "#FFE4C4")
+    ("Black" . "#000000")
+    ("BlanchedAlmond" . "#FFEBCD")
+    ("Blue" . "#0000FF")
+    ("BlueViolet" . "#8A2BE2")
+    ("Brown" . "#A52A2A")
+    ("BurlyWood" . "#DEB887")
+    ("CadetBlue" . "#5F9EA0")
+    ("Chartreuse" . "#7FFF00")
+    ("Chocolate" . "#D2691E")
+    ("Coral" . "#FF7F50")
+    ("CornflowerBlue" . "#6495ED")
+    ("Cornsilk" . "#FFF8DC")
+    ("Crimson" . "#DC143C")
+    ("Cyan" . "#00FFFF")
+    ("DarkBlue" . "#00008B")
+    ("DarkCyan" . "#008B8B")
+    ("DarkGoldenRod" . "#B8860B")
+    ("DarkGray" . "#A9A9A9")
+    ("DarkGrey" . "#A9A9A9")
+    ("DarkGreen" . "#006400")
+    ("DarkKhaki" . "#BDB76B")
+    ("DarkMagenta" . "#8B008B")
+    ("DarkOliveGreen" . "#556B2F")
+    ("Darkorange" . "#FF8C00")
+    ("DarkOrchid" . "#9932CC")
+    ("DarkRed" . "#8B0000")
+    ("DarkSalmon" . "#E9967A")
+    ("DarkSeaGreen" . "#8FBC8F")
+    ("DarkSlateBlue" . "#483D8B")
+    ("DarkSlateGray" . "#2F4F4F")
+    ("DarkSlateGrey" . "#2F4F4F")
+    ("DarkTurquoise" . "#00CED1")
+    ("DarkViolet" . "#9400D3")
+    ("DeepPink" . "#FF1493")
+    ("DeepSkyBlue" . "#00BFFF")
+    ("DimGray" . "#696969")
+    ("DimGrey" . "#696969")
+    ("DodgerBlue" . "#1E90FF")
+    ("FireBrick" . "#B22222")
+    ("FloralWhite" . "#FFFAF0")
+    ("ForestGreen" . "#228B22")
+    ("Fuchsia" . "#FF00FF")
+    ("Gainsboro" . "#DCDCDC")
+    ("GhostWhite" . "#F8F8FF")
+    ("Gold" . "#FFD700")
+    ("GoldenRod" . "#DAA520")
+    ("Gray" . "#808080")
+    ("Grey" . "#808080")
+    ("Green" . "#008000")
+    ("GreenYellow" . "#ADFF2F")
+    ("HoneyDew" . "#F0FFF0")
+    ("HotPink" . "#FF69B4")
+    ("IndianRed" . "#CD5C5C")
+    ("Indigo" . "#4B0082")
+    ("Ivory" . "#FFFFF0")
+    ("Khaki" . "#F0E68C")
+    ("Lavender" . "#E6E6FA")
+    ("LavenderBlush" . "#FFF0F5")
+    ("LawnGreen" . "#7CFC00")
+    ("LemonChiffon" . "#FFFACD")
+    ("LightBlue" . "#ADD8E6")
+    ("LightCoral" . "#F08080")
+    ("LightCyan" . "#E0FFFF")
+    ("LightGoldenRodYellow" . "#FAFAD2")
+    ("LightGray" . "#D3D3D3")
+    ("LightGrey" . "#D3D3D3")
+    ("LightGreen" . "#90EE90")
+    ("LightPink" . "#FFB6C1")
+    ("LightSalmon" . "#FFA07A")
+    ("LightSeaGreen" . "#20B2AA")
+    ("LightSkyBlue" . "#87CEFA")
+    ("LightSlateGray" . "#778899")
+    ("LightSlateGrey" . "#778899")
+    ("LightSteelBlue" . "#B0C4DE")
+    ("LightYellow" . "#FFFFE0")
+    ("Lime" . "#00FF00")
+    ("LimeGreen" . "#32CD32")
+    ("Linen" . "#FAF0E6")
+    ("Magenta" . "#FF00FF")
+    ("Maroon" . "#800000")
+    ("MediumAquaMarine" . "#66CDAA")
+    ("MediumBlue" . "#0000CD")
+    ("MediumOrchid" . "#BA55D3")
+    ("MediumPurple" . "#9370D8")
+    ("MediumSeaGreen" . "#3CB371")
+    ("MediumSlateBlue" . "#7B68EE")
+    ("MediumSpringGreen" . "#00FA9A")
+    ("MediumTurquoise" . "#48D1CC")
+    ("MediumVioletRed" . "#C71585")
+    ("MidnightBlue" . "#191970")
+    ("MintCream" . "#F5FFFA")
+    ("MistyRose" . "#FFE4E1")
+    ("Moccasin" . "#FFE4B5")
+    ("NavajoWhite" . "#FFDEAD")
+    ("Navy" . "#000080")
+    ("OldLace" . "#FDF5E6")
+    ("Olive" . "#808000")
+    ("OliveDrab" . "#6B8E23")
+    ("Orange" . "#FFA500")
+    ("OrangeRed" . "#FF4500")
+    ("Orchid" . "#DA70D6")
+    ("PaleGoldenRod" . "#EEE8AA")
+    ("PaleGreen" . "#98FB98")
+    ("PaleTurquoise" . "#AFEEEE")
+    ("PaleVioletRed" . "#D87093")
+    ("PapayaWhip" . "#FFEFD5")
+    ("PeachPuff" . "#FFDAB9")
+    ("Peru" . "#CD853F")
+    ("Pink" . "#FFC0CB")
+    ("Plum" . "#DDA0DD")
+    ("PowderBlue" . "#B0E0E6")
+    ("Purple" . "#800080")
+    ("Red" . "#FF0000")
+    ("RosyBrown" . "#BC8F8F")
+    ("RoyalBlue" . "#4169E1")
+    ("SaddleBrown" . "#8B4513")
+    ("Salmon" . "#FA8072")
+    ("SandyBrown" . "#F4A460")
+    ("SeaGreen" . "#2E8B57")
+    ("SeaShell" . "#FFF5EE")
+    ("Sienna" . "#A0522D")
+    ("Silver" . "#C0C0C0")
+    ("SkyBlue" . "#87CEEB")
+    ("SlateBlue" . "#6A5ACD")
+    ("SlateGray" . "#708090")
+    ("SlateGrey" . "#708090")
+    ("Snow" . "#FFFAFA")
+    ("SpringGreen" . "#00FF7F")
+    ("SteelBlue" . "#4682B4")
+    ("Tan" . "#D2B48C")
+    ("Teal" . "#008080")
+    ("Thistle" . "#D8BFD8")
+    ("Tomato" . "#FF6347")
+    ("Turquoise" . "#40E0D0")
+    ("Violet" . "#EE82EE")
+    ("Wheat" . "#F5DEB3")
+    ("White" . "#FFFFFF")
+    ("WhiteSmoke" . "#F5F5F5")
+    ("Yellow" . "#FFFF00")
+    ("YellowGreen" . "#9ACD32"))
+  "Alist of HTML colors.
+Each entry should have the form (COLOR-NAME . HEXADECIMAL-COLOR)."
+  :type 'alist
+  :group 'rainbow)
+
+(defcustom rainbow-html-colors-major-mode-list
+  '(html-mode css-mode php-mode nxml-mode xml-mode)
+  "List of major mode where HTML colors are enabled when
+`rainbow-html-colors' is set to auto."
+  :type '(repeat (symbol :tag "Major-Mode"))
+  :group 'rainbow)
+
+(defcustom rainbow-html-colors 'auto
+  "When to enable HTML colors.
+If set to t, the HTML colors will be enabled.  If set to nil, the
+HTML colors will not be enabled.  If set to auto, the HTML colors
+will be enabled if a major mode has been detected from the
+`rainbow-html-colors-major-mode-list'."
+  :type '(choice (symbol :tag "enable in certain modes" auto)
+                 (symbol :tag "enable globally" t)
+                 (symbol :tag "disable" nil))
+  :group 'rainbow)
+
+;;; X colors
+
+(defvar rainbow-x-colors-font-lock-keywords
+  `((,(regexp-opt (defined-colors) 'words)
+     (0 (rainbow-colorize-itself))))
+  "Font-lock keywords to add for X colors.")
+
+(defcustom rainbow-x-colors-major-mode-list
+  '(emacs-lisp-mode lisp-interaction-mode c-mode c++-mode java-mode)
+  "List of major mode where X colors are enabled when
+`rainbow-x-colors' is set to auto."
+  :type '(repeat (symbol :tag "Major-Mode"))
+  :group 'rainbow)
+
+(defcustom rainbow-x-colors 'auto
+  "When to enable X colors.
+If set to t, the X colors will be enabled.  If set to nil, the
+X colors will not be enabled.  If set to auto, the X colors
+will be enabled if a major mode has been detected from the
+`rainbow-x-colors-major-mode-list'."
+  :type '(choice (symbol :tag "enable in certain modes" auto)
+                 (symbol :tag "enable globally" t)
+                 (symbol :tag "disable" nil))
+  :group 'rainbow)
+
+;;; LaTeX colors
+
+(defvar rainbow-latex-rgb-colors-font-lock-keywords
+  '(("{rgb}{\\([0-9.]+\\),\s*\\([0-9.]+\\),\s*\\([0-9.]+\\)}"
+     (0 (rainbow-colorize-rgb-float)))
+    ("{RGB}{\\([0-9]\\{1,3\\}\\),\s*\\([0-9]\\{1,3\\}\\),\s*\\([0-9]\\{1,3\\}\\)}"
+     (0 (rainbow-colorize-rgb)))
+    ("{HTML}{\\([0-9A-Fa-f]\\{6\\}\\)}"
+     (0 (rainbow-colorize-hexadecimal-without-sharp))))
+  "Font-lock keywords to add for LaTeX colors.")
+
+(defcustom rainbow-latex-colors-major-mode-list
+  '(latex-mode)
+  "List of major mode where LaTeX colors are enabled when
+`rainbow-x-colors' is set to auto."
+  :type '(repeat (symbol :tag "Major-Mode"))
+  :group 'rainbow)
+
+(defcustom rainbow-latex-colors 'auto
+  "When to enable LaTeX colors.
+If set to t, the LaTeX colors will be enabled. If set to nil, the
+LaTeX colors will not be enabled.  If set to auto, the LaTeX colors
+will be enabled if a major mode has been detected from the
+`rainbow-latex-colors-major-mode-list'."
+  :type '(choice (symbol :tag "enable in certain modes" auto)
+                 (symbol :tag "enable globally" t)
+                 (symbol :tag "disable" nil))
+  :group 'rainbow)
+
+;;; Shell colors
+
+(defvar rainbow-ansi-colors-font-lock-keywords
+  '(("\\(\\\\[eE]\\|\\\\033\\|\\\\x1[bB]\\|\033\\)\\[\\([0-9;]*m\\)"
+     (0 (rainbow-colorize-ansi))))
+  "Font-lock keywords to add for ANSI colors.")
+
+(defcustom rainbow-ansi-colors-major-mode-list
+  '(sh-mode c-mode c++-mode)
+  "List of major mode where ANSI colors are enabled when
+`rainbow-ansi-colors' is set to auto."
+  :type '(repeat (symbol :tag "Major-Mode"))
+  :group 'rainbow)
+
+(defcustom rainbow-ansi-colors 'auto
+  "When to enable ANSI colors.
+If set to t, the ANSI colors will be enabled. If set to nil, the
+ANSI colors will not be enabled.  If set to auto, the ANSI colors
+will be enabled if a major mode has been detected from the
+`rainbow-ansi-colors-major-mode-list'."
+  :type '(choice (symbol :tag "enable in certain modes" auto)
+                 (symbol :tag "enable globally" t)
+                 (symbol :tag "disable" nil))
+  :group 'rainbow)
+
+;;; R colors
+
+(defvar rainbow-r-colors-font-lock-keywords nil
+  "Font-lock keywords to add for R colors.")
+(make-variable-buffer-local 'rainbow-r-colors-font-lock-keywords)
+
+;; use the following code to generate the list in R
+;; output_colors <- function(colors) {for(color in colors) {col <- col2rgb(color); cat(sprintf("(\"%s\" . \"#%02X%02X%02X\")\n",color,col[1],col[2],col[3]));}}
+;; output_colors(colors())
+(defcustom rainbow-r-colors-alist
+  '(("white" . "#FFFFFF")
+    ("aliceblue" . "#F0F8FF")
+    ("antiquewhite" . "#FAEBD7")
+    ("antiquewhite1" . "#FFEFDB")
+    ("antiquewhite2" . "#EEDFCC")
+    ("antiquewhite3" . "#CDC0B0")
+    ("antiquewhite4" . "#8B8378")
+    ("aquamarine" . "#7FFFD4")
+    ("aquamarine1" . "#7FFFD4")
+    ("aquamarine2" . "#76EEC6")
+    ("aquamarine3" . "#66CDAA")
+    ("aquamarine4" . "#458B74")
+    ("azure" . "#F0FFFF")
+    ("azure1" . "#F0FFFF")
+    ("azure2" . "#E0EEEE")
+    ("azure3" . "#C1CDCD")
+    ("azure4" . "#838B8B")
+    ("beige" . "#F5F5DC")
+    ("bisque" . "#FFE4C4")
+    ("bisque1" . "#FFE4C4")
+    ("bisque2" . "#EED5B7")
+    ("bisque3" . "#CDB79E")
+    ("bisque4" . "#8B7D6B")
+    ("black" . "#000000")
+    ("blanchedalmond" . "#FFEBCD")
+    ("blue" . "#0000FF")
+    ("blue1" . "#0000FF")
+    ("blue2" . "#0000EE")
+    ("blue3" . "#0000CD")
+    ("blue4" . "#00008B")
+    ("blueviolet" . "#8A2BE2")
+    ("brown" . "#A52A2A")
+    ("brown1" . "#FF4040")
+    ("brown2" . "#EE3B3B")
+    ("brown3" . "#CD3333")
+    ("brown4" . "#8B2323")
+    ("burlywood" . "#DEB887")
+    ("burlywood1" . "#FFD39B")
+    ("burlywood2" . "#EEC591")
+    ("burlywood3" . "#CDAA7D")
+    ("burlywood4" . "#8B7355")
+    ("cadetblue" . "#5F9EA0")
+    ("cadetblue1" . "#98F5FF")
+    ("cadetblue2" . "#8EE5EE")
+    ("cadetblue3" . "#7AC5CD")
+    ("cadetblue4" . "#53868B")
+    ("chartreuse" . "#7FFF00")
+    ("chartreuse1" . "#7FFF00")
+    ("chartreuse2" . "#76EE00")
+    ("chartreuse3" . "#66CD00")
+    ("chartreuse4" . "#458B00")
+    ("chocolate" . "#D2691E")
+    ("chocolate1" . "#FF7F24")
+    ("chocolate2" . "#EE7621")
+    ("chocolate3" . "#CD661D")
+    ("chocolate4" . "#8B4513")
+    ("coral" . "#FF7F50")
+    ("coral1" . "#FF7256")
+    ("coral2" . "#EE6A50")
+    ("coral3" . "#CD5B45")
+    ("coral4" . "#8B3E2F")
+    ("cornflowerblue" . "#6495ED")
+    ("cornsilk" . "#FFF8DC")
+    ("cornsilk1" . "#FFF8DC")
+    ("cornsilk2" . "#EEE8CD")
+    ("cornsilk3" . "#CDC8B1")
+    ("cornsilk4" . "#8B8878")
+    ("cyan" . "#00FFFF")
+    ("cyan1" . "#00FFFF")
+    ("cyan2" . "#00EEEE")
+    ("cyan3" . "#00CDCD")
+    ("cyan4" . "#008B8B")
+    ("darkblue" . "#00008B")
+    ("darkcyan" . "#008B8B")
+    ("darkgoldenrod" . "#B8860B")
+    ("darkgoldenrod1" . "#FFB90F")
+    ("darkgoldenrod2" . "#EEAD0E")
+    ("darkgoldenrod3" . "#CD950C")
+    ("darkgoldenrod4" . "#8B6508")
+    ("darkgray" . "#A9A9A9")
+    ("darkgreen" . "#006400")
+    ("darkgrey" . "#A9A9A9")
+    ("darkkhaki" . "#BDB76B")
+    ("darkmagenta" . "#8B008B")
+    ("darkolivegreen" . "#556B2F")
+    ("darkolivegreen1" . "#CAFF70")
+    ("darkolivegreen2" . "#BCEE68")
+    ("darkolivegreen3" . "#A2CD5A")
+    ("darkolivegreen4" . "#6E8B3D")
+    ("darkorange" . "#FF8C00")
+    ("darkorange1" . "#FF7F00")
+    ("darkorange2" . "#EE7600")
+    ("darkorange3" . "#CD6600")
+    ("darkorange4" . "#8B4500")
+    ("darkorchid" . "#9932CC")
+    ("darkorchid1" . "#BF3EFF")
+    ("darkorchid2" . "#B23AEE")
+    ("darkorchid3" . "#9A32CD")
+    ("darkorchid4" . "#68228B")
+    ("darkred" . "#8B0000")
+    ("darksalmon" . "#E9967A")
+    ("darkseagreen" . "#8FBC8F")
+    ("darkseagreen1" . "#C1FFC1")
+    ("darkseagreen2" . "#B4EEB4")
+    ("darkseagreen3" . "#9BCD9B")
+    ("darkseagreen4" . "#698B69")
+    ("darkslateblue" . "#483D8B")
+    ("darkslategray" . "#2F4F4F")
+    ("darkslategray1" . "#97FFFF")
+    ("darkslategray2" . "#8DEEEE")
+    ("darkslategray3" . "#79CDCD")
+    ("darkslategray4" . "#528B8B")
+    ("darkslategrey" . "#2F4F4F")
+    ("darkturquoise" . "#00CED1")
+    ("darkviolet" . "#9400D3")
+    ("deeppink" . "#FF1493")
+    ("deeppink1" . "#FF1493")
+    ("deeppink2" . "#EE1289")
+    ("deeppink3" . "#CD1076")
+    ("deeppink4" . "#8B0A50")
+    ("deepskyblue" . "#00BFFF")
+    ("deepskyblue1" . "#00BFFF")
+    ("deepskyblue2" . "#00B2EE")
+    ("deepskyblue3" . "#009ACD")
+    ("deepskyblue4" . "#00688B")
+    ("dimgray" . "#696969")
+    ("dimgrey" . "#696969")
+    ("dodgerblue" . "#1E90FF")
+    ("dodgerblue1" . "#1E90FF")
+    ("dodgerblue2" . "#1C86EE")
+    ("dodgerblue3" . "#1874CD")
+    ("dodgerblue4" . "#104E8B")
+    ("firebrick" . "#B22222")
+    ("firebrick1" . "#FF3030")
+    ("firebrick2" . "#EE2C2C")
+    ("firebrick3" . "#CD2626")
+    ("firebrick4" . "#8B1A1A")
+    ("floralwhite" . "#FFFAF0")
+    ("forestgreen" . "#228B22")
+    ("gainsboro" . "#DCDCDC")
+    ("ghostwhite" . "#F8F8FF")
+    ("gold" . "#FFD700")
+    ("gold1" . "#FFD700")
+    ("gold2" . "#EEC900")
+    ("gold3" . "#CDAD00")
+    ("gold4" . "#8B7500")
+    ("goldenrod" . "#DAA520")
+    ("goldenrod1" . "#FFC125")
+    ("goldenrod2" . "#EEB422")
+    ("goldenrod3" . "#CD9B1D")
+    ("goldenrod4" . "#8B6914")
+    ("gray" . "#BEBEBE")
+    ("gray0" . "#000000")
+    ("gray1" . "#030303")
+    ("gray2" . "#050505")
+    ("gray3" . "#080808")
+    ("gray4" . "#0A0A0A")
+    ("gray5" . "#0D0D0D")
+    ("gray6" . "#0F0F0F")
+    ("gray7" . "#121212")
+    ("gray8" . "#141414")
+    ("gray9" . "#171717")
+    ("gray10" . "#1A1A1A")
+    ("gray11" . "#1C1C1C")
+    ("gray12" . "#1F1F1F")
+    ("gray13" . "#212121")
+    ("gray14" . "#242424")
+    ("gray15" . "#262626")
+    ("gray16" . "#292929")
+    ("gray17" . "#2B2B2B")
+    ("gray18" . "#2E2E2E")
+    ("gray19" . "#303030")
+    ("gray20" . "#333333")
+    ("gray21" . "#363636")
+    ("gray22" . "#383838")
+    ("gray23" . "#3B3B3B")
+    ("gray24" . "#3D3D3D")
+    ("gray25" . "#404040")
+    ("gray26" . "#424242")
+    ("gray27" . "#454545")
+    ("gray28" . "#474747")
+    ("gray29" . "#4A4A4A")
+    ("gray30" . "#4D4D4D")
+    ("gray31" . "#4F4F4F")
+    ("gray32" . "#525252")
+    ("gray33" . "#545454")
+    ("gray34" . "#575757")
+    ("gray35" . "#595959")
+    ("gray36" . "#5C5C5C")
+    ("gray37" . "#5E5E5E")
+    ("gray38" . "#616161")
+    ("gray39" . "#636363")
+    ("gray40" . "#666666")
+    ("gray41" . "#696969")
+    ("gray42" . "#6B6B6B")
+    ("gray43" . "#6E6E6E")
+    ("gray44" . "#707070")
+    ("gray45" . "#737373")
+    ("gray46" . "#757575")
+    ("gray47" . "#787878")
+    ("gray48" . "#7A7A7A")
+    ("gray49" . "#7D7D7D")
+    ("gray50" . "#7F7F7F")
+    ("gray51" . "#828282")
+    ("gray52" . "#858585")
+    ("gray53" . "#878787")
+    ("gray54" . "#8A8A8A")
+    ("gray55" . "#8C8C8C")
+    ("gray56" . "#8F8F8F")
+    ("gray57" . "#919191")
+    ("gray58" . "#949494")
+    ("gray59" . "#969696")
+    ("gray60" . "#999999")
+    ("gray61" . "#9C9C9C")
+    ("gray62" . "#9E9E9E")
+    ("gray63" . "#A1A1A1")
+    ("gray64" . "#A3A3A3")
+    ("gray65" . "#A6A6A6")
+    ("gray66" . "#A8A8A8")
+    ("gray67" . "#ABABAB")
+    ("gray68" . "#ADADAD")
+    ("gray69" . "#B0B0B0")
+    ("gray70" . "#B3B3B3")
+    ("gray71" . "#B5B5B5")
+    ("gray72" . "#B8B8B8")
+    ("gray73" . "#BABABA")
+    ("gray74" . "#BDBDBD")
+    ("gray75" . "#BFBFBF")
+    ("gray76" . "#C2C2C2")
+    ("gray77" . "#C4C4C4")
+    ("gray78" . "#C7C7C7")
+    ("gray79" . "#C9C9C9")
+    ("gray80" . "#CCCCCC")
+    ("gray81" . "#CFCFCF")
+    ("gray82" . "#D1D1D1")
+    ("gray83" . "#D4D4D4")
+    ("gray84" . "#D6D6D6")
+    ("gray85" . "#D9D9D9")
+    ("gray86" . "#DBDBDB")
+    ("gray87" . "#DEDEDE")
+    ("gray88" . "#E0E0E0")
+    ("gray89" . "#E3E3E3")
+    ("gray90" . "#E5E5E5")
+    ("gray91" . "#E8E8E8")
+    ("gray92" . "#EBEBEB")
+    ("gray93" . "#EDEDED")
+    ("gray94" . "#F0F0F0")
+    ("gray95" . "#F2F2F2")
+    ("gray96" . "#F5F5F5")
+    ("gray97" . "#F7F7F7")
+    ("gray98" . "#FAFAFA")
+    ("gray99" . "#FCFCFC")
+    ("gray100" . "#FFFFFF")
+    ("green" . "#00FF00")
+    ("green1" . "#00FF00")
+    ("green2" . "#00EE00")
+    ("green3" . "#00CD00")
+    ("green4" . "#008B00")
+    ("greenyellow" . "#ADFF2F")
+    ("grey" . "#BEBEBE")
+    ("grey0" . "#000000")
+    ("grey1" . "#030303")
+    ("grey2" . "#050505")
+    ("grey3" . "#080808")
+    ("grey4" . "#0A0A0A")
+    ("grey5" . "#0D0D0D")
+    ("grey6" . "#0F0F0F")
+    ("grey7" . "#121212")
+    ("grey8" . "#141414")
+    ("grey9" . "#171717")
+    ("grey10" . "#1A1A1A")
+    ("grey11" . "#1C1C1C")
+    ("grey12" . "#1F1F1F")
+    ("grey13" . "#212121")
+    ("grey14" . "#242424")
+    ("grey15" . "#262626")
+    ("grey16" . "#292929")
+    ("grey17" . "#2B2B2B")
+    ("grey18" . "#2E2E2E")
+    ("grey19" . "#303030")
+    ("grey20" . "#333333")
+    ("grey21" . "#363636")
+    ("grey22" . "#383838")
+    ("grey23" . "#3B3B3B")
+    ("grey24" . "#3D3D3D")
+    ("grey25" . "#404040")
+    ("grey26" . "#424242")
+    ("grey27" . "#454545")
+    ("grey28" . "#474747")
+    ("grey29" . "#4A4A4A")
+    ("grey30" . "#4D4D4D")
+    ("grey31" . "#4F4F4F")
+    ("grey32" . "#525252")
+    ("grey33" . "#545454")
+    ("grey34" . "#575757")
+    ("grey35" . "#595959")
+    ("grey36" . "#5C5C5C")
+    ("grey37" . "#5E5E5E")
+    ("grey38" . "#616161")
+    ("grey39" . "#636363")
+    ("grey40" . "#666666")
+    ("grey41" . "#696969")
+    ("grey42" . "#6B6B6B")
+    ("grey43" . "#6E6E6E")
+    ("grey44" . "#707070")
+    ("grey45" . "#737373")
+    ("grey46" . "#757575")
+    ("grey47" . "#787878")
+    ("grey48" . "#7A7A7A")
+    ("grey49" . "#7D7D7D")
+    ("grey50" . "#7F7F7F")
+    ("grey51" . "#828282")
+    ("grey52" . "#858585")
+    ("grey53" . "#878787")
+    ("grey54" . "#8A8A8A")
+    ("grey55" . "#8C8C8C")
+    ("grey56" . "#8F8F8F")
+    ("grey57" . "#919191")
+    ("grey58" . "#949494")
+    ("grey59" . "#969696")
+    ("grey60" . "#999999")
+    ("grey61" . "#9C9C9C")
+    ("grey62" . "#9E9E9E")
+    ("grey63" . "#A1A1A1")
+    ("grey64" . "#A3A3A3")
+    ("grey65" . "#A6A6A6")
+    ("grey66" . "#A8A8A8")
+    ("grey67" . "#ABABAB")
+    ("grey68" . "#ADADAD")
+    ("grey69" . "#B0B0B0")
+    ("grey70" . "#B3B3B3")
+    ("grey71" . "#B5B5B5")
+    ("grey72" . "#B8B8B8")
+    ("grey73" . "#BABABA")
+    ("grey74" . "#BDBDBD")
+    ("grey75" . "#BFBFBF")
+    ("grey76" . "#C2C2C2")
+    ("grey77" . "#C4C4C4")
+    ("grey78" . "#C7C7C7")
+    ("grey79" . "#C9C9C9")
+    ("grey80" . "#CCCCCC")
+    ("grey81" . "#CFCFCF")
+    ("grey82" . "#D1D1D1")
+    ("grey83" . "#D4D4D4")
+    ("grey84" . "#D6D6D6")
+    ("grey85" . "#D9D9D9")
+    ("grey86" . "#DBDBDB")
+    ("grey87" . "#DEDEDE")
+    ("grey88" . "#E0E0E0")
+    ("grey89" . "#E3E3E3")
+    ("grey90" . "#E5E5E5")
+    ("grey91" . "#E8E8E8")
+    ("grey92" . "#EBEBEB")
+    ("grey93" . "#EDEDED")
+    ("grey94" . "#F0F0F0")
+    ("grey95" . "#F2F2F2")
+    ("grey96" . "#F5F5F5")
+    ("grey97" . "#F7F7F7")
+    ("grey98" . "#FAFAFA")
+    ("grey99" . "#FCFCFC")
+    ("grey100" . "#FFFFFF")
+    ("honeydew" . "#F0FFF0")
+    ("honeydew1" . "#F0FFF0")
+    ("honeydew2" . "#E0EEE0")
+    ("honeydew3" . "#C1CDC1")
+    ("honeydew4" . "#838B83")
+    ("hotpink" . "#FF69B4")
+    ("hotpink1" . "#FF6EB4")
+    ("hotpink2" . "#EE6AA7")
+    ("hotpink3" . "#CD6090")
+    ("hotpink4" . "#8B3A62")
+    ("indianred" . "#CD5C5C")
+    ("indianred1" . "#FF6A6A")
+    ("indianred2" . "#EE6363")
+    ("indianred3" . "#CD5555")
+    ("indianred4" . "#8B3A3A")
+    ("ivory" . "#FFFFF0")
+    ("ivory1" . "#FFFFF0")
+    ("ivory2" . "#EEEEE0")
+    ("ivory3" . "#CDCDC1")
+    ("ivory4" . "#8B8B83")
+    ("khaki" . "#F0E68C")
+    ("khaki1" . "#FFF68F")
+    ("khaki2" . "#EEE685")
+    ("khaki3" . "#CDC673")
+    ("khaki4" . "#8B864E")
+    ("lavender" . "#E6E6FA")
+    ("lavenderblush" . "#FFF0F5")
+    ("lavenderblush1" . "#FFF0F5")
+    ("lavenderblush2" . "#EEE0E5")
+    ("lavenderblush3" . "#CDC1C5")
+    ("lavenderblush4" . "#8B8386")
+    ("lawngreen" . "#7CFC00")
+    ("lemonchiffon" . "#FFFACD")
+    ("lemonchiffon1" . "#FFFACD")
+    ("lemonchiffon2" . "#EEE9BF")
+    ("lemonchiffon3" . "#CDC9A5")
+    ("lemonchiffon4" . "#8B8970")
+    ("lightblue" . "#ADD8E6")
+    ("lightblue1" . "#BFEFFF")
+    ("lightblue2" . "#B2DFEE")
+    ("lightblue3" . "#9AC0CD")
+    ("lightblue4" . "#68838B")
+    ("lightcoral" . "#F08080")
+    ("lightcyan" . "#E0FFFF")
+    ("lightcyan1" . "#E0FFFF")
+    ("lightcyan2" . "#D1EEEE")
+    ("lightcyan3" . "#B4CDCD")
+    ("lightcyan4" . "#7A8B8B")
+    ("lightgoldenrod" . "#EEDD82")
+    ("lightgoldenrod1" . "#FFEC8B")
+    ("lightgoldenrod2" . "#EEDC82")
+    ("lightgoldenrod3" . "#CDBE70")
+    ("lightgoldenrod4" . "#8B814C")
+    ("lightgoldenrodyellow" . "#FAFAD2")
+    ("lightgray" . "#D3D3D3")
+    ("lightgreen" . "#90EE90")
+    ("lightgrey" . "#D3D3D3")
+    ("lightpink" . "#FFB6C1")
+    ("lightpink1" . "#FFAEB9")
+    ("lightpink2" . "#EEA2AD")
+    ("lightpink3" . "#CD8C95")
+    ("lightpink4" . "#8B5F65")
+    ("lightsalmon" . "#FFA07A")
+    ("lightsalmon1" . "#FFA07A")
+    ("lightsalmon2" . "#EE9572")
+    ("lightsalmon3" . "#CD8162")
+    ("lightsalmon4" . "#8B5742")
+    ("lightseagreen" . "#20B2AA")
+    ("lightskyblue" . "#87CEFA")
+    ("lightskyblue1" . "#B0E2FF")
+    ("lightskyblue2" . "#A4D3EE")
+    ("lightskyblue3" . "#8DB6CD")
+    ("lightskyblue4" . "#607B8B")
+    ("lightslateblue" . "#8470FF")
+    ("lightslategray" . "#778899")
+    ("lightslategrey" . "#778899")
+    ("lightsteelblue" . "#B0C4DE")
+    ("lightsteelblue1" . "#CAE1FF")
+    ("lightsteelblue2" . "#BCD2EE")
+    ("lightsteelblue3" . "#A2B5CD")
+    ("lightsteelblue4" . "#6E7B8B")
+    ("lightyellow" . "#FFFFE0")
+    ("lightyellow1" . "#FFFFE0")
+    ("lightyellow2" . "#EEEED1")
+    ("lightyellow3" . "#CDCDB4")
+    ("lightyellow4" . "#8B8B7A")
+    ("limegreen" . "#32CD32")
+    ("linen" . "#FAF0E6")
+    ("magenta" . "#FF00FF")
+    ("magenta1" . "#FF00FF")
+    ("magenta2" . "#EE00EE")
+    ("magenta3" . "#CD00CD")
+    ("magenta4" . "#8B008B")
+    ("maroon" . "#B03060")
+    ("maroon1" . "#FF34B3")
+    ("maroon2" . "#EE30A7")
+    ("maroon3" . "#CD2990")
+    ("maroon4" . "#8B1C62")
+    ("mediumaquamarine" . "#66CDAA")
+    ("mediumblue" . "#0000CD")
+    ("mediumorchid" . "#BA55D3")
+    ("mediumorchid1" . "#E066FF")
+    ("mediumorchid2" . "#D15FEE")
+    ("mediumorchid3" . "#B452CD")
+    ("mediumorchid4" . "#7A378B")
+    ("mediumpurple" . "#9370DB")
+    ("mediumpurple1" . "#AB82FF")
+    ("mediumpurple2" . "#9F79EE")
+    ("mediumpurple3" . "#8968CD")
+    ("mediumpurple4" . "#5D478B")
+    ("mediumseagreen" . "#3CB371")
+    ("mediumslateblue" . "#7B68EE")
+    ("mediumspringgreen" . "#00FA9A")
+    ("mediumturquoise" . "#48D1CC")
+    ("mediumvioletred" . "#C71585")
+    ("midnightblue" . "#191970")
+    ("mintcream" . "#F5FFFA")
+    ("mistyrose" . "#FFE4E1")
+    ("mistyrose1" . "#FFE4E1")
+    ("mistyrose2" . "#EED5D2")
+    ("mistyrose3" . "#CDB7B5")
+    ("mistyrose4" . "#8B7D7B")
+    ("moccasin" . "#FFE4B5")
+    ("navajowhite" . "#FFDEAD")
+    ("navajowhite1" . "#FFDEAD")
+    ("navajowhite2" . "#EECFA1")
+    ("navajowhite3" . "#CDB38B")
+    ("navajowhite4" . "#8B795E")
+    ("navy" . "#000080")
+    ("navyblue" . "#000080")
+    ("oldlace" . "#FDF5E6")
+    ("olivedrab" . "#6B8E23")
+    ("olivedrab1" . "#C0FF3E")
+    ("olivedrab2" . "#B3EE3A")
+    ("olivedrab3" . "#9ACD32")
+    ("olivedrab4" . "#698B22")
+    ("orange" . "#FFA500")
+    ("orange1" . "#FFA500")
+    ("orange2" . "#EE9A00")
+    ("orange3" . "#CD8500")
+    ("orange4" . "#8B5A00")
+    ("orangered" . "#FF4500")
+    ("orangered1" . "#FF4500")
+    ("orangered2" . "#EE4000")
+    ("orangered3" . "#CD3700")
+    ("orangered4" . "#8B2500")
+    ("orchid" . "#DA70D6")
+    ("orchid1" . "#FF83FA")
+    ("orchid2" . "#EE7AE9")
+    ("orchid3" . "#CD69C9")
+    ("orchid4" . "#8B4789")
+    ("palegoldenrod" . "#EEE8AA")
+    ("palegreen" . "#98FB98")
+    ("palegreen1" . "#9AFF9A")
+    ("palegreen2" . "#90EE90")
+    ("palegreen3" . "#7CCD7C")
+    ("palegreen4" . "#548B54")
+    ("paleturquoise" . "#AFEEEE")
+    ("paleturquoise1" . "#BBFFFF")
+    ("paleturquoise2" . "#AEEEEE")
+    ("paleturquoise3" . "#96CDCD")
+    ("paleturquoise4" . "#668B8B")
+    ("palevioletred" . "#DB7093")
+    ("palevioletred1" . "#FF82AB")
+    ("palevioletred2" . "#EE799F")
+    ("palevioletred3" . "#CD6889")
+    ("palevioletred4" . "#8B475D")
+    ("papayawhip" . "#FFEFD5")
+    ("peachpuff" . "#FFDAB9")
+    ("peachpuff1" . "#FFDAB9")
+    ("peachpuff2" . "#EECBAD")
+    ("peachpuff3" . "#CDAF95")
+    ("peachpuff4" . "#8B7765")
+    ("peru" . "#CD853F")
+    ("pink" . "#FFC0CB")
+    ("pink1" . "#FFB5C5")
+    ("pink2" . "#EEA9B8")
+    ("pink3" . "#CD919E")
+    ("pink4" . "#8B636C")
+    ("plum" . "#DDA0DD")
+    ("plum1" . "#FFBBFF")
+    ("plum2" . "#EEAEEE")
+    ("plum3" . "#CD96CD")
+    ("plum4" . "#8B668B")
+    ("powderblue" . "#B0E0E6")
+    ("purple" . "#A020F0")
+    ("purple1" . "#9B30FF")
+    ("purple2" . "#912CEE")
+    ("purple3" . "#7D26CD")
+    ("purple4" . "#551A8B")
+    ("red" . "#FF0000")
+    ("red1" . "#FF0000")
+    ("red2" . "#EE0000")
+    ("red3" . "#CD0000")
+    ("red4" . "#8B0000")
+    ("rosybrown" . "#BC8F8F")
+    ("rosybrown1" . "#FFC1C1")
+    ("rosybrown2" . "#EEB4B4")
+    ("rosybrown3" . "#CD9B9B")
+    ("rosybrown4" . "#8B6969")
+    ("royalblue" . "#4169E1")
+    ("royalblue1" . "#4876FF")
+    ("royalblue2" . "#436EEE")
+    ("royalblue3" . "#3A5FCD")
+    ("royalblue4" . "#27408B")
+    ("saddlebrown" . "#8B4513")
+    ("salmon" . "#FA8072")
+    ("salmon1" . "#FF8C69")
+    ("salmon2" . "#EE8262")
+    ("salmon3" . "#CD7054")
+    ("salmon4" . "#8B4C39")
+    ("sandybrown" . "#F4A460")
+    ("seagreen" . "#2E8B57")
+    ("seagreen1" . "#54FF9F")
+    ("seagreen2" . "#4EEE94")
+    ("seagreen3" . "#43CD80")
+    ("seagreen4" . "#2E8B57")
+    ("seashell" . "#FFF5EE")
+    ("seashell1" . "#FFF5EE")
+    ("seashell2" . "#EEE5DE")
+    ("seashell3" . "#CDC5BF")
+    ("seashell4" . "#8B8682")
+    ("sienna" . "#A0522D")
+    ("sienna1" . "#FF8247")
+    ("sienna2" . "#EE7942")
+    ("sienna3" . "#CD6839")
+    ("sienna4" . "#8B4726")
+    ("skyblue" . "#87CEEB")
+    ("skyblue1" . "#87CEFF")
+    ("skyblue2" . "#7EC0EE")
+    ("skyblue3" . "#6CA6CD")
+    ("skyblue4" . "#4A708B")
+    ("slateblue" . "#6A5ACD")
+    ("slateblue1" . "#836FFF")
+    ("slateblue2" . "#7A67EE")
+    ("slateblue3" . "#6959CD")
+    ("slateblue4" . "#473C8B")
+    ("slategray" . "#708090")
+    ("slategray1" . "#C6E2FF")
+    ("slategray2" . "#B9D3EE")
+    ("slategray3" . "#9FB6CD")
+    ("slategray4" . "#6C7B8B")
+    ("slategrey" . "#708090")
+    ("snow" . "#FFFAFA")
+    ("snow1" . "#FFFAFA")
+    ("snow2" . "#EEE9E9")
+    ("snow3" . "#CDC9C9")
+    ("snow4" . "#8B8989")
+    ("springgreen" . "#00FF7F")
+    ("springgreen1" . "#00FF7F")
+    ("springgreen2" . "#00EE76")
+    ("springgreen3" . "#00CD66")
+    ("springgreen4" . "#008B45")
+    ("steelblue" . "#4682B4")
+    ("steelblue1" . "#63B8FF")
+    ("steelblue2" . "#5CACEE")
+    ("steelblue3" . "#4F94CD")
+    ("steelblue4" . "#36648B")
+    ("tan" . "#D2B48C")
+    ("tan1" . "#FFA54F")
+    ("tan2" . "#EE9A49")
+    ("tan3" . "#CD853F")
+    ("tan4" . "#8B5A2B")
+    ("thistle" . "#D8BFD8")
+    ("thistle1" . "#FFE1FF")
+    ("thistle2" . "#EED2EE")
+    ("thistle3" . "#CDB5CD")
+    ("thistle4" . "#8B7B8B")
+    ("tomato" . "#FF6347")
+    ("tomato1" . "#FF6347")
+    ("tomato2" . "#EE5C42")
+    ("tomato3" . "#CD4F39")
+    ("tomato4" . "#8B3626")
+    ("turquoise" . "#40E0D0")
+    ("turquoise1" . "#00F5FF")
+    ("turquoise2" . "#00E5EE")
+    ("turquoise3" . "#00C5CD")
+    ("turquoise4" . "#00868B")
+    ("violet" . "#EE82EE")
+    ("violetred" . "#D02090")
+    ("violetred1" . "#FF3E96")
+    ("violetred2" . "#EE3A8C")
+    ("violetred3" . "#CD3278")
+    ("violetred4" . "#8B2252")
+    ("wheat" . "#F5DEB3")
+    ("wheat1" . "#FFE7BA")
+    ("wheat2" . "#EED8AE")
+    ("wheat3" . "#CDBA96")
+    ("wheat4" . "#8B7E66")
+    ("whitesmoke" . "#F5F5F5")
+    ("yellow" . "#FFFF00")
+    ("yellow1" . "#FFFF00")
+    ("yellow2" . "#EEEE00")
+    ("yellow3" . "#CDCD00")
+    ("yellow4" . "#8B8B00")
+    ("yellowgreen" . "#9ACD32"))
+  "Alist of R colors.
+Each entry should have the form (COLOR-NAME . HEXADECIMAL-COLOR)."
+  :type 'alist
+  :group 'rainbow)
+
+(defcustom rainbow-r-colors-major-mode-list
+  '(ess-mode)
+  "List of major mode where R colors are enabled when
+`rainbow-r-colors' is set to auto."
+  :type '(repeat (symbol :tag "Major-Mode"))
+  :group 'rainbow)
+
+(defcustom rainbow-r-colors 'auto
+  "When to enable R colors.
+If set to t, the R colors will be enabled.  If set to nil, the
+R colors will not be enabled.  If set to auto, the R colors
+will be enabled if a major mode has been detected from the
+`rainbow-r-colors-major-mode-list'."
+  :type '(choice (symbol :tag "enable in certain modes" auto)
+                 (symbol :tag "enable globally" t)
+                 (symbol :tag "disable" nil))
+  :group 'rainbow)
+
+;;; Functions
+
+(defun rainbow-colorize-match (color &optional match)
+  "Return a matched string propertized with a face whose
+background is COLOR. The foreground is computed using
+`rainbow-color-luminance', and is either white or black."
+  (let ((match (or match 0)))
+    (put-text-property
+     (match-beginning match) (match-end match)
+     'face `((:foreground ,(if (> 0.5 (rainbow-x-color-luminance color))
+                               "white" "black"))
+             (:background ,color)))))
+
+(defun rainbow-colorize-itself (&optional match)
+  "Colorize a match with itself."
+  (rainbow-colorize-match (match-string-no-properties (or match 0)) match))
+
+(defun rainbow-colorize-hexadecimal-without-sharp ()
+  "Colorize an hexadecimal colors and prepend # to it."
+  (rainbow-colorize-match (concat "#" (match-string-no-properties 1))))
+
+(defun rainbow-colorize-by-assoc (assoc-list)
+  "Colorize a match with its association from ASSOC-LIST."
+  (rainbow-colorize-match (cdr (assoc-string (match-string-no-properties 0)
+                                             assoc-list t))))
+
+(defun rainbow-rgb-relative-to-absolute (number)
+  "Convert a relative NUMBER to absolute. If NUMBER is absolute, return NUMBER.
+This will convert \"80 %\" to 204, \"100 %\" to 255 but \"123\" to \"123\".
+If the percentage value is above 100, it's converted to 100."
+  (let ((string-length (- (length number) 1)))
+    ;; Is this a number with %?
+    (if (eq (elt number string-length) ?%)
+        (/ (* (min (string-to-number (substring number 0 string-length)) 100) 255) 100)
+      (string-to-number number))))
+
+(defun rainbow-colorize-hsl ()
+  "Colorize a match with itself."
+  (let ((h (/ (string-to-number (match-string-no-properties 1)) 360.0))
+        (s (/ (string-to-number (match-string-no-properties 2)) 100.0))
+        (l (/ (string-to-number (match-string-no-properties 3)) 100.0)))
+    (rainbow-colorize-match
+     (cl-destructuring-bind (r g b)
+         (color-hsl-to-rgb h s l)
+       (format "#%02X%02X%02X" (* r 255) (* g 255) (* b 255))))))
+
+(defun rainbow-colorize-rgb ()
+  "Colorize a match with itself."
+  (let ((r (rainbow-rgb-relative-to-absolute (match-string-no-properties 1)))
+        (g (rainbow-rgb-relative-to-absolute (match-string-no-properties 2)))
+        (b (rainbow-rgb-relative-to-absolute (match-string-no-properties 3))))
+    (rainbow-colorize-match (format "#%02X%02X%02X" r g b))))
+
+(defun rainbow-colorize-rgb-float ()
+  "Colorize a match with itself, with relative value."
+  (let ((r (* (string-to-number (match-string-no-properties 1)) 255.0))
+        (g (* (string-to-number (match-string-no-properties 2)) 255.0))
+        (b (* (string-to-number (match-string-no-properties 3)) 255.0)))
+    (rainbow-colorize-match (format "#%02X%02X%02X" r g b))))
+
+(defvar ansi-color-context)
+(defvar xterm-color-current)
+
+(defun rainbow-colorize-ansi ()
+  "Return a matched string propertized with ansi color face."
+  (let ((xterm-color? (featurep 'xterm-color))
+        (string (match-string-no-properties 0))
+        color)
+    (save-match-data
+      (let* ((replaced (concat
+                        (replace-regexp-in-string
+                         "^\\(\\\\[eE]\\|\\\\033\\|\\\\x1[bB]\\)"
+                         "\033" string) "x"))
+             xterm-color-current
+             ansi-color-context
+             (applied (funcall (if xterm-color?
+                                   'xterm-color-filter
+                                 'ansi-color-apply)
+                               replaced))
+             (face-property (get-text-property
+                             0
+                             (if xterm-color? 'face 'font-lock-face)
+                             applied)))
+        (unless (listp (or (car-safe face-property) face-property))
+          (setq face-property (list face-property)))
+        (setq color (funcall (if xterm-color? 'cadr 'cdr)
+                             (or (assq (if xterm-color?
+                                           :foreground
+                                         'foreground-color)
+                                       face-property)
+                                 (assq (if xterm-color?
+                                           :background
+                                         'background-color)
+                                       face-property))))))
+    (when color
+      (rainbow-colorize-match color))))
+
+(defun rainbow-color-luminance (red green blue)
+  "Calculate the relative luminance of color composed of RED, GREEN and BLUE.
+Return a value between 0 and 1."
+  (/ (+ (* .2126 red) (* .7152 green) (* .0722 blue)) 255))
+
+(defun rainbow-x-color-luminance (color)
+  "Calculate the relative luminance of a color string (e.g. \"#ffaa00\", \"blue\").
+Return a value between 0 and 1."
+  (let* ((values (color-values color))
+         (r (/ (car values) 256.0))
+         (g (/ (cadr values) 256.0))
+         (b (/ (caddr values) 256.0)))
+    (rainbow-color-luminance r g b)))
+
+;;; Mode
+
+(defun rainbow-turn-on ()
+  "Turn on rainbow-mode."
+  (font-lock-add-keywords nil
+                          rainbow-hexadecimal-colors-font-lock-keywords
+                          t)
+  ;; Activate X colors?
+  (when (or (eq rainbow-x-colors t)
+            (and (eq rainbow-x-colors 'auto)
+                 (memq major-mode rainbow-x-colors-major-mode-list)))
+    (font-lock-add-keywords nil
+                            rainbow-x-colors-font-lock-keywords
+                            t))
+  ;; Activate LaTeX colors?
+  (when (or (eq rainbow-latex-colors t)
+            (and (eq rainbow-latex-colors 'auto)
+                 (memq major-mode rainbow-latex-colors-major-mode-list)))
+    (font-lock-add-keywords nil
+                            rainbow-latex-rgb-colors-font-lock-keywords
+                            t))
+  ;; Activate ANSI colors?
+  (when (or (eq rainbow-ansi-colors t)
+            (and (eq rainbow-ansi-colors 'auto)
+                 (memq major-mode rainbow-ansi-colors-major-mode-list)))
+    (font-lock-add-keywords nil
+                            rainbow-ansi-colors-font-lock-keywords
+                            t))
+  ;; Activate HTML colors?
+  (when (or (eq rainbow-html-colors t)
+            (and (eq rainbow-html-colors 'auto)
+                 (memq major-mode rainbow-html-colors-major-mode-list)))
+    (setq rainbow-html-colors-font-lock-keywords
+          `((,(regexp-opt (mapcar 'car rainbow-html-colors-alist) 'words)
+             (0 (rainbow-colorize-by-assoc rainbow-html-colors-alist)))))
+    (font-lock-add-keywords nil
+                            `(,@rainbow-html-colors-font-lock-keywords
+                              ,@rainbow-html-rgb-colors-font-lock-keywords)
+                            t))
+  ;; Activate R colors?
+  (when (or (eq rainbow-r-colors t)
+            (and (eq rainbow-r-colors 'auto)
+                 (memq major-mode rainbow-r-colors-major-mode-list)))
+    (setq rainbow-r-colors-font-lock-keywords
+          `((,(regexp-opt (mapcar 'car rainbow-r-colors-alist) 'words)
+             (0 (rainbow-colorize-by-assoc rainbow-r-colors-alist)))))
+    (font-lock-add-keywords nil
+                            rainbow-r-colors-font-lock-keywords
+                            t)))
+
+(defun rainbow-turn-off ()
+  "Turn off rainbow-mode."
+  (font-lock-remove-keywords
+   nil
+   `(,@rainbow-hexadecimal-colors-font-lock-keywords
+     ,@rainbow-x-colors-font-lock-keywords
+     ,@rainbow-latex-rgb-colors-font-lock-keywords
+     ,@rainbow-r-colors-font-lock-keywords
+     ,@rainbow-html-colors-font-lock-keywords
+     ,@rainbow-html-rgb-colors-font-lock-keywords)))
+
+(defvar rainbow-keywords-hook nil
+  "Hook used to add additional font-lock keywords.
+This hook is called by `rainbow-mode' before it re-enables
+`font-lock-mode'.  Hook functions must only add additional
+keywords when `rainbow-mode' is non-nil.  When that is nil,
+then they must remove those additional keywords again.")
+
+;;;###autoload
+(define-minor-mode rainbow-mode
+  "Colorize strings that represent colors.
+This will fontify with colors the string like \"#aabbcc\" or \"blue\"."
+  :lighter " Rbow"
+  (if rainbow-mode
+      (rainbow-turn-on)
+    (rainbow-turn-off))
+  ;; We cannot use `rainbow-mode-hook' because this has
+  ;; to be done before `font-lock-mode' is re-enabled.
+  (run-hooks 'rainbow-keywords-hook)
+  ;; Call `font-lock-mode' to refresh the buffer when used
+  ;; e.g. interactively.
+  (font-lock-mode 1))
+
+(provide 'rainbow-mode)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+;;; rainbow-mode.el ends here


### PR DESCRIPTION
* Re-organized the main list of categories in the Org file.
* Add the ability to load an optional Early-init-proxy.el file.
    * It's deliberately called "proxy" since it's not intended for anything other than proxy handling
* Exec paths are now, effectively, hard-coded but with all the well-know directories for typical U*NIX and macOS with `homebrew` installed. Something I'll probably change in the future. But, it's very custom to my install for now.
* `mrf/` now is `mifi/`. Just seems cooler and it's still accurate.
* Embracing org-agenda more so there is an expansion of the TODO feature included.
* Updated package parameters and key-bindings across many packages.
* Org-roam might be going away for me. I'm warming up to `denote`.
* Comments and other cleanup. Nothing major.