### PR TITLE
Fixed issue with eshell not doing an :ensure nil

### DIFF
--- a/emacs-config.org
+++ b/emacs-config.org
@@ -2164,7 +2164,7 @@ For more thoughts on Eshell, check out these articles by Pierre Neidhardt:
     :after eshell)
 
   (use-package eshell
-    :ensure
+    :ensure nil
     :defer t
     :hook (eshell-first-time-mode . mifi/configure-eshell)
     :config

--- a/init.el
+++ b/init.el
@@ -1361,7 +1361,7 @@ font size is computed + 20 of this value."
   :after eshell)
 
 (use-package eshell
-  :ensure
+  :ensure nil
   :defer t
   :hook (eshell-first-time-mode . mifi/configure-eshell)
   :config


### PR DESCRIPTION
shell just had an `:ensure` without a parameter. It has been set to `nil` signifying to Elpaca that the package is built-in.